### PR TITLE
docs: add UdonProgramAsset auto-generation workflow via AssetPostprocessor

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -444,7 +444,7 @@ When AI creates a new `.cs` UdonSharp script file, the corresponding `.asset` (U
 
 Every UdonSharp script requires a paired UdonSharpProgramAsset:
 
-```
+```text
 MyScript.cs          → Source code (UdonSharpBehaviour)
 MyScript.asset       → UdonSharpProgramAsset (links script to Udon compiler)
 ```

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -770,7 +770,7 @@ EditorUtility.SetDirty(behaviour);
 2. Remove the UdonBehaviour and re-add the UdonSharpBehaviour
 3. Check the Console for detailed error messages
 
-4. If the UdonSharpProgramAsset is missing, see [Editor Scripting Reference: UdonSharpProgramAsset Auto-Generation](editor-scripting.md#udonsharpProgramasset-auto-generation) for an `AssetPostprocessor`-based auto-generation workflow
+4. If the UdonSharpProgramAsset is missing, see [Editor Scripting Reference: UdonSharpProgramAsset Auto-Generation](editor-scripting.md#udonsharpprogramasset-auto-generation) for an `AssetPostprocessor`-based auto-generation workflow
 
 ---
 


### PR DESCRIPTION
## Related Issue

Closes #30

## Background

When AI creates a new `.cs` UdonSharp script, the corresponding `.asset` (UdonSharpProgramAsset) is not auto-generated. Users must manually create it in Unity Editor. The Skills had zero documentation on this workflow.

Community feedback from nemurigi suggests using `AssetPostprocessor` to auto-generate the `.asset` file on script import.

Ref: https://gist.github.com/nemurigi/dea7c0a1fb94f7b9cf1c36481a459ded (MIT License)

## Changes

- Add "UdonSharpProgramAsset Auto-Generation" section to `references/editor-scripting.md`
  - Explain `.cs` to `.asset` relationship
  - Provide `AssetPostprocessor.OnPostprocessAllAssets()` code example
  - Credit nemurigi's approach (MIT License)
- Update `references/troubleshooting.md` "script cannot be loaded" entry with cross-reference

## Impact

- `skills/unity-vrc-udon-sharp/references/editor-scripting.md`
- `skills/unity-vrc-udon-sharp/references/troubleshooting.md`

## Quality Gate

- [x] Code examples follow UdonSharp/Unity Editor conventions
- [x] nemurigi credited with MIT license reference
- [x] `npm pack --dry-run` includes updated files