### PR TITLE
docs: add v1.1.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.1] - 2026-03-16
+
+### Added
+
+- Japanese README (`README.ja.md`)
+- Quick Feedback Issue template for lower contribution barrier
+- Blank issues now enabled for freeform feedback
+- `type: feedback` label for lightweight contributions
+- Core Principles section in `unity-vrc-udon-sharp` SKILL.md
+
+### Changed
+
+- Moved `unity-vrc-skills-renovator` from `skills/` to `.claude/skills/` (dev-only, no longer distributed via npm)
+- Separated development `CLAUDE.md` from distribution templates
+- npm migration notice added to README
+
+### Security
+
+- Pinned all GitHub Actions to SHA hashes
+- Hardened CI pipeline configuration
+
+### Infrastructure
+
+- Branch policy documented in CLAUDE.md and CONTRIBUTING.md
+
 ## [1.0.0] - 2026-03-12
 
 ### Added
@@ -20,4 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Support for Claude Code, Codex CLI, Gemini CLI
 - SDK 3.7.1 - 3.10.2 coverage
 
+[1.1.1]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.1.1
 [1.0.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.0.0


### PR DESCRIPTION
## 関連Issue

N/A (release preparation)

## 背景

v1.1.1 リリースに向けて CHANGELOG.md を更新する。

## このPRでやったこと

- CHANGELOG.md に v1.1.1 エントリを追加（Added / Changed / Security / Infrastructure セクション）

## 影響範囲

- ドキュメントのみ。コードへの影響なし。

## 品質ゲート

- [x] CHANGELOG フォーマット確認済み（Keep a Changelog 準拠）
- [ ] CI 全通過