### PR TITLE
fix: resolve phantom template refs, add missing See Also and search hints

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -110,17 +110,17 @@ WebSearch: "error message UdonSharp site:github.com"
 | File | Contents | Search Hints |
 |------|----------|--------------|
 | `constraints.md` | C# feature availability in UdonSharp; blocked features; syncable types; attributes | List, async, try/catch, LINQ, generics, DataList, DataDictionary |
-| `networking.md` | Ownership model, sync modes, RequestSerialization, NetworkCallable, network events, data limits | UdonSynced, SetOwner, BehaviourSyncMode, FieldChangeCallback, OnDeserialization |
+| `networking.md` | Ownership model, sync modes, RequestSerialization, NetworkCallable, network events, data limits | UdonSynced, SetOwner, BehaviourSyncMode, FieldChangeCallback, OnDeserialization, master leave, ownership cascade |
 | `networking-bandwidth.md` | Bandwidth throttling, bit packing, synced data size examples, debugging, owner-centric architecture | IsClogged, bandwidth, throttle, bit packing, data budget, IsMaster |
 | `networking-antipatterns.md` | 6 anti-patterns to avoid; 5 advanced sync patterns with template links | anti-pattern, race condition, ownership fight, late-joiner, PackedStateSync, BatchedSync |
 | `persistence.md` | PlayerData/PlayerObject API (SDK 3.7.4+); per-player save data | PlayerData, PlayerObject, OnPlayerRestored, SetInt, TryGetInt |
 | `dynamics.md` | PhysBones, Contacts, VRC Constraints (SDK 3.10.0+) | PhysBone, ContactReceiver, ContactSender, VRCConstraint, OnContactEnter |
 | `patterns-core.md` | Initialization, interaction, player detection, timer, audio, pickup, animation, UI, teleportation, lazy init guard | Interact, OnEnable, Initialize, AudioSource, VRCPickup, Animator, UI, TeleportTo |
-| `patterns-networking.md` | Object pooling, NetworkCallable patterns, persistence integration, dynamics integration, synced game state, delayed event debounce | pool, MasterManagedPlayerPool, NetworkCallable, DamageReceiver, game state, debounce |
+| `patterns-networking.md` | Object pooling, NetworkCallable patterns, persistence integration, dynamics integration, synced game state, delayed event debounce | pool, MasterManagedPlayerPool, NetworkCallable, DamageReceiver, game state, debounce, state machine |
 | `patterns-performance.md` | Partial class pattern, update handler, PostLateUpdate, spatial query, platform optimization | Update, PostLateUpdate, Bounds, AnimatorHash, performance, mobile, PC |
 | `patterns-utilities.md` | Array helpers (List alternatives), event bus, GameObject relay communication | ArrayUtils, EventBus, relay, subscriber, FindIndex, ShuffleArray |
 | `web-loading.md` | String/Image downloading, VRCJson, Trusted URLs | VRCStringDownloader, VRCImageDownloader, VRCJson, DataDictionary, VRCUrl |
-| `api.md` | VRCPlayerApi, Networking, enums reference | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity |
+| `api.md` | VRCPlayerApi, Networking, enums reference | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity, Drone, VRCDroneApi |
 | `events.md` | All Udon events (including OnPlayerRestored, OnContactEnter) | OnPlayerJoined, OnPlayerLeft, OnPlayerTriggerEnter, OnOwnershipTransferred |
 | `editor-scripting.md` | Editor scripting and proxy system | UdonSharpEditor, UdonSharpBehaviourProxy, SerializedObject |
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -870,5 +870,6 @@ public class DroneCheckpoint : UdonSharpBehaviour
 
 ## See Also
 
+- [constraints.md](constraints.md) - C# feature availability in UdonSharp that affects which APIs can be used
 - [events.md](events.md) - Complete event list and execution-order diagrams
 - [networking.md](networking.md) - `Networking` class, ownership, and `RequestSerialization` patterns

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -477,6 +477,12 @@ public class MyScript : UdonSharpBehaviour
 
 Note: `ExecuteInEditMode` can cause issues with UdonSharp. Use with caution.
 
+## See Also
+
+- [api.md](api.md) - VRChat API reference including types used in editor scripts
+- [constraints.md](constraints.md) - C# feature constraints that affect editor-time validation
+- [patterns-performance.md](patterns-performance.md) - DefaultExecutionOrder and performance patterns
+
 ## UdonSharpProgramAsset Auto-Generation
 
 ### The Problem

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -815,5 +815,6 @@ public override void OnPlayerJoined(VRCPlayerApi player)
 
 ## See Also
 
