### PR TITLE
docs: add late-joiner initialization flag to SyncedObject template

### DIFF
--- a/skills/unity-vrc-udon-sharp/assets/templates/SyncedObject.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/SyncedObject.cs
@@ -50,13 +50,18 @@ public class SyncedObject : UdonSharpBehaviour
 
     void Start()
     {
-        // Apply initial state without side effects (safe for late joiners)
+        // Apply initial visual state only (no side effects).
+        // _isInitialized stays false until first OnDeserialization,
+        // which is the late-joiner guard boundary.
         ApplyVisualState();
-        _isInitialized = true;
     }
 
     public override void Interact()
     {
+        // Local interaction always marks as initialized (instance master
+        // may never receive OnDeserialization for their own changes)
+        _isInitialized = true;
+
         // Take ownership before modifying synced variables
         if (!Networking.IsOwner(gameObject))
         {
@@ -160,6 +165,8 @@ public class SyncedObject : UdonSharpBehaviour
     /// </summary>
     public void SetState(bool newState)
     {
+        _isInitialized = true;
+
         if (!Networking.IsOwner(gameObject))
         {
             Networking.SetOwner(Networking.LocalPlayer, gameObject);


### PR DESCRIPTION
## Related Issue

Closes #33

## Background

The existing `SyncedObject.cs` template triggers `audioSource.PlayOneShot()` in `OnStateChanged()` unconditionally, including when a late joiner receives the initial `OnDeserialization` sync. This causes audio to replay on join.

Depends on: #29 (OnDeserialization guard pattern documentation — should be merged first for cross-reference consistency).

## Changes

- Add `_isInitialized` flag with explanatory comments
- Split `OnStateChanged` into visual update (`ApplyVisualState`) + guarded side effects
- Guard `OnDeserialization` to mark initialization on first sync
- Update `Start()` to use `ApplyVisualState()` instead of `OnStateChanged()`
- Add cross-reference to `networking.md` guard pattern in class summary

## Impact

- `skills/unity-vrc-udon-sharp/assets/templates/SyncedObject.cs`

## Quality Gate

- [x] Template follows UdonSharp constraints
- [x] Late-joiner side effects are properly guarded
- [x] `npm pack --dry-run` includes updated file