### PR TITLE
Release v1.5.1

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -55,7 +55,7 @@ These constraints cause **silent failures** — no compiler error, no runtime ex
 | 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Attribute compiles but is **silently ignored** — methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
 | 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Events and components do not exist for worlds — code compiles but callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | `PlayerData`, `PlayerObject`, `OnPlayerRestored` do not exist — compile or silent runtime failure | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
-| 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | Install `UdonSharpProgramAssetAutoGenerator.cs` template in an `Editor` folder, or create scripts via Unity's Assets > Create > U# Script |
+| 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
 
 ## Sync Mode Quick Decision
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1140,11 +1140,13 @@ EditorUtility.SetDirty(behaviour);
 1. Fix all compile errors first
 2. Check the Console for detailed error messages
 3. Remove the UdonBehaviour and re-add the UdonSharpBehaviour
-4. **If the `.asset` file is missing**: Install `UdonSharpProgramAssetAutoGenerator.cs` (from `assets/templates/`) into your `Assets/Editor/` folder
+4. **If the `.asset` file is missing**: Install `UdonSharpProgramAssetAutoGenerator.cs` (from `assets/templates/UdonSharpProgramAssetAutoGenerator.cs`, or obtain the implementation from `references/editor-scripting.md`) into your `Assets/Editor/` folder
 5. Reimport each affected `.cs` file (right-click -> Reimport, or make a trivial edit and save) to trigger domain reload and auto-generation
 6. Confirm the matching `.asset` file is created, then re-add the component if needed. See [Editor Scripting Reference: UdonSharpProgramAsset Auto-Generation](editor-scripting.md#udonsharpprogramasset-auto-generation) for details
 
 > **Note**: The auto-generator skips scripts that have compile errors, are `abstract`, do not inherit from `UdonSharpBehaviour`, or already have a registered `.asset`. If the `.asset` is still not generated after reimport, check the Console for error messages.
+
+> **Prevention**: When creating new `.cs` files, the auto-generator MUST be installed proactively — not after breakage. See Rule 8 in `rules/udonsharp-constraints.md` for the mandatory check-install-notify procedure.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -130,7 +130,15 @@ public override void OnPlayerJoined(VRCPlayerApi player) { }
 
 ### 8. UdonSharpProgramAsset Requirement
 
-Every `.cs` UdonSharpBehaviour needs a corresponding `.asset` (UdonSharpProgramAsset). Without it, the script won't compile to Udon. When creating new scripts outside Unity's "Create > U# Script" menu, recommend the auto-generator template (`UdonSharpProgramAssetAutoGenerator.cs`) in an `Editor` folder. See `references/editor-scripting.md` for details.
+Every `.cs` UdonSharpBehaviour needs a corresponding `.asset` (UdonSharpProgramAsset). Without it, the script won't compile to Udon.
+
+**When creating a new `.cs` file, the agent MUST follow this procedure:**
+
+1. **Check**: Verify that `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists in the user's Unity project
+2. **Install if missing**: If the file does not exist, create the `Assets/Editor/` directory (if needed) and write the auto-generator using the implementation from `references/editor-scripting.md` (UdonSharpProgramAsset Auto-Generation section)
+3. **Notify**: Inform the user that the auto-generator was installed and that new `.cs` files will automatically receive `.asset` files on domain reload
+
+Do NOT assume the auto-generator is already installed. The agent cannot verify installation status without explicitly checking, so skipping this procedure based on assumption is prohibited. See `references/editor-scripting.md` for the full implementation.
 
 ## Attribute Quick Reference
 
@@ -178,4 +186,4 @@ Types that can be used with `[UdonSynced]`:
 - [ ] Using return values for struct methods
 - [ ] Not using `AddListener()`
 - [ ] Unity callbacks (OnTriggerEnter, etc.) do not have override
-- [ ] New scripts have corresponding `.asset` files (or auto-generator is installed)
+- [ ] Auto-generator (`UdonSharpProgramAssetAutoGenerator.cs`) confirmed present in `Assets/Editor/` (installed if it was missing)


### PR DESCRIPTION
## Summary

Merge dev into main for release v1.5.1.

### Changes included

- fix(udon-sharp): enforce mandatory auto-generator check when creating new scripts (#130)
  - Replaced soft/recommendatory language with mandatory check-install-notify procedure for `.asset` file handling
  - Removed unfalsifiable escape hatch from Validation Checklist
  - Added cross-reference from troubleshooting to proactive Rule 8

### Version bump

- **Patch** (v1.5.0 → v1.5.1) — bug fix label