### PR TITLE
docs: add npm migration notice for fork/clone users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ This repository provides AI coding agents with the knowledge to generate correct
 
 <h2 id="install">Install</h2>
 
+> **Migrating from fork/clone?** &mdash; Since v1.0.0, this project is distributed as an **npm package**. You no longer need to fork or clone the repository. Simply run one of the install commands below inside your VRChat Unity project. If you previously cloned this repo, you can safely delete the cloned directory and switch to the npm-based install.
+
 ### Method 1: skills CLI (recommended)
 
 ```bash


### PR DESCRIPTION
## 関連Issue

Closes #15

## 背景

v1.0.0 で OSS 化 + npm パッケージ配布に移行したが、旧方式（fork/clone）からの移行案内がなかった。既存ユーザーおよび新規訪問者に対して移行方法を明確に告知する。

## このPRでやったこと

- **README.md**: Install セクション冒頭に migration notice（blockquote）を追加
- **v1.0.0 Release Notes**: 冒頭に Migration Notice を追記（gh release edit で直接更新済み）

## 影響範囲

- `README.md`（1行の blockquote 追加のみ）
- GitHub Release v1.0.0 の body テキスト（PR外で更新済み）

## 品質ゲート

- [x] ドキュメントのみの変更のため、コードレビュー省略
- [x] CI 通過で十分