### PR TITLE
docs: add Persistence Storage Information API reference

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -116,7 +116,10 @@ string[] keys = PlayerData.GetKeys(player);
 
 ### Checking Data Usage (SDK 3.10.0+)
 
-Since SDK 3.10.0, PlayerData usage information is exposed. You can check how much Persistence data each player is using through the world's debug panel or SDK tools. Monitor usage against the 100 KB limit to prevent data write failures due to exceeding the limit.
+Since SDK 3.10.0, VRChat exposes runtime APIs to query storage usage programmatically via
+`VRCPlayerApi` methods and the `OnPersistenceUsageUpdated` event. See
+[Persistence Storage Information API](#persistence-storage-information-api-sdk-3100) for the
+full API reference and a complete monitoring example.
 
 ## PlayerObject
 


### PR DESCRIPTION
## 関連Issue

Closes #45

## 背景

SDK 3.10.0 added persistence storage monitoring APIs. Developers need visibility into their 100KB data budget usage.

## このPRでやったこと

- Added Storage Information API section to `references/persistence.md`
- Documented GetPlayerDataStorageUsage, GetPlayerDataStorageLimit, RequestStorageUsageUpdate
- Documented OnPersistenceUsageUpdated event
- Added storage monitoring code example

## 影響範囲

- `skills/unity-vrc-udon-sharp/references/persistence.md`

## 品質ゲート

- [x] UdonSharp constraint compliance
- [x] validate-udonsharp.sh passed