### PR TITLE
docs: document OnOwnershipRequest and owner-leave cascade behavior

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -397,7 +397,7 @@ public override bool OnOwnershipRequest(
 }
 ```
 
-> **Important**: If the current owner disconnects, `OnOwnershipRequest` is **not called** — VRChat auto-assigns a new owner directly. Only use this for arbitrating live transfer requests.
+> **Important**: This callback runs locally on **both the requester and the current owner**. The logic must return the same result on both sides to avoid desync. If the current owner has disconnected, the callback is not invoked — VRChat auto-assigns a new owner directly.
 
 ## Station Events
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -401,7 +401,7 @@ Acknowledges transfer   |
 
 When the owner of a networked GameObject disconnects:
 
-1. **VRChat automatically assigns a new owner** — typically the instance master (lowest join order)
+1. **VRChat automatically assigns a new owner** — the exact selection rule is not publicly documented; do not assume a specific player will be chosen
 2. **`OnOwnershipTransferred` fires** on all clients with the new owner
 3. **Synced variables are preserved** — they are not reset when ownership transfers
 
@@ -461,6 +461,7 @@ public override bool OnOwnershipRequest(
 ```
 
 **When to use `OnOwnershipRequest`:**
+
 | Scenario | Return |
 |----------|--------|
 | Default (no override) | Always accepts (`true`) |
@@ -468,7 +469,7 @@ public override bool OnOwnershipRequest(
 | Turn-based game during active turn | Reject (`false`) until turn ends |
 | Free-for-all interaction | Accept (`true`) |
 
-> **Note**: `OnOwnershipRequest` is only called on the **current owner's client**. If the owner has left, there is no one to reject — VRChat auto-assigns directly.
+> **Important**: `OnOwnershipRequest` runs locally on **both the requester and the current owner**. The logic must be consistent on both sides to avoid desync. If the owner has disconnected, the callback is not invoked — VRChat auto-assigns directly.
 
 ## Synced Variables
 


### PR DESCRIPTION
## Related Issue

Closes #31

## Background

`OnOwnershipRequest` was listed in `events.md` but had no usage guidance. There was no documentation on what happens when an owner disconnects (automatic ownership re-assignment). This knowledge gap contributed to ownership management issues in a multiplayer game.

Ref: https://qiita.com/Yodokoro/items/01bbc93dabc796191fc2

## Changes

- Add "Owner Leave and Ownership Cascade" section to `references/networking.md`
  - Owner disconnect behavior and auto-assignment
  - Best practices for ownership transitions
- Add "Ownership Arbitration with OnOwnershipRequest" section
  - Code example for accepting/rejecting transfers
  - Scenario-based decision table
- Enhance `OnOwnershipRequest` entry in `references/events.md`
  - Fix return type from `void` to `bool`
  - Add arbitration code example and usage notes

## Impact

- `skills/unity-vrc-udon-sharp/references/networking.md`
- `skills/unity-vrc-udon-sharp/references/events.md`

## Quality Gate

- [x] Code examples follow UdonSharp constraints
- [x] `npm pack --dry-run` includes updated files