+- [api.md](api.md) - VRCPlayerApi and Networking class reference for types used in event handlers
 - [dynamics.md](dynamics.md) - PhysBone and Contact component setup for the events listed here
 - [networking.md](networking.md) - Serialization and ownership events in depth (`OnDeserialization`, `OnOwnershipTransferred`)

--- a/skills/unity-vrc-udon-sharp/references/networking-bandwidth.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-bandwidth.md
@@ -93,8 +93,6 @@ public void ExecuteSync()
 - Up to `SyncInterval` seconds of latency
 - Individual sync requests may be merged (syncing state, not events)
 
-Reference template: `assets/templates/ThrottledSync.cs`
-
 ### Periodic Sync Pattern
 
 Continuous synchronization at controlled intervals:
@@ -215,8 +213,6 @@ public void UnpackValues(ulong packed, byte[] values)
     }
 }
 ```
-
-Reference template: `assets/templates/BitPacking.cs`
 
 ### Range Shifting
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1109,5 +1109,6 @@ void Update()
 - [networking-bandwidth.md](networking-bandwidth.md) - Bandwidth throttling, bit packing, owner-centric architecture, debugging
 - [networking-antipatterns.md](networking-antipatterns.md) - 6 anti-patterns and 5 advanced patterns
 - [patterns-networking.md](patterns-networking.md) - Object pooling, game state management, NetworkCallable patterns
+- [persistence.md](persistence.md) - PlayerData/PlayerObject API for persisting data across sessions
 - [sync-examples.md](sync-examples.md) - Concrete synced gimmick patterns with data budget reference
 - [troubleshooting.md](troubleshooting.md) - Debugging networking issues, ownership race conditions

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -907,6 +907,7 @@ public class ScoreBoard : UdonSharpBehaviour
 
 ## See Also
 
+- [dynamics.md](dynamics.md) - PhysBones, Contacts, and VRC Constraints for physics-based interactions
 - [patterns-networking.md](patterns-networking.md) - Object pooling, game state, NetworkCallable, persistence, dynamics
 - [patterns-performance.md](patterns-performance.md) - Partial class, update handler, PostLateUpdate, spatial query
 - [patterns-utilities.md](patterns-utilities.md) - Array helpers, event bus, relay communication

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -617,6 +617,8 @@ public class DebouncedSearch : UdonSharpBehaviour
 
 ## See Also
 
+- [networking-antipatterns.md](networking-antipatterns.md) - Anti-patterns to avoid and advanced sync patterns
+- [networking-bandwidth.md](networking-bandwidth.md) - Bandwidth throttling, bit packing, and data size optimization
 - [patterns-core.md](patterns-core.md) - Initialization, interaction, timer, audio, pickup, animation, UI
 - [patterns-performance.md](patterns-performance.md) - Partial class, update handler, PostLateUpdate, spatial query
 - [patterns-utilities.md](patterns-utilities.md) - Array helpers, event bus, relay communication

--- a/skills/unity-vrc-udon-sharp/references/patterns-performance.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-performance.md
@@ -248,8 +248,6 @@ With 100 inactive gimmicks in a world:
 - Simple Update() with minimal overhead
 - When the extra component adds more complexity than benefit
 
-Reference template: `assets/templates/UpdateHandler.cs`
-
 ### Combining Both Patterns
 
 For complex gimmicks, combine Partial Class and Update Handler:

--- a/skills/unity-vrc-udon-sharp/references/sync-examples.md
+++ b/skills/unity-vrc-udon-sharp/references/sync-examples.md
@@ -342,4 +342,5 @@ The following is a summary of synced data amounts for the patterns above. Use fo
 ## See Also
 
 - [networking.md](networking.md) - Sync mode selection, ownership rules, and bandwidth limits explained
+- [networking-bandwidth.md](networking-bandwidth.md) - Bandwidth throttling, bit packing, and data size optimization
 - [persistence.md](persistence.md) - Persisting player data across sessions with PlayerData and PlayerObject


### PR DESCRIPTION
## 関連Issue

Closes #96

## 背景

Post-restructure quality verification found: 3 phantom template references, 1 missing See Also section, search hint gaps in SKILL.md, and bidirectional link inconsistencies.

## このPRでやったこと

- Removed 3 phantom template references (ThrottledSync.cs, BitPacking.cs, UpdateHandler.cs)
- Added See Also section to editor-scripting.md
- Extended SKILL.md search hints (Drone, state machine, master leave)
- Added 6 missing reverse links in See Also sections

## 影響範囲

- `references/networking-bandwidth.md`, `references/patterns-performance.md`
- `references/editor-scripting.md`
- `SKILL.md`
- 6 reference files (See Also sections)

## 品質ゲート

- [x] All fixes verified against QA report
- [x] No content lost