### PR TITLE
docs: add VRC Constraints Udon API documentation

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -378,6 +378,256 @@ public VRCRotationConstraint rotationConstraint;
 | Migrating from Unity Constraints | Replace with VRC equivalents |
 | Avatar constraints | Follow VRChat avatar documentation |
 
+## VRC Constraints Udon API
+
+This section covers the full Udon API for controlling VRC Constraints at runtime. For component type selection and cross-platform considerations, see the [VRC Constraints vs Unity Constraints comparison table](#vrc-constraints-vs-unity-constraints) above.
+
+### Constraint Types Overview
+
+All six VRC Constraint types share a common base API. The table below summarises each type's purpose and the namespace required in UdonSharp:
+
+| Component Class | Purpose | Typical Use Case |
+|-----------------|---------|-----------------|
+| `VRCPositionConstraint` | Constrains world/local position | Object that follows a target's position |
+| `VRCRotationConstraint` | Constrains world/local rotation | Object that mirrors a target's rotation |
+| `VRCScaleConstraint` | Constrains world/local scale | Object that scales with a target |
+| `VRCParentConstraint` | Constrains position **and** rotation (like re-parenting) | Attaching props to moving targets |
+| `VRCAimConstraint` | Rotates so a chosen axis points at the target | Turrets, eye tracking |
+| `VRCLookAtConstraint` | Rotates so the forward axis looks at the target (Y-up preserved) | Billboards, simplified eye tracking |
+
+All types live in `VRC.SDK3.Dynamics.Constraint.Components`.
+
+### Udon-Accessible Properties
+
+The properties below are available on every VRC Constraint component from Udon. Properties marked **read/write** can be set at runtime.
+
+#### Common Properties (All Types)
+
+| Property | Type | Access | Description |
+|----------|------|--------|-------------|
+| `IsActive` | `bool` | R/W | Enables or disables the constraint evaluation |
+| `GlobalWeight` | `float` | R/W | Master blend weight (0.0 – 1.0) applied on top of per-source weights |
+| `FreezeToWorld` | `bool` | R/W | When `true`, locks the constrained object in world space (ignores sources) |
+| `AffectsPositionX/Y/Z` | `bool` | R/W | (Position / Parent) Toggle per-axis position constraint |
+| `AffectsRotationX/Y/Z` | `bool` | R/W | (Rotation / Parent) Toggle per-axis rotation constraint |
+| `AffectsScaleX/Y/Z` | `bool` | R/W | (Scale) Toggle per-axis scale constraint |
+
+#### Source List Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetSourceCount()` | `int` | Returns the current number of constraint sources |
+| `GetSource(int index)` | `VRCConstraintSource` | Returns the source struct at the given index |
+| `SetSource(int index, VRCConstraintSource source)` | `void` | Overwrites the source at the given index |
+| `AddSource(VRCConstraintSource source)` | `void` | Appends a new source to the list |
+| `RemoveSource(int index)` | `void` | Removes the source at the given index |
+| `SetSourceWeight(int index, float weight)` | `void` | Convenience method – sets only the weight of source at index |
+
+#### VRCConstraintSource Struct
+
+`VRCConstraintSource` is a value-type struct. Always assign the full struct back after modifying it (struct-mutation rule applies — see [UdonSharp constraints reference](../rules/udonsharp-constraints.md)):
+
+```csharp
+// Fields
+public Transform sourceTransform;   // The target Transform (can be null to disable source)
+public float weight;                // Per-source blend weight (0.0 – 1.0)
+```
+
+### Code Examples
+
+#### Example 1: Enable / Disable a Constraint at Runtime
+
+Toggle a `VRCPositionConstraint` on and off, for example when a player picks up an object.
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Dynamics.Constraint.Components;
+using VRC.SDKBase;
+
+public class ConstraintToggle : UdonSharpBehaviour
+{
+    [Header("Constraint to control")]
+    public VRCPositionConstraint positionConstraint;
+
+    [Header("Optional: animate global weight instead of hard on/off")]
+    public bool useWeightFade = false;
+
+    // Called from a UI button or InteractEvent
+    public void EnableConstraint()
+    {
+        if (positionConstraint == null) return;
+
+        if (useWeightFade)
+        {
+            positionConstraint.GlobalWeight = 1f;
+        }
+        else
+        {
+            positionConstraint.IsActive = true;
+        }
+    }
+
+    public void DisableConstraint()
+    {
+        if (positionConstraint == null) return;
+
+        if (useWeightFade)
+        {
+            positionConstraint.GlobalWeight = 0f;
+        }
+        else
+        {
+            positionConstraint.IsActive = false;
+        }
+    }
+
+    // Toggle helper – safe to call from network events
+    public void ToggleConstraint()
+    {
+        if (positionConstraint == null) return;
+        positionConstraint.IsActive = !positionConstraint.IsActive;
+    }
+}
+```
+
+**Notes**:
+- Setting `IsActive = false` stops constraint evaluation entirely (cheapest option).
+- Setting `GlobalWeight = 0` keeps evaluation running but blends to zero; useful for smooth transitions.
+- No ownership transfer is needed to change constraint properties on the local client. If the result must be visible to all players, combine with `[UdonSynced]` state and `RequestSerialization()`.
+
+#### Example 2: Modify Constraint Sources at Runtime
+
+Dynamically swap or blend between multiple target transforms — for example, switching which player a spotlight follows.
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Dynamics.Constraint.Components;
+using VRC.SDKBase;
+
+public class ConstraintSourceSwapper : UdonSharpBehaviour
+{
+    [Header("The aim constraint that points a spotlight")]
+    public VRCAimConstraint spotlightAim;
+
+    [Header("A pool of potential target transforms")]
+    public Transform[] targetPool;
+
+    // Switch the single source to point at a new target
+    public void SetTarget(int targetIndex)
+    {
+        if (spotlightAim == null) return;
+        if (targetIndex < 0 || targetIndex >= targetPool.Length) return;
+
+        // Build a new source struct pointing at the chosen transform
+        VRCConstraintSource newSource = new VRCConstraintSource();
+        newSource.sourceTransform = targetPool[targetIndex];
+        newSource.weight = 1f;
+
+        if (spotlightAim.GetSourceCount() == 0)
+        {
+            spotlightAim.AddSource(newSource);
+        }
+        else
+        {
+            // Overwrite the first (and only) source
+            spotlightAim.SetSource(0, newSource);
+        }
+    }
+
+    // Blend equally between two targets by adjusting their weights
+    public void BlendBetweenTargets(int indexA, int indexB, float weightA)
+    {
+        if (spotlightAim == null) return;
+        if (spotlightAim.GetSourceCount() < 2) return;
+
+        float weightB = 1f - weightA;
+
+        // SetSourceWeight is a convenience wrapper; equivalent to reading the source,
+        // updating weight, and calling SetSource() back.
+        spotlightAim.SetSourceWeight(indexA, weightA);
+        spotlightAim.SetSourceWeight(indexB, weightB);
+    }
+
+    // Remove all sources except the first, then clear it
+    public void ClearAllSources()
+    {
+        if (spotlightAim == null) return;
+
+        int count = spotlightAim.GetSourceCount();
+        // Remove from the end to avoid index shifting
+        for (int i = count - 1; i > 0; i--)
+        {
+            spotlightAim.RemoveSource(i);
+        }
+
+        if (spotlightAim.GetSourceCount() > 0)
+        {
+            VRCConstraintSource empty = new VRCConstraintSource();
+            empty.sourceTransform = null;
+            empty.weight = 0f;
+            spotlightAim.SetSource(0, empty);
+        }
+    }
+}
+```
+
+**Notes**:
+- `VRCConstraintSource` is a **struct** — always construct a new instance and assign it; do not attempt to mutate the value returned by `GetSource()` in place (see [struct mutation caveat](../rules/udonsharp-constraints.md#struct-mutation)).
+- Remove sources from the **highest index downward** when removing multiple at once, to avoid index shifting mid-loop.
+- `SetSourceWeight(index, weight)` is a shorthand for read-modify-write with `GetSource` / `SetSource`; both approaches are equivalent.
+
+### Per-Type Additional Properties
+
+Some constraint types expose extra writable properties beyond the common set:
+
+| Type | Extra Properties | Description |
+|------|-----------------|-------------|
+| `VRCAimConstraint` | `AimVector`, `UpVector`, `WorldUpVector`, `WorldUpType` | Axis vectors for the aim calculation |
+| `VRCLookAtConstraint` | `Roll` | Roll angle offset around the look axis |
+| `VRCParentConstraint` | `AffectsPositionX/Y/Z`, `AffectsRotationX/Y/Z` | Independent axis masking for position and rotation |
+
+### Runtime Source Management — Pattern Summary
+
+```csharp
+using VRC.SDK3.Dynamics.Constraint.Components;
+
+// --- Read ---
+int count = constraint.GetSourceCount();
+VRCConstraintSource src = constraint.GetSource(0);
+float w = src.weight;
+Transform t = src.sourceTransform;
+
+// --- Write (weight only) ---
+constraint.SetSourceWeight(0, 0.5f);
+
+// --- Write (full source) ---
+// IMPORTANT: structs must be fully reassigned — do not mutate GetSource() result in place
+VRCConstraintSource updated = constraint.GetSource(0);
+updated.sourceTransform = someNewTransform; // modify copy
+updated.weight = 0.75f;
+constraint.SetSource(0, updated);           // write back
+
+// --- Add ---
+VRCConstraintSource newSrc = new VRCConstraintSource();
+newSrc.sourceTransform = targetTransform;
+newSrc.weight = 1f;
+constraint.AddSource(newSrc);
+
+// --- Remove (always remove from highest index first in loops) ---
+constraint.RemoveSource(count - 1);
+```
+
+### Performance Considerations
+
+| Tip | Reason |
+|-----|--------|
+| Disable (`IsActive = false`) when not needed | Stops CPU evaluation of the constraint entirely |
+| Prefer `SetSourceWeight` over removing/re-adding sources | Avoids internal list reallocation |
+| Avoid modifying sources every `Update()` frame | Batch changes and apply only when the target actually changes |
+| Use `GlobalWeight` for smooth fades | Cheaper than adding/removing sources for blending |
+
 ## Common Patterns
 
 ### Interactive Button with Feedback


### PR DESCRIPTION
## 関連Issue

Closes #48

## 背景

SDK 3.10.0 added VRC Constraints to Worlds with Udon integration. The dynamics.md had a comparison table but no API documentation for runtime control.

## このPRでやったこと

- Added VRC Constraints Udon API section to `references/dynamics.md`
- Documented all constraint types with Udon-accessible properties
- Added code examples for runtime constraint control

## 影響範囲

- `skills/unity-vrc-udon-sharp/references/dynamics.md`

## 品質ゲート

- [x] UdonSharp constraint compliance
- [x] Code examples validated