### PR TITLE
feat: add ref/out, multidim array, and method overloading checks to validation hooks

### DIFF
--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
@@ -145,6 +145,33 @@ if ($FileContent -match 'NoVariableSync' -and $FileContent -match '\[UdonSynced\
     $Warnings += "[UdonSharp] ERROR: NoVariableSync mode but [UdonSynced] variables found. Remove [UdonSynced] or change sync mode."
 }
 
+# Check for ref parameter in method declaration
+if ($FileContent -match '\b(void|int|float|bool|string|[A-Z][A-Za-z0-9_]*)\s+\w+\s*\(.*\bref\s+\w') {
+    $Warnings += "[UdonSharp] BLOCKED: ref parameters not supported in UdonSharp. Use return values or synced fields instead."
+}
+
+# Check for out parameter in method declaration
+if ($FileContent -match '\b(void|int|float|bool|string|[A-Z][A-Za-z0-9_]*)\s+\w+\s*\(.*\bout\s+\w') {
+    $Warnings += "[UdonSharp] BLOCKED: out parameters not supported in UdonSharp. Use return values instead."
+}
+
+# Check for multi-dimensional arrays (T[,])
+if ($FileContent -match '\w+\s*\[,') {
+    $Warnings += "[UdonSharp] BLOCKED: Multi-dimensional arrays (T[,]) not supported. Use jagged arrays (T[][]) or flatten to 1D instead."
+}
+
+# Check for method overloading (same name, different signatures)
+$MethodMatches = [regex]::Matches(
+    $FileContent,
+    '(?m)^\s*(?:public|private|protected|internal|override|virtual|static|\s)+\s+(?:void|int|float|bool|string|[A-Z][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\('
+)
+$MethodNames = $MethodMatches | ForEach-Object { $_.Groups[1].Value }
+$OverloadedNames = $MethodNames | Group-Object | Where-Object { $_.Count -gt 1 } | Select-Object -ExpandProperty Name
+if ($OverloadedNames.Count -gt 0) {
+    $OverloadList = $OverloadedNames -join ', '
+    $Warnings += "[UdonSharp] WARNING: Method overloading detected for: $OverloadList. Only simple overloads may work; prefer unique method names."
+}
+
 # Output warnings
 if ($Warnings.Count -gt 0) {
     $SavedErrorAction = $ErrorActionPreference

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
@@ -133,6 +133,30 @@ if grep -qE 'NoVariableSync' "$file_path" && \
     warnings+=("[UdonSharp] ERROR: NoVariableSync mode but [UdonSynced] variables found. Remove [UdonSynced] or change sync mode.")
 fi
 
+# ref parameter in method declaration
+if grep -qE '\b(void|int|float|bool|string|[A-Z][A-Za-z0-9_]*)\s+\w+\s*\(.*\bref\s+\w' "$file_path"; then
+    warnings+=("[UdonSharp] BLOCKED: ref parameters not supported in UdonSharp. Use return values or synced fields instead.")
+fi
+
+# out parameter in method declaration
+if grep -qE '\b(void|int|float|bool|string|[A-Z][A-Za-z0-9_]*)\s+\w+\s*\(.*\bout\s+\w' "$file_path"; then
+    warnings+=("[UdonSharp] BLOCKED: out parameters not supported in UdonSharp. Use return values instead.")
+fi
+
+# Multi-dimensional arrays (T[,])
+if grep -qE '\w+\s*\[,' "$file_path"; then
+    warnings+=("[UdonSharp] BLOCKED: Multi-dimensional arrays (T[,]) not supported. Use jagged arrays (T[][]) or flatten to 1D instead.")
+fi
+
+# Method overloading (same name, different signatures)
+overloaded=$(grep -oE '^\s*(public|private|protected|internal|override|virtual|static|public\s+override|private\s+static|public\s+static)(\s+(public|private|protected|internal|override|virtual|static))?\s+(void|int|float|bool|string|[A-Z][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(' "$file_path" \
+    | grep -oE '[A-Za-z_][A-Za-z0-9_]*\s*\($' \
+    | sed 's/[[:space:]]*($//' \
+    | sort | uniq -d)
+if [[ -n "$overloaded" ]]; then
+    warnings+=("[UdonSharp] WARNING: Method overloading detected for: $(echo "$overloaded" | tr '\n' ' '). Only simple overloads may work; prefer unique method names.")
+fi
+
 # Output warnings
 if [[ ${#warnings[@]} -gt 0 ]]; then
     echo "" >&2


### PR DESCRIPTION
## 関連Issue

Closes #55

## 背景

The validation hook catches 14+ violations but misses ref/out parameters, multi-dimensional arrays, and method overloading. These blocked features cause confusing compile errors.

## このPRでやったこと

- Added ref/out parameter detection to both .sh and .ps1 hooks
- Added multi-dimensional array T[,] detection
- Added method overloading detection (WARNING level)
- All existing checks preserved
- Tested against existing templates (no false positives)

## 影響範囲

- `skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh`
- `skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1`

## 品質ゲート

- [x] Existing template validation still passes
- [x] New checks correctly detect violations
- [x] Both .sh and .ps1 versions updated