### PR TITLE
feat(world-sdk): add VRC_Pickup/Station templates and Quest optimization guidance

### DIFF
--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -381,6 +381,15 @@ WebSearch:
 
 ---
 
+## Templates (`assets/templates/`)
+
+Starter templates for common SDK component patterns. Each template compiles without modification; adjust Inspector fields and extend the event stubs for your world.
+
+| Template | Purpose |
+|---|---|
+| `VRC_Pickup_Rigidbody.cs` | VRC_Pickup with Rigidbody — OnPickup/OnDrop/OnPickupUseDown/OnPickupUseUp events, ownership transfer, audio feedback |
+| `VRC_Station_Basic.cs` | VRC_Station controller — OnStationEntered/OnStationExited events, PlayerMobility, force-eject API |
+
 ## References
 
 | File                            | Content                   | Approx. Lines |

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
@@ -1,0 +1,179 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.Udon; // Kept for consistency with other UdonSharp templates; not directly referenced here.
+
+/// <summary>
+/// Template for a UdonSharpBehaviour attached to a GameObject with VRC_Pickup and Rigidbody.
+///
+/// Requirements:
+///   - This GameObject MUST have a Rigidbody component (VRC_Pickup will not work without it).
+///   - This GameObject MUST have a Collider component (required for Interact detection).
+///   - Add VRC_ObjectSync if you want position/physics to sync automatically across players.
+///     Without VRC_ObjectSync, picking up the object also transfers ownership but does NOT
+///     sync physics — add [UdonSynced] variables and call RequestSerialization() in OnPickup
+///     for custom sync behaviour (BehaviourSyncMode.Manual is already set for this).
+///
+/// Sync mode note:
+///   BehaviourSyncMode.Manual is used so that synced variables (if you add any) are
+///   serialised on demand via RequestSerialization. If you add VRC_ObjectSync and have
+///   no UdonSynced variables, you can safely switch to BehaviourSyncMode.None instead.
+///
+/// Ownership note:
+///   Picking up a VRC_Pickup with VRC_ObjectSync automatically transfers ownership to the
+///   grabbing player; Networking.SetOwner is called here only as an explicit example for
+///   cases where ownership must be transferred before the pickup event (e.g. without ObjectSync).
+///
+/// Usage:
+///   1. Add this script, VRC_Pickup, Rigidbody, Collider, and (optionally) VRC_ObjectSync
+///      to the same GameObject.
+///   2. Assign optional audio sources in the Inspector.
+///   3. Override OnPickupUseDown / OnPickupUseUp to implement custom use behaviour.
+/// </summary>
+[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+public class VRC_Pickup_Rigidbody : UdonSharpBehaviour
+{
+    [Header("Audio Feedback")]
+    [Tooltip("Audio source used for pickup and drop sounds")]
+    public AudioSource audioSource;
+
+    [Tooltip("Sound played when the object is picked up")]
+    public AudioClip pickupSound;
+
+    [Tooltip("Sound played when the object is dropped")]
+    public AudioClip dropSound;
+
+    [Tooltip("Sound played when the Use button is pressed while holding")]
+    public AudioClip useSound;
+
+    [Header("Debug")]
+    [Tooltip("Enable debug logging to the Unity console")]
+    public bool debugMode = false;
+
+    // Cached VRC_Pickup component — retrieved once in Start() to avoid repeated GetComponent calls.
+    private VRC_Pickup _pickup;
+
+    // [UdonSynced] private bool _isSynced; // Add UdonSynced fields here if needed, then call RequestSerialization() after changing them.
+
+    // -------------------------------------------------------------------------
+    // Unity lifecycle
+    // -------------------------------------------------------------------------
+
+    private void Start()
+    {
+        _pickup = (VRC_Pickup)GetComponent(typeof(VRC_Pickup));
+    }
+
+    // -------------------------------------------------------------------------
+    // VRC_Pickup events
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Called on the local player when they pick up this object.
+    /// At this point the local player has already become the owner
+    /// (VRC_Pickup transfers ownership automatically on grab).
+    /// </summary>
+    public override void OnPickup()
+    {
+        // Explicit ownership transfer — required when VRC_ObjectSync is NOT present
+        // and you manage synced variables manually. Safe to leave in even with ObjectSync.
+        if (!Networking.IsOwner(gameObject))
+        {
+            Networking.SetOwner(Networking.LocalPlayer, gameObject);
+        }
+
+        PlaySound(pickupSound);
+        LogDebug("OnPickup: picked up by " + GetLocalPlayerName());
+    }
+
+    /// <summary>
+    /// Called on the local player when they drop this object.
+    /// Ownership is NOT automatically transferred away on drop — the last holder
+    /// remains owner until another player picks it up.
+    /// </summary>
+    public override void OnDrop()
+    {
+        PlaySound(dropSound);
+        LogDebug("OnDrop: dropped by " + GetLocalPlayerName());
+    }
+
+    /// <summary>
+    /// Called when the local player presses the Use button while holding this object.
+    /// On desktop this is the left mouse button; in VR this is the trigger.
+    /// NOTE: VRC_Pickup.AutoHold must be set to "Yes" for this event to fire on desktop.
+    /// </summary>
+    public override void OnPickupUseDown()
+    {
+        PlaySound(useSound);
+        LogDebug("OnPickupUseDown");
+
+        // Add your Use-button logic here.
+        // To broadcast an effect to all players, use SendCustomNetworkEvent:
+        //   SendCustomNetworkEvent(VRC.Udon.Common.Interfaces.NetworkEventTarget.All, "OnUsed");
+        //   (Replace "OnUsed" with the actual name of your public networked method.)
+    }
+
+    /// <summary>
+    /// Called when the local player releases the Use button while holding this object.
+    /// NOTE: VRC_Pickup.AutoHold must be set to "Yes" for this event to fire on desktop.
+    /// </summary>
+    public override void OnPickupUseUp()
+    {
+        LogDebug("OnPickupUseUp");
+
+        // Add your Use-button release logic here.
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Forcibly drops the pickup from the local player's hand.
+    /// Has no effect if this player is not currently holding the object.
+    /// </summary>
+    public void ForceDropPickup()
+    {
+        if (_pickup != null)
+        {
+            _pickup.Drop();
+            LogDebug("ForceDropPickup called");
+        }
+    }
+
+    /// <summary>
+    /// Returns whether the local player is currently holding this pickup.
+    /// </summary>
+    public bool IsHeld()
+    {
+        if (_pickup == null) return false;
+        return _pickup.IsHeld;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void PlaySound(AudioClip clip)
+    {
+        if (audioSource != null && clip != null)
+        {
+            audioSource.PlayOneShot(clip);
+        }
+    }
+
+    private string GetLocalPlayerName()
+    {
+        VRCPlayerApi localPlayer = Networking.LocalPlayer;
+        if (localPlayer == null || !localPlayer.IsValid()) return "Unknown";
+        return localPlayer.displayName;
+    }
+
+    private void LogDebug(string message)
+    {
+        if (debugMode)
+        {
+            Debug.Log("[VRC_Pickup_Rigidbody:" + gameObject.name + "] " + message);
+        }
+    }
+}

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
@@ -10,9 +10,10 @@ using VRC.Udon; // Kept for consistency with other UdonSharp templates; not dire
 ///   - This GameObject MUST have a Rigidbody component (VRC_Pickup will not work without it).
 ///   - This GameObject MUST have a Collider component (required for Interact detection).
 ///   - Add VRC_ObjectSync if you want position/physics to sync automatically across players.
-///     Without VRC_ObjectSync, picking up the object also transfers ownership but does NOT
-///     sync physics — add [UdonSynced] variables and call RequestSerialization() in OnPickup
-///     for custom sync behaviour (BehaviourSyncMode.Manual is already set for this).
+///     Without VRC_ObjectSync, ownership is NOT transferred automatically on pickup — you must
+///     call Networking.SetOwner() explicitly (done in OnPickup below). Add [UdonSynced] variables
+///     and call RequestSerialization() in OnPickup for custom sync behaviour
+///     (BehaviourSyncMode.Manual is already set for this).
 ///
 /// Sync mode note:
 ///   BehaviourSyncMode.Manual is used so that synced variables (if you add any) are
@@ -20,9 +21,9 @@ using VRC.Udon; // Kept for consistency with other UdonSharp templates; not dire
 ///   no UdonSynced variables, you can safely switch to BehaviourSyncMode.None instead.
 ///
 /// Ownership note:
-///   Picking up a VRC_Pickup with VRC_ObjectSync automatically transfers ownership to the
-///   grabbing player; Networking.SetOwner is called here only as an explicit example for
-///   cases where ownership must be transferred before the pickup event (e.g. without ObjectSync).
+///   VRC_ObjectSync automatically transfers ownership to the grabbing player on pickup.
+///   Without VRC_ObjectSync, ownership is NOT transferred automatically — Networking.SetOwner
+///   is called in OnPickup to handle this case explicitly.
 ///
 /// Usage:
 ///   1. Add this script, VRC_Pickup, Rigidbody, Collider, and (optionally) VRC_ObjectSync
@@ -70,13 +71,14 @@ public class VRC_Pickup_Rigidbody : UdonSharpBehaviour
 
     /// <summary>
     /// Called on the local player when they pick up this object.
-    /// At this point the local player has already become the owner
-    /// (VRC_Pickup transfers ownership automatically on grab).
+    /// If VRC_ObjectSync is present, ownership has already been transferred automatically.
+    /// If VRC_ObjectSync is absent, the SetOwner call below performs the transfer explicitly.
     /// </summary>
     public override void OnPickup()
     {
-        // Explicit ownership transfer — required when VRC_ObjectSync is NOT present
-        // and you manage synced variables manually. Safe to leave in even with ObjectSync.
+        // Explicit ownership transfer — required when VRC_ObjectSync is NOT present,
+        // because VRC_Pickup alone does NOT auto-transfer ownership on grab.
+        // Safe to leave in even when ObjectSync is present (the condition makes it a no-op).
         if (!Networking.IsOwner(gameObject))
         {
             Networking.SetOwner(Networking.LocalPlayer, gameObject);

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs
@@ -1,0 +1,203 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.Udon;
+
+/// <summary>
+/// Template for controlling a VRC_Station component from UdonSharp.
+///
+/// Requirements:
+///   - This GameObject MUST have a Collider (required for Interact to fire).
+///   - Add a VRC_Station component to the same or a child GameObject.
+///
+/// Station behaviour notes:
+///   - OnStationEntered and OnStationExited fire on ALL clients for any player
+///     who enters or exits the station.
+///   - Disable Station Exit prevents the default exit gesture; you must call
+///     station.ExitStation(player) manually from Udon to release the player.
+///   - ImmobilizeForVehicle: Use this mobility mode when the station is on a
+///     moving platform (e.g. vehicle). The player view follows the station transform.
+///   - Real-time lights and post-processing are unavailable on Quest — ensure
+///     any visual effects triggered here use baked or lightweight alternatives.
+///
+/// Sync mode note:
+///   BehaviourSyncMode.None is intentional — this script has no UdonSynced
+///   variables. All state tracking (_isOccupied) is local-only; see the field
+///   comment below for late-joiner implications.
+///
+/// Usage:
+///   1. Add this script, a Collider, and VRC_Station to the same GameObject.
+///   2. Assign the stationComponent field in the Inspector.
+///   3. Optionally set PlayerMobility in the Inspector to control movement.
+///   4. Extend OnStationEntered / OnStationExited with your world logic.
+/// </summary>
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+public class VRC_Station_Basic : UdonSharpBehaviour
+{
+    [Header("Station Reference")]
+    [Tooltip("VRC_Station component to control. Must be on the same or a child GameObject.")]
+    public VRCStation stationComponent;
+
+    [Header("Mobility Settings")]
+    [Tooltip(
+        "Mobile = player can move freely.\n" +
+        "Immobilize = player is fixed at the entry point (chairs, benches).\n" +
+        "ImmobilizeForVehicle = fixed, but view follows the station (vehicles).")]
+    public VRCStation.Mobility playerMobility = VRCStation.Mobility.Immobilize;
+
+    [Header("Audio Feedback")]
+    [Tooltip("Audio source for enter and exit sounds")]
+    public AudioSource audioSource;
+
+    [Tooltip("Sound played when any player enters this station")]
+    public AudioClip enterSound;
+
+    [Tooltip("Sound played when any player exits this station")]
+    public AudioClip exitSound;
+
+    [Header("Debug")]
+    [Tooltip("Enable debug logging to the Unity console")]
+    public bool debugMode = false;
+
+    // Tracks whether a player is currently in this station (local approximation only).
+    // This value is NOT synced across the network. Late-joining players always start
+    // with _isOccupied = false and will only see the correct state after the next
+    // OnStationEntered/OnStationExited event fires.
+    // To persist occupancy state for late joiners, add:
+    //   [UdonSynced] private bool _isOccupiedSynced;
+    // and call RequestSerialization() inside OnStationEntered/OnStationExited.
+    // Switch BehaviourSyncMode to Manual when adding UdonSynced variables.
+    private bool _isOccupied = false;
+
+    // -------------------------------------------------------------------------
+    // Unity lifecycle
+    // -------------------------------------------------------------------------
+
+    private void Start()
+    {
+        // Apply the configured mobility mode to the station at startup.
+        if (stationComponent != null)
+        {
+            stationComponent.PlayerMobility = playerMobility;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // VRChat interaction (seat the local player on Interact)
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Called when the local player interacts with (clicks) this object.
+    /// Seats the local player in the station.
+    /// </summary>
+    public override void Interact()
+    {
+        if (stationComponent == null)
+        {
+            LogDebug("Interact: stationComponent is not assigned");
+            return;
+        }
+
+        VRCPlayerApi localPlayer = Networking.LocalPlayer;
+        if (localPlayer == null || !localPlayer.IsValid()) return;
+
+        stationComponent.UseStation(localPlayer);
+        LogDebug("Interact: " + localPlayer.displayName + " entering station");
+    }
+
+    // -------------------------------------------------------------------------
+    // VRC_Station events
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Called on ALL clients when any player enters this station.
+    /// Use player.isLocal to distinguish the sitting player from observers.
+    /// </summary>
+    public override void OnStationEntered(VRCPlayerApi player)
+    {
+        if (player == null || !player.IsValid()) return;
+
+        _isOccupied = true;
+        PlaySound(enterSound);
+        LogDebug("OnStationEntered: " + player.displayName + " (local=" + player.isLocal + ")");
+
+        // Add your on-enter logic here.
+        // Example: disable the Interact prompt while occupied
+        //   DisableInteractive = true;
+    }
+
+    /// <summary>
+    /// Called on ALL clients when any player exits this station.
+    /// </summary>
+    public override void OnStationExited(VRCPlayerApi player)
+    {
+        if (player == null || !player.IsValid()) return;
+
+        _isOccupied = false;
+        PlaySound(exitSound);
+        LogDebug("OnStationExited: " + player.displayName + " (local=" + player.isLocal + ")");
+
+        // Add your on-exit logic here.
+        // Example: re-enable the Interact prompt
+        //   DisableInteractive = false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Ejects the specified player from this station.
+    /// Call this to force-exit a player when Disable Station Exit is enabled.
+    /// </summary>
+    public void EjectPlayer(VRCPlayerApi player)
+    {
+        if (stationComponent == null || player == null || !player.IsValid()) return;
+        stationComponent.ExitStation(player);
+        LogDebug("EjectPlayer: ejecting " + player.displayName);
+    }
+
+    /// <summary>
+    /// Changes the mobility mode at runtime.
+    /// Must be called before the player enters for it to take effect.
+    /// </summary>
+    public void SetMobility(VRCStation.Mobility mobility)
+    {
+        playerMobility = mobility;
+        if (stationComponent != null)
+        {
+            stationComponent.PlayerMobility = mobility;
+        }
+        LogDebug("SetMobility: " + mobility.ToString());
+    }
+
+    /// <summary>
+    /// Returns whether any player is currently in this station.
+    /// This is a local approximation based on received events and may be
+    /// briefly inconsistent for late-joining players.
+    /// </summary>
+    public bool IsOccupied()
+    {
+        return _isOccupied;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void PlaySound(AudioClip clip)
+    {
+        if (audioSource != null && clip != null)
+        {
+            audioSource.PlayOneShot(clip);
+        }
+    }
+
+    private void LogDebug(string message)
+    {
+        if (debugMode)
+        {
+            Debug.Log("[VRC_Station_Basic:" + gameObject.name + "] " + message);
+        }
+    }
+}

--- a/skills/unity-vrc-world-sdk-3/references/lighting.md
+++ b/skills/unity-vrc-world-sdk-3/references/lighting.md
@@ -377,7 +377,7 @@ Vertical placement: place probes at multiple heights (floor level ~0.5 m, mid-bo
 |---|---|---|
 | Type | **Baked** | Realtime probes re-render every frame — avoid on Quest |
 | Resolution | **128** | 256 is acceptable for hero areas only |
-| HDR | Disabled | HDR reflection textures use ~50% more memory on Quest; appropriate when the scene has no metallic or glossy surfaces that require HDR reflections |
+| HDR | Disabled | Saves ~50% reflection texture memory; enable only for hero areas with highly reflective metallic or glossy surfaces that require HDR reflections |
 | Box Projection | Only when needed | Adds overdraw; use only in box-shaped rooms |
 
 Aim for one probe per enclosed room and one large probe outdoors. Avoid overlapping more than 2–3 probes in any one area.

--- a/skills/unity-vrc-world-sdk-3/references/lighting.md
+++ b/skills/unity-vrc-world-sdk-3/references/lighting.md
@@ -313,7 +313,7 @@ Bounces control how many times indirect light reflects off surfaces. More bounce
 | PC | 3–4 | Use 4 only for complex interiors with many reflective surfaces (approximate guideline — adjust based on profiling) |
 
 In Unity Lighting Settings:
-```
+```text
 Window > Rendering > Lighting > Lightmapping Settings
 └── Indirect Bounces: 2  (Quest)  /  3  (PC)
 ```
@@ -322,7 +322,7 @@ Window > Rendering > Lighting > Lightmapping Settings
 
 On Quest, **Baked lighting is strongly preferred over Mixed**. Use this decision guide:
 
-```
+```text
 Does the world have any moving lights or real-time shadows?
 ├── Yes → Is this required? (gameplay mechanic, not just aesthetics)
 │   ├── Yes → Use Mixed (PC only); remove or replace with Baked on Android build
@@ -343,7 +343,7 @@ Practical rule: **convert all Mixed lights to Baked before the Android build**. 
 
 Baked AO adds depth cues where surfaces meet, at zero runtime cost. Screen-space AO (SSAO) is unavailable on Quest.
 
-```
+```text
 Window > Rendering > Lighting > Lightmapping Settings
 
 Recommended settings for Quest:
@@ -386,7 +386,7 @@ Aim for one probe per enclosed room and one large probe outdoors. Avoid overlapp
 
 ## Lighting Workflow Summary: PC vs Quest
 
-```
+```text
 PC Build                           Quest/Android Build
 ────────────────────────────────   ──────────────────────────────────
 Resolution: 10–20 texels/unit      Resolution: 5–10 texels/unit

--- a/skills/unity-vrc-world-sdk-3/references/lighting.md
+++ b/skills/unity-vrc-world-sdk-3/references/lighting.md
@@ -285,6 +285,120 @@ Recommended shaders:
 | Reflection Probe Res | 256 | 128 |
 | Realtime Lights | 0-1 | 0 |
 
+---
+
+## Quest Bake Parameter Reference
+
+Detailed recommended parameters for baking lightmaps targeting Quest/Android. These supplement the Quick Reference table with rationale and acceptable ranges.
+
+### Lightmap Resolution: PC vs Quest
+
+| Setting | PC | Quest | Why |
+|---|---|---|---|
+| Lightmap Resolution | 10–20 texels/unit | **5–10 texels/unit** | Lower resolution keeps lightmap textures within 1024×1024 and reduces build size |
+| Max Lightmap Size | 2048×2048 | **1024×1024** | Quest GPU memory is limited; oversized lightmaps cause stuttering and load failures |
+| Directional Mode | Directional or Non-Directional | **Non-Directional (required)** | Directional mode stores an extra texture per lightmap; not worth the cost on Quest |
+| Compress Lightmaps | Optional | **Required** | Uncompressed lightmaps can exceed the 100 MB Android build limit |
+
+> If your world still looks dark or blurry at 5 texels/unit, increase to 10 before raising Max Size.
+> Raising resolution is cheaper in quality terms; raising size increases memory consumption more.
+
+### Bounce Count
+
+Bounces control how many times indirect light reflects off surfaces. More bounces improve realism but increase bake time and can add unwanted light bleed.
+
+| Platform | Recommended Bounces | Notes |
+|---|---|---|
+| Quest | **2–3** | Sufficient for enclosed interiors; 2 is often enough outdoors (approximate guideline — adjust based on profiling) |
+| PC | 3–4 | Use 4 only for complex interiors with many reflective surfaces (approximate guideline — adjust based on profiling) |
+
+In Unity Lighting Settings:
+```
+Window > Rendering > Lighting > Lightmapping Settings
+└── Indirect Bounces: 2  (Quest)  /  3  (PC)
+```
+
+### Baked vs Mixed Lighting: Quest Guidance
+
+On Quest, **Baked lighting is strongly preferred over Mixed**. Use this decision guide:
+
+```
+Does the world have any moving lights or real-time shadows?
+├── Yes → Is this required? (gameplay mechanic, not just aesthetics)
+│   ├── Yes → Use Mixed (PC only); remove or replace with Baked on Android build
+│   └── No  → Switch to Baked and use light probes for dynamics
+└── No  → Use Baked for everything
+```
+
+| Mode | Quest Support | Notes |
+|---|---|---|
+| **Baked** | Full support | Required for Quest builds; zero runtime cost |
+| **Mixed (Subtractive)** | Partial support | Shadowmask not fully supported; avoid |
+| **Mixed (Shadowmask)** | Not recommended | Extra memory, inconsistent shadow behaviour |
+| **Realtime** | Avoid | No shadow support on Quest; significant GPU cost even without shadows |
+
+Practical rule: **convert all Mixed lights to Baked before the Android build**. Use the Platform Override workflow (Unity Build Settings → Android) to maintain separate PC and Quest lighting if needed.
+
+### Baked Ambient Occlusion
+
+Baked AO adds depth cues where surfaces meet, at zero runtime cost. Screen-space AO (SSAO) is unavailable on Quest.
+
+```
+Window > Rendering > Lighting > Lightmapping Settings
+
+Recommended settings for Quest:
+├── Ambient Occlusion: ✓ Enabled
+├── Max Distance:       1.0–2.0 m  (larger = broader but softer AO)
+├── Indirect AO:        0.5–1.0
+└── Direct AO:          0 (default — direct AO can look artificial)
+
+PC can use higher Max Distance (2–3 m) for richer results.
+```
+
+> Baked AO is included in the base lightmap texture — no extra textures or memory.
+> Enable it for all Quest builds without hesitation.
+
+### Light Probe Density (Quest)
+
+Light probes provide baked lighting influence to dynamic objects (players, pickups). More probes improve quality; excessive probes increase bake time and CPU cost.
+
+| Area Type | Quest Recommended Spacing | Notes |
+|---|---|---|
+| Narrow corridors | 2–3 m intervals | Players fill most of the space |
+| Open indoor areas | 3–4 m intervals | Sufficient for smooth transitions |
+| Light/shadow boundaries | ≤ 1 m intervals | Tight clustering prevents hard edges |
+| Outdoor areas | 4–6 m intervals | Light varies slowly outdoors |
+
+Vertical placement: place probes at multiple heights (floor level ~0.5 m, mid-body ~1.5 m, head ~2 m) to capture the full player silhouette.
+
+### Reflection Probe Settings (Quest)
+
+| Setting | Quest Recommended | Notes |
+|---|---|---|
+| Type | **Baked** | Realtime probes re-render every frame — avoid on Quest |
+| Resolution | **128** | 256 is acceptable for hero areas only |
+| HDR | Disabled | HDR reflection textures use ~50% more memory on Quest; appropriate when the scene has no metallic or glossy surfaces that require HDR reflections |
+| Box Projection | Only when needed | Adds overdraw; use only in box-shaped rooms |
+
+Aim for one probe per enclosed room and one large probe outdoors. Avoid overlapping more than 2–3 probes in any one area.
+
+---
+
+## Lighting Workflow Summary: PC vs Quest
+
+```
+PC Build                           Quest/Android Build
+────────────────────────────────   ──────────────────────────────────
+Resolution: 10–20 texels/unit      Resolution: 5–10 texels/unit
+Max Size:   2048×2048              Max Size:   1024×1024
+Bounces:    3–4                    Bounces:    2–3
+Direction:  Directional (opt.)     Direction:  Non-Directional (required)
+Compress:   Optional               Compress:   Required
+AO:         Optional (baked)       AO:         Baked only (no SSAO)
+Refl. res:  256                    Refl. res:  128
+Lights:     Mixed or Baked         Lights:     Baked only
+```
+
 ## See Also
 
 - [performance.md](performance.md) - Overall performance targets and Quest optimization checklist that governs lighting budgets

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -657,6 +657,72 @@ Verify all items below before uploading a Quest-compatible world build.
 □ No crashes or memory warnings during extended play session
 ```
 
+---
+
+## World Performance Rating
+
+VRChat does **not** have a formal in-client performance ranking system for worlds (unlike avatars which display Excellent/Good/Medium/Poor badges). There is no SDK-enforced ranking threshold that blocks world uploads based on polygon count or draw calls.
+
+In practice, use the **FPS tiers** at the top of this document as the pass/fail criteria, and apply the Quest/Android hard limits below as mandatory constraints.
+
+### Official World Triangle Budget (Quest)
+
+From the official Android Content Optimization documentation:
+
+```
+Total world triangle budget (Quest/Android): ~250,000 triangles
+```
+
+> This is the official guideline figure. The 200K hard cap listed in the Mesh Optimization
+> section above is a conservative community target; 250K is the documented upper boundary.
+> Staying within 50K–100K provides the best frame rate headroom for worlds with many players.
+
+### Per-Object Polygon Guidelines (Quest)
+
+These are approximate guidelines based on community practice and the official optimization guide:
+
+| Object Category | Triangle Target | Notes |
+|---|---|---|
+| Hero / focal interactive objects | ≤ 5,000 | Pickups, NPCs, key props |
+| Background / decorative objects | ≤ 1,000 | Furniture, environmental details |
+| Ground / floor planes | Minimal subdivision | Avoid dense meshes; bake detail into textures |
+| Total scene (ideal) | 50K–100K | Leaves headroom for players and avatars |
+| Total scene (upper limit) | ~250K | Official documented budget |
+
+### Draw Call Targets (Quest)
+
+No hard SDK limit exists for draw calls, but practical performance targets are:
+
+> These are community-derived approximate guidelines, not official VRChat thresholds.
+
+| Tier | Draw Calls | Expected Result |
+|---|---|---|
+| Excellent | < 50 | Stable 72 FPS with multiple players |
+| Acceptable | 50–100 | Achievable with batching and instancing |
+| Problematic | > 100 | Frame rate drops; optimization required |
+
+Reduce draw calls with Static Batching, GPU Instancing, and texture atlasing (see Draw Call Reduction section above).
+
+### Texture Compression Format (Quest)
+
+Quest uses the Qualcomm Adreno GPU, which natively supports **ASTC** (Adaptive Scalable Texture Compression). Always override textures to ASTC for the Android platform:
+
+```
+Inspector → Texture → Android override:
+├── Format: ASTC 6x6 block  (diffuse, albedo — good quality/size balance)
+├── Format: ASTC 4x4 block  (UI, normal maps — higher quality)
+└── Format: ASTC 8x8 block  (distant/minor textures — smaller size)
+
+ETC2 is the fallback when ASTC is unavailable. Prefer ASTC for all new content.
+```
+
+### Lightmap Resolution and Size (Quest)
+
+For detailed lightmap resolution and size recommendations (texels/unit, max size, directional mode, compression, AO settings), see:
+
+- **[Baked Lighting Workflow for Quest](#baked-lighting-workflow-for-quest)** — full settings table in this file
+- **[references/lighting.md — Quest Bake Parameter Reference](lighting.md#quest-bake-parameter-reference)** — rationale, acceptable ranges, and Baked vs Mixed decision guide
+
 ## See Also
 
 - [components.md](components.md) - Component reference including Quest-incompatible components to avoid

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -413,7 +413,7 @@ In-game checks:
 Cross-platform worlds (PC + Quest) require stricter constraints on the Quest/Android build.
 These limits apply to the Android build target and are enforced at upload time or at runtime.
 
-Reference: https://creators.vrchat.com/worlds/udon/
+Reference: https://creators.vrchat.com/platforms/android/quest-content-optimization
 
 ### Hard Limits
 

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -421,7 +421,7 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 |-----------|-------|-------|
 | World build size (compressed) | 100 MB max | Aim for 5–8 MB in practice |
 | Texture resolution | 1024×1024 recommended max | Higher resolutions increase memory and load time |
-| Custom shaders | Not supported | Standard or Mobile shaders only |
+| Custom shaders | Supported with caution | Custom shaders are allowed for worlds; use mobile-compatible shaders to avoid GPU overload. Avatars are restricted to VRChat Mobile shaders. |
 | Post-processing effects | Not supported | Bloom, depth of field, color grading unavailable |
 | Real-time shadows | Not supported | Baked lighting only |
 | Video player (AVPro) | Not supported | Use Unity Video Player component instead |
@@ -430,7 +430,7 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 ### Features Not Available on Quest
 
 ```
-❌ Custom shaders (HLSL/ShaderLab beyond Mobile subset)
+⚠️ Custom shaders (worlds only: allowed with caution; avoid complex HLSL/ShaderLab features that stress the mobile GPU. Avatar shaders are restricted to VRChat Mobile shaders.)
 ❌ Post-processing stack (any effect)
 ❌ Real-time shadow casting and receiving
 ❌ AVPro video player
@@ -668,8 +668,9 @@ In practice, use the **FPS tiers** at the top of this document as the pass/fail 
 ### Official World Triangle Budget (Quest)
 
 From the official Android Content Optimization documentation:
+<https://creators.vrchat.com/platforms/android/android-content-optimization/>
 
-```
+```text
 Total world triangle budget (Quest/Android): ~250,000 triangles
 ```
 
@@ -680,6 +681,7 @@ Total world triangle budget (Quest/Android): ~250,000 triangles
 ### Per-Object Polygon Guidelines (Quest)
 
 These are approximate guidelines based on community practice and the official optimization guide:
+<https://creators.vrchat.com/platforms/android/android-content-optimization/>
 
 | Object Category | Triangle Target | Notes |
 |---|---|---|
@@ -691,7 +693,9 @@ These are approximate guidelines based on community practice and the official op
 
 ### Draw Call Targets (Quest)
 
-No hard SDK limit exists for draw calls, but practical performance targets are:
+No hard SDK limit exists for draw calls. The targets below are community-derived approximate
+guidelines, not official VRChat thresholds. Verify current recommendations against the
+official documentation: <https://creators.vrchat.com/platforms/android/android-content-optimization/>
 
 > These are community-derived approximate guidelines, not official VRChat thresholds.
 


### PR DESCRIPTION
## Summary

- Add `VRC_Pickup_Rigidbody.cs` template with pickup/drop/use events, GetComponent caching, and sync mode guidance
- Add `VRC_Station_Basic.cs` template with station enter/exit events and late-joiner sync notes
- Expand `references/performance.md` with Quest-specific polygon/draw call/texture guidelines
- Expand `references/lighting.md` with Quest bake parameters, Baked vs Mixed decision guide, and probe settings

## Changes

- `skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs` (new)
- `skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs` (new)
- `skills/unity-vrc-world-sdk-3/references/performance.md` (updated)
- `skills/unity-vrc-world-sdk-3/references/lighting.md` (updated)
- `skills/unity-vrc-world-sdk-3/SKILL.md` (updated template list)

## Test Plan

- [ ] `npm pack --dry-run` includes new template files
- [ ] Markdown links check passes
- [ ] EditorConfig check passes
- [ ] Template C# syntax is correct

Closes #137