### PR TITLE
fix(udon-sharp): resolve documentation contradictions in constraints and networking rules

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -423,7 +423,7 @@ Know the sizes of synced types for bandwidth optimization:
 | `float` | 4 | |
 | `double` | 8 | |
 | `char` | 2 | UTF-16 |
-| `string` | variable | ~2 bytes per char + overhead, max ~50 chars |
+| `string` | variable | 2 bytes per char; no separate per-string limit — bounded by sync mode budget |
 | `Vector2` | 8 | 2 floats |
 | `Vector3` | 12 | 3 floats |
 | `Vector4` | 16 | 4 floats |
@@ -435,7 +435,7 @@ Know the sizes of synced types for bandwidth optimization:
 ### Bandwidth Limits
 
 - **Continuous sync**: ~200 bytes per UdonBehaviour
-- **Manual sync**: ~282KB per UdonBehaviour
+- **Manual sync**: ~280KB (280,496 bytes) per UdonBehaviour
 - **Total transmission**: ~11 KB/sec
 
 ## SerializationResult

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -33,7 +33,7 @@ UdonSharp transpiles C# source to Udon Assembly, which runs on VRChat's UdonVM. 
 | `Vector3`, `Quaternion`, `Color` | Supported | 3.0+ | Unity struct types; see struct mutation caveat |
 | `GameObject`, `Transform` | Supported | 3.0+ | Unity object types |
 | `T[]` (one-dimensional arrays) | Supported | 3.0+ | Primary collection type |
-| `T[,]` (multi-dimensional arrays) | Supported | 3.0+ | Works but less common |
+| `T[,]` (multi-dimensional arrays) | Blocked | — | Use jagged arrays `T[][]` instead |
 | `T[][]` (jagged arrays) | Supported | 3.0+ | Arrays of arrays |
 
 ### Control Flow
@@ -493,7 +493,12 @@ Udon dispatches events (like `SendCustomEvent`) by searching public method names
 
 ### String Sync Limit
 
-Synced `string` fields (`[UdonSynced]`) have an approximate 50-character limit. For longer strings, split across multiple fields or use a different sync strategy.
+Synced `string` fields (`[UdonSynced]`) are encoded at 2 bytes per character. There is no separate per-string character limit; the practical limit is set by the sync mode's per-serialization buffer:
+
+- **Continuous sync**: ~200 bytes shared across all synced fields on the behaviour. A single synced string can consume the entire budget quickly (e.g., a 100-character string = 200 bytes), leaving no room for other fields.
+- **Manual sync**: 280,496 bytes (~280KB) per serialization, allowing much larger strings.
+
+For Continuous sync, keep synced strings very short or switch to Manual sync.
 
 ---
 
@@ -514,85 +519,6 @@ Before compiling UdonSharp code, verify:
 - [ ] Unity callbacks (OnTriggerEnter, etc.) do not have `override`
 - [ ] VRChat event callbacks (OnPlayerJoined, etc.) do have `override`
 - [ ] `Button.onClick` not used; events configured in Inspector
