### PR TITLE
fix(installer): mark unity-vrc-skills-renovator as internal to exclude from npx skills selection

### DIFF
--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -12,6 +12,7 @@ metadata:
     author: niaka3dayo
     version: "1.2.1"
     tags: skill-maintenance, sdk-update, knowledge-management
+    internal: true
 ---
 
 # VRC Skills Renovator


### PR DESCRIPTION
## Summary

- `unity-vrc-skills-renovator` was appearing in the `npx skills add niaka3dayo/agent-skills-vrc-udon` selection menu alongside the two distributable skills
- Root cause: the `npx skills` CLI scans all `SKILL.md` files in the cloned repository (including `.claude/skills/`) and shows them unless `metadata.internal: true` is set
- Fix: add `internal: true` to `unity-vrc-skills-renovator/SKILL.md` metadata — the `skills` npm package's `parseSkillMd()` already implements this filter

## Changes

- `.claude/skills/unity-vrc-skills-renovator/SKILL.md`: add `internal: true` to `metadata`

## Test Plan

- [ ] Run `npx skills add niaka3dayo/agent-skills-vrc-udon --list` after this merges — should show exactly 2 skills (not 3)
- [ ] Confirm `unity-vrc-skills-renovator` does not appear in the interactive selection
- [ ] Verify `INSTALL_INTERNAL_SKILLS=1 npx skills add niaka3dayo/agent-skills-vrc-udon --list` still shows all 3 skills (for dev use)

Closes #132