### PR TITLE
fix: add explicit Rules loading instruction to CLAUDE.md template

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -3,20 +3,20 @@
 Agent Skills for VRChat world development using UdonSharp (C# → Udon Assembly).
 **UdonSharp has significant constraints compared to standard C#. Always read the Rules before generating code.**
 
+## Rules (Required Reading)
+
+Read the following Rules before writing any UdonSharp code:
+
+- **`skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md`** — Blocked Features, Code Generation Rules, Attributes, Syncable Types
+- **`skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md`** — Ownership, Sync Modes, RequestSerialization, NetworkCallable
+- **`skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md`** — Sync Pattern Decision Tree, Data Budget, Minimization
+
 ## Skills
 
 | Skill | Purpose | Path |
 |-------|---------|------|
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
-
-## Rules
-
-Located in `skills/unity-vrc-udon-sharp/rules/`:
-
-- **udonsharp-constraints.md** — Blocked Features, Code Generation Rules, Attributes, Syncable Types
-- **udonsharp-networking.md** — Ownership, Sync Modes, RequestSerialization, NetworkCallable
-- **udonsharp-sync-selection.md** — Sync Pattern Decision Tree, Data Budget, Minimization
 
 ## SDK (3.7.1 - 3.10.2)
 


### PR DESCRIPTION
## Related Issue

Closes #28

## Background

`templates/AGENTS.md` and `templates/GEMINI.md` include `## Rules (Required Reading)` with an
explicit instruction: "Read the following Rules before writing any UdonSharp code". However,
`templates/CLAUDE.md` only had `## Rules` with no loading instruction and abbreviated file paths.

This inconsistency was identified as the root cause of a real-world issue where Claude Code
failed to load sync-related rules, resulting in missing seed synchronization in a multiplayer
VRChat game (Bottle Sort Puzzle).

Ref: https://qiita.com/Yodokoro/items/01bbc93dabc796191fc2

## Changes

- Renamed Rules heading to `## Rules (Required Reading)`
- Added explicit instruction: "Read the following Rules before writing any UdonSharp code:"
- Updated file paths to full paths with bold backtick formatting (matching AGENTS.md/GEMINI.md)
- Reordered sections: Rules before Skills (consistent with other templates)

## Impact

- `templates/CLAUDE.md` — Rules section updated
- No changes to AGENTS.md or GEMINI.md (already correct)

## Quality Gate

- [x] All 3 templates (CLAUDE.md, AGENTS.md, GEMINI.md) Rules sections are now identical
- [x] `npm pack --dry-run` confirms updated file is included
- [x] No functional changes to other sections