-
-## Known Limitations and Caveats
-
-### Prefab Field Changes
-
-Changes to serialized fields on prefabs do NOT propagate to instances in the scene or other prefabs that reference them. This is a Unity limitation that affects UdonSharp as well.
-
-**Workaround**: After modifying a prefab, manually update instances or use `PrefabUtility.ApplyPrefabInstance` in editor scripts.
-
-### Field Initializers
-
-Field initializers are evaluated at **compile time**, not runtime. This means:
-
-```csharp
-// WRONG - Random.Range is evaluated once at compile time
-private int randomValue = Random.Range(0, 100); // Same value for all instances!
-
-// CORRECT - Initialize in Start()
-private int randomValue;
-
-void Start()
-{
-    randomValue = Random.Range(0, 100);
-}
-```
-
-### GetComponent and UdonBehaviour
-
-Generic `GetComponent<UdonBehaviour>()` is not directly exposed, but **SDK 3.8+** improved support for inherited types:
-
-```csharp
-// WRONG - Raw UdonBehaviour generic
-UdonBehaviour udon = GetComponent<UdonBehaviour>();
-
-// CORRECT - Cast syntax for raw UdonBehaviour
-UdonBehaviour udon = (UdonBehaviour)GetComponent(typeof(UdonBehaviour));
-
-// CORRECT (SDK 3.8+) - Generic works for UdonSharpBehaviour inheritance
-MyScript script = GetComponent<MyScript>(); // Works for UdonSharpBehaviour types
-
-// CORRECT (SDK 3.8+) - Works with inheritance hierarchy
-public class BaseGimmick : UdonSharpBehaviour { }
-public class DerivedGimmick : BaseGimmick { }
-
-// This now works correctly:
-BaseGimmick gimmick = GetComponent<BaseGimmick>();
-DerivedGimmick derived = GetComponent<DerivedGimmick>();
-```
-
-**Note:** SDK 3.8+ added proper handling for `GetComponent(s)<T>()` on UdonSharpBehaviour types using inheritance.
-
-### Struct Method Mutation (Reiterated)
-
-Methods that mutate structs do NOT modify the original:
-
-```csharp
-// WRONG
-Vector3 v = new Vector3(3, 4, 0);
-v.Normalize(); // v is UNCHANGED!
-
-// CORRECT
-v = v.normalized;
-```
-
-### uGUI Button Event Registration
-
-`Button.onClick.AddListener()` is not available (delegate-based). uGUI button events must be configured in the Unity Inspector.
-
-```csharp
-// WRONG - NotImplementedException at runtime
-button.onClick.AddListener(() => DoSomething());
-button.onClick.AddListener(DoSomething); // Also not possible
-
-// CORRECT - Configure in Unity Inspector:
-// 1. Add to the Button component's OnClick() list
-// 2. Drag the UdonBehaviour
-// 3. Select SendCustomEvent
-// 4. Enter the method name (e.g., "OnButtonClicked")
-```
 
 ## Advanced Constraint Workarounds
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -805,7 +805,7 @@ Only types syncable with `[UdonSynced]` can be used as parameters:
 | `long`, `ulong` | 8 bytes | |
 | `float` | 4 bytes | |
 | `double` | 8 bytes | |
-| `string` | 2 bytes/char | No fixed limit; bounded by sync mode budget (Continuous: shared ~200 bytes; Manual: ~280KB) |
+| `string` | 2 bytes/char | No fixed per-string limit; bounded by NetworkCallable event payload (16 KB/event max, ~18 KB/s throughput). Events >1024 bytes are split into multiple internal packets. Independent of `[UdonSynced]` sync mode budgets. |
 | `Vector2/3/4` | 8/12/16 bytes | |
 | `Quaternion` | 16 bytes | |
 | `Color`, `Color32` | 16/4 bytes | |

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -73,7 +73,7 @@ Explicit synchronization via `RequestSerialization()` calls.
 
 **Characteristics:**
 - Only syncs when `RequestSerialization()` is called
-- Data limit: **65KB -> 280KB** (see release notes for details)
+- Data limit: **280,496 bytes (~280KB)** per serialization (increased from 65,024 bytes in an earlier release)
 - Best for: Game state, scores, settings, infrequent updates
 
 ```csharp
@@ -144,7 +144,7 @@ public class NoSyncExample : UdonSharpBehaviour
 | Mode | Data size | Frequency | Use case |
 |--------|-------------|------|-------------|
 | Continuous | ~200 bytes | High (10Hz) | Position/rotation tracking |
-| Manual | 280KB | On-demand | Game state, scores, settings |
+| Manual | ~280KB (280,496 bytes) | On-demand | Game state, scores, settings |
 | None | N/A | N/A | Event-only communication |
 
 ## VRC_ObjectSync Warning
@@ -591,7 +591,7 @@ Use the `[UdonSynced]` attribute to synchronize fields:
 [UdonSynced] private float health;
 [UdonSynced] private bool isActive;
 [UdonSynced] private Vector3 position;
-[UdonSynced] private string playerName; // Max ~50 characters!
+[UdonSynced] private string playerName; // 2 bytes/char; keep short in Continuous mode (~200 byte shared budget)
 ```
 
 ### Sync Modes
@@ -805,7 +805,7 @@ Only types syncable with `[UdonSynced]` can be used as parameters:
 | `long`, `ulong` | 8 bytes | |
 | `float` | 4 bytes | |
 | `double` | 8 bytes | |
-| `string` | variable | ~50 char limit |
+| `string` | 2 bytes/char | No fixed limit; bounded by sync mode budget (Continuous: shared ~200 bytes; Manual: ~280KB) |
 | `Vector2/3/4` | 8/12/16 bytes | |
 | `Quaternion` | 16 bytes | |
 | `Color`, `Color32` | 16/4 bytes | |
@@ -957,8 +957,8 @@ public void CheckMessage()
 ### String Length
 
 Synced strings have no fixed character limit. The practical limit depends on sync buffer size and UTF-16 encoding (2 bytes per character):
-- **Continuous**: ~200 bytes per serialization
-- **Manual**: ~280KB per serialization
+- **Continuous**: ~200 bytes per serialization (shared across all synced fields on the behaviour)
+- **Manual**: 280,496 bytes (~280KB) per serialization
 
 ```csharp
 // Keep synced strings short to conserve sync buffer

--- a/skills/unity-vrc-udon-sharp/references/patterns-performance.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-performance.md
@@ -826,7 +826,7 @@ private void ReplayFromScratch()
 
 **Cross-reference:** The `UndoableGameManager.cs` template uses **full-state snapshots** rather than operation logs — each move saves the complete `currentState` array via `System.Array.Copy`. Use snapshots when state is small and replay is expensive; use the operation-log approach when state is large but individual operations are compact. See [assets/templates/UndoableGameManager.cs](../assets/templates/UndoableGameManager.cs).
 
-> **Note:** The operation-log snippet above is a fragment showing the data layout and replay loop. In a full implementation, wrap it in an `UdonSharpBehaviour` class with `[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]` and add an initialized array (e.g., `private byte[] _opLog = new byte[4000];` for up to 1000 four-byte operations — 4 KB, well within the ~282 KB Manual sync limit).
+> **Note:** The operation-log snippet above is a fragment showing the data layout and replay loop. In a full implementation, wrap it in an `UdonSharpBehaviour` class with `[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]` and add an initialized array (e.g., `private byte[] _opLog = new byte[4000];` for up to 1000 four-byte operations — 4 KB, well within the ~280KB (280,496 bytes) Manual sync limit).
 
 #### Reset vs Cancel
 
@@ -863,7 +863,7 @@ public void ResetToInitial()
 | Keep authoritative data in synced arrays, derived state in local references | Late joiners receive authoritative data via `OnDeserialization` and rebuild locally |
 | One rebuild entry point (`BeginFullRebuild`) for all triggers | Reset, undo, late-joiner sync, and error recovery all use the same path — fewer edge cases |
 | Do not mix rebuild progress with sync serialization | If `RequestSerialization` fires mid-rebuild, the partial derived state is irrelevant — only authoritative data is transmitted |
-| Cap operation logs with a maximum size | `byte[]` sync has a ~282 KB Manual sync limit; a 4-byte-per-op log with 1000 ops = 4 KB — well within budget |
+| Cap operation logs with a maximum size | `byte[]` sync has a ~280KB (280,496 bytes) Manual sync limit; a 4-byte-per-op log with 1000 ops = 4 KB — well within budget |
 | Use cancel for user-initiated abort, reset for state revert | Cancel preserves partial visual progress; reset guarantees a clean starting state |
 
 ---

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -40,7 +40,7 @@ Does another player need to see this value?
 | Layer | Scope | Lifetime | Capacity | Typical use |
 |-------|-------|----------|----------|-------------|
 | **Non-synced field** | Self only | Until scene reload | Unlimited | UI state, timers, cooldown flags |
-| **[UdonSynced]** | All players in instance | Instance lifetime (late joiners receive current value) | ~200 B continuous / ~282 KB manual per behaviour | Shared game state, scores, toggles |
+| **[UdonSynced]** | All players in instance | Instance lifetime (late joiners receive current value) | ~200 B continuous / ~280KB (280,496 bytes) manual per behaviour | Shared game state, scores, toggles |
 | **SendCustomNetworkEvent** | All players in instance | Instant (no persistence, late joiners miss it) | Event name only (no payload) | Sound effects, particle triggers, one-shot notifications |
 | **PlayerData** | Per player, readable by all | Cross-session (permanent until deleted) | 100 KB per player per world | Settings, unlocks, high scores |
 | **PlayerObject** | Per player, synced behaviour | Instance lifetime (+ cross-session if `VRCEnablePersistence` is on) | One UdonBehaviour per player | Complex per-player state with frequent updates |

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -36,10 +36,9 @@ UdonSharpException: UdonSharp does not currently support [feature]
 | Generics `List<T>` | Arrays `T[]` or `DataList` |
 | LINQ | Manual loops |
 | `dynamic` | Explicit types |
-| `ref`/`out` parameters | Return values or class fields |
 | Multi-dimensional arrays `T[,]` | Jagged arrays `T[][]` |
 | Delegates / Events | `SendCustomEvent()` |
-| `nameof()` on external types | String literals |
+| `nameof()` on types from blocked namespaces (e.g., `System.Net.HttpWebRequest`) | String literals (`"HttpWebRequest"`); `nameof()` works normally for UdonSharp-compatible types and method/property names |
 | `try/catch/finally` | Validate inputs, null checks |
 
 **Solution:**

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -170,7 +170,7 @@ Do NOT assume the auto-generator is already installed. The agent cannot verify i
 Types that can be used with `[UdonSynced]`:
 
 `bool`, `byte`, `sbyte`, `char`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`,
-`float`, `double`, `string` (~50 character limit), `Vector2`, `Vector3`, `Vector4`,
+`float`, `double`, `string` (2 bytes/char; bounded by sync mode budget — keep short in Continuous), `Vector2`, `Vector3`, `Vector4`,
 `Quaternion`, `Color`, `Color32`, `T[]` (arrays of the above types)
 
 ## Validation Checklist

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -62,7 +62,7 @@ Manual sync procedure: Acquire ownership -> Update synced variables -> `RequestS
 
 Synced `string` fields are encoded at 2 bytes/char. There is no separate per-string character limit; the practical limit depends on the sync mode's serialization budget:
 
-- **Continuous**: strings share the ~200 byte budget with all other synced fields on the behaviour. Keep synced strings short (a single short word or short code), as even a 20-character string consumes 40 bytes.
+- **Continuous**: strings share the ~200-byte budget with all other synced fields on the behaviour. Keep synced strings short (a single short word or short code), as even a 20-character string consumes 40 bytes.
 - **Manual**: strings can be much larger within the ~280KB (280,496 byte) per-serialization limit.
 
 For longer data in Continuous mode, consider splitting across multiple fields or switching to Manual sync.
@@ -200,7 +200,7 @@ public override void OnDeserialization()
 
 - [ ] Ownership verified/acquired before modifying synced variables
 - [ ] `RequestSerialization()` called for Manual sync
-- [ ] Synced strings in Continuous sync are kept short (respect the ~200 byte shared budget; 2 bytes/char)
+- [ ] Synced strings in Continuous sync are kept short (respect the ~200-byte shared budget; 2 bytes/char)
 - [ ] VRCPlayerApi validity checked
 - [ ] Works correctly for late joiners
 - [ ] NetworkCallable rate limits considered

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -25,7 +25,7 @@ RequestSerialization();
 |------|----------------|-----------------|------------|
 | **NoVariableSync** | `BehaviourSyncMode.NoVariableSync` | No variable sync, events only | - |
 | **Continuous** | `BehaviourSyncMode.Continuous` | Automatic sync ~10Hz | ~200 bytes |
-| **Manual** | `BehaviourSyncMode.Manual` | Explicit sync via `RequestSerialization()` | ~282KB |
+| **Manual** | `BehaviourSyncMode.Manual` | Explicit sync via `RequestSerialization()` | ~280KB (280,496 bytes) |
 
 ### Continuous
 
@@ -60,8 +60,12 @@ Manual sync procedure: Acquire ownership -> Update synced variables -> `RequestS
 
 ## String Sync Limitations
 
-- Maximum length for synced strings: **~50 characters**
-- For longer data, consider splitting into chunks or using alternative approaches
+Synced `string` fields are encoded at 2 bytes/char. There is no separate per-string character limit; the practical limit depends on the sync mode's serialization budget:
+
+- **Continuous**: strings share the ~200 byte budget with all other synced fields on the behaviour. Keep synced strings short (a single short word or short code), as even a 20-character string consumes 40 bytes.
+- **Manual**: strings can be much larger within the ~280KB (280,496 byte) per-serialization limit.
+
+For longer data in Continuous mode, consider splitting across multiple fields or switching to Manual sync.
 
 ## NetworkCallable (SDK 3.8.1+)
 
@@ -196,7 +200,7 @@ public override void OnDeserialization()
 
 - [ ] Ownership verified/acquired before modifying synced variables
 - [ ] `RequestSerialization()` called for Manual sync
-- [ ] Synced strings are within 50 characters
+- [ ] Synced strings in Continuous sync are kept short (respect the ~200 byte shared budget; 2 bytes/char)
 - [ ] VRCPlayerApi validity checked
 - [ ] Works correctly for late joiners
 - [ ] NetworkCallable rate limits considered

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md
@@ -39,7 +39,7 @@ Estimate synced data volume before generating code.
 | `float` | 4 | Decimal values |
 | `Vector3` | 12 | Position |
 | `Quaternion` | 16 | Rotation |
-| `string` | ~50B limit | Text (keep short) |
+| `string` | 2 bytes/char | Text (keep short; Continuous budget is ~200B shared) |
 
 **Target**: < 50 bytes per behaviour
 


### PR DESCRIPTION
## Summary

- Resolves 6 documented contradictions between rule files and reference files in the `unity-vrc-udon-sharp` skill.
- All changes are grounded in official VRChat documentation or UdonSharp docs; no speculative values are introduced.

Closes #135

## Changes by Contradiction

### C1: Synced string character limit (rules vs references)
The false "~50 character limit" has been replaced with accurate budget-based guidance in all files:
- `rules/udonsharp-networking.md` — replaced hard limit with Continuous/Manual budget explanation
- `rules/udonsharp-constraints.md` — updated Syncable Types inline note
- `references/networking.md` — updated comment, NetworkCallable table, and Data Limits section
- `references/constraints.md` — updated String Sync Limit subsection

**Source**: [Networking Specs & Tricks](https://creators.vrchat.com/worlds/udon/networking/network-details/) — strings are 2 bytes/char, bounded by sync mode budget (Continuous: ~200 bytes shared; Manual: 280,496 bytes).

### C2: `ref`/`out` parameters listed as unsupported in troubleshooting.md
Removed `ref`/`out` from the unsupported features table in `references/troubleshooting.md`. Official UdonSharp docs confirm these are **supported** for both extern and user-defined methods. `references/constraints.md` already correctly listed them as Supported.

**Source**: [UdonSharp docs](https://udonsharp.docs.vrchat.com/) — "User defined methods with parameters and return values, supports out/ref, extension methods, and params"

### C3: `T[,]` multi-dimensional arrays listed as supported in constraints.md
Changed the `T[,]` row in `references/constraints.md` from `Supported` to `Blocked` with jagged arrays `T[][]` as the alternative. Aligns with `references/troubleshooting.md` which already listed `T[,]` as unsupported.

**Source**: [UdonSharp docs](https://udonsharp.docs.vrchat.com/) — "Udon currently only supports array [] collections"

### C4: Duplicate "Known Limitations and Caveats" section in constraints.md
Deleted the second (lines 518–596) of two identically-named sections. Confirmed no unique information was present in the removed section; all content was already covered earlier in the file.

### C5: Manual sync data limit inconsistency
Unified to **280,496 bytes (~280KB)** across all files. Previous values were `~282KB` (rules) and `65KB -> 280KB` (references).

**Source**: [Networking Specs & Tricks](https://creators.vrchat.com/worlds/udon/networking/network-details/) — exact value: 280,496 bytes (increased from 65,024 bytes).

### C6: `nameof()` troubleshooting entry was too broad
Narrowed the entry from "`nameof()` on external types" to "`nameof()` on types from blocked namespaces (e.g., `System.Net.HttpWebRequest`)". Added a note that `nameof()` works normally for UdonSharp-compatible types and method/property names to prevent agents from avoiding `nameof()` entirely.

## Test plan

- [ ] Verify all changed file paths exist and are syntactically valid Markdown
- [ ] Confirm no remaining `~50 char` or `~282KB` values exist in the skill files
- [ ] Confirm `T[,]` is marked Blocked in `references/constraints.md`
- [ ] Confirm `ref`/`out` is absent from `troubleshooting.md` unsupported table
- [ ] Confirm the duplicate "Known Limitations and Caveats" section is removed from `references/constraints.md`
- [ ] Confirm `nameof()` entry in `troubleshooting.md` is scoped to blocked-namespace types only