### PR TITLE
feat: lower contribution barrier with quick feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: VRChat Creators Docs
     url: https://creators.vrchat.com/

--- a/.github/ISSUE_TEMPLATE/quick_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/quick_feedback.yml
@@ -1,0 +1,31 @@
+name: Quick Feedback
+description: Share quick feedback, tips, or anything that doesn't fit other templates
+labels: ["type: feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing! This is for quick feedback that doesn't fit the Bug Report or Knowledge Request templates.
+        Feel free to write in **Japanese or English**.
+
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback
+      description: Share anything -- tips, suggestions, corrections, or things you noticed.
+      placeholder: |
+        Examples:
+        - "I noticed SDK 3.11 added a new event called OnXxx"
+        - "The SyncedObject template could use an example with arrays"
+        - "Is there a reason XxxComponent isn't covered?"
+    validations:
+      required: true
+
+  - type: input
+    id: source
+    attributes:
+      label: Source / Reference
+      description: Link to official docs, forum post, or other reference (optional)
+      placeholder: "https://creators.vrchat.com/..."
+    validations:
+      required: false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,6 +10,10 @@
   color: "a2eeef"
   description: "Request for new patterns, tips, or SDK coverage"
 
+- name: "type: feedback"
+  color: "c5def5"
+  description: "Quick feedback, tips, or lightweight suggestions"
+
 - name: "type: sdk-update"
   color: "0075ca"
   description: "SDK version update requiring rule/reference changes"


### PR DESCRIPTION
## 関連Issue

Closes #22

## 背景

現在のコントリビュートチャネルは構造化された Issue テンプレート（Bug Report / Knowledge Request）のみで、`blank_issues_enabled: false` のためフリーフォームの Issue も作成不可。コントリビュート障壁が高い。

## このPRでやったこと

- `.github/ISSUE_TEMPLATE/config.yml` の `blank_issues_enabled` を `true` に変更
  - テンプレートに当てはまらない報告を blank issue として受け入れ可能に
- `.github/ISSUE_TEMPLATE/quick_feedback.yml` を新規作成
  - 必須項目はテキストエリア1つのみ（`feedback`）
  - オプションで参照リンク（`source`）を添付可能
  - 自動ラベル: `type: feedback`
- `.github/labels.yml` に `type: feedback` ラベルを追加
- GitHub 上にも `type: feedback` ラベルを作成済み

## 影響範囲

- Issue テンプレート選択画面に「Quick Feedback」が追加される
- 「Blank issue」リンクも表示されるようになる
- 既存の Bug Report / Knowledge Request テンプレートには影響なし

## 品質ゲート

- [x] code-reviewer レビュー完了（CRITICAL/HIGH: 0, WARNING: 2 → 全対応済み）
- [ ] CI 全通過