### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.1.1] - 2026-03-16
+## [1.2.0] - 2026-03-16
 
 ### Added
 
@@ -45,5 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Support for Claude Code, Codex CLI, Gemini CLI
 - SDK 3.7.1 - 3.10.2 coverage
 
-[1.1.1]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.1.1
+[1.2.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.2.0
 [1.0.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",


### PR DESCRIPTION
## Release v1.2.0

Version bump from 1.1.1 to 1.2.0 for npm publish.

### Changes since last main merge
- `package.json` version: `1.1.1` → `1.2.0`
- `CHANGELOG.md` header and link: `1.1.1` → `1.2.0`

**Release process**: After merge, publish the existing draft GitHub Release `v1.2.0` to trigger npm publish.