### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",


### PR DESCRIPTION
## 関連Issue

Closes #7

## 背景

v1.0.0 リリース以降、セキュリティ強化・テンプレート分離・ブランチポリシー文書化の3つのPRがdevにマージされた。これらをまとめてv1.1.0としてリリースするため、バージョンをバンプする。

## このPRでやったこと

- `package.json` の version を `1.0.0` → `1.1.0` にバンプ

## 影響範囲

- `package.json` のみ（バージョン番号のみの変更）
- npm publish 時のバージョン番号に影響

## 品質ゲート

- [x] 変更がバージョン番号のみのため、コードレビュー省略
- [x] CI通過で十分