### PR TITLE
chore: add plans/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 node_modules/
 *.tgz
 .npm/
+plans/


### PR DESCRIPTION
## Summary

Add `plans/` directory to `.gitignore` to exclude AI planning files from version control.

## Changes

- `.gitignore`: Add `plans/` entry