### PR TITLE
feat(udon-sharp): add Camera Dolly API, VRCObjectPool details, and testing guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -111,7 +111,7 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（21ファイル）
+    references/                          # 詳細ドキュメント（22ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7ファイル）
 templates/                               # AIツール設定テンプレート

--- a/README.ko.md
+++ b/README.ko.md
@@ -112,7 +112,7 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (21개 파일)
+    references/                          # 상세 문서 (22개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7개 파일)
 templates/                               # AI 도구 설정 템플릿

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (21 files)
+    references/                          # Detailed documentation (22 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7 files)
 templates/                               # AI tool config templates

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,7 +112,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（21 个文件）
+    references/                          # 详细文档（22 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 个文件）
 templates/                               # AI 工具配置模板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -112,7 +112,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（21 個檔案）
+    references/                          # 詳細文件（22 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 個檔案）
 templates/                               # AI 工具設定範本

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -82,7 +82,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Using PhysBones/Contacts/Constraints | `dynamics.md`, `events.md` | `patterns-networking.md`, `api.md` | `web-loading.md`, `image-loading-vram.md`, `persistence.md` |
 | Optimizing performance (Update loops) | `patterns-performance.md` | `patterns-utilities.md`, `api.md` | `dynamics.md`, `web-loading.md`, `persistence.md` |
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
-| Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
+| Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
 ## Pattern Selection Guide
@@ -234,6 +234,7 @@ WebSearch: "error message UdonSharp site:github.com"
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |
+| `testing.md` | Testing and debugging guide: ClientSim editor testing, Build and Test (single and multi-client), Debug.Log patterns, pre-release cleanup, testing checklist | ClientSim, Build and Test, multi-client, late joiner test, debug, Debug.Log, ownership test, sync test, testing checklist |
 
 ## Templates (`assets/templates/`)
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -313,18 +313,154 @@ station.ExitStation(VRCPlayerApi player);
 
 ## VRCObjectPool
 
-Object pooling for network-aware objects.
+Object pooling for network-aware objects. The pool manages and synchronizes the active state of each held object across all players.
+
+**Class**: `VRC.SDK3.Components.VRCObjectPool`
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Pool` | `GameObject[]` | The objects managed by this pool |
 
 ### Methods
 
 ```csharp
 public VRCObjectPool pool;
 
-// Spawn (owner only)
+// Activate an unused object (pool owner only). Returns null if all objects are in use.
 GameObject spawned = pool.TryToSpawn();
 
-// Return to pool
+// Return an object to the pool (pool owner only). Deactivates the object.
 pool.Return(GameObject obj);
+```
+
+### Ownership Behavior
+
+The VRCObjectPool itself is a networked object; only its **owner** can call `TryToSpawn()` and `Return()`.
+
+- **`TryToSpawn()`** activates an available pooled object and returns it. The ownership of the activated object is **not** automatically transferred to any specific player — call `Networking.SetOwner()` explicitly after spawning if you need the spawned object to be owned by a particular player.
+- **`Return()`** deactivates the object and returns it to the pool. Only the pool owner can call this method.
+
+### Network Synchronization
+
+The pool synchronizes the active/inactive state of every held object across all players. Late joiners automatically receive the correct active or inactive state for each pooled object.
+
+### Pooled Object Contract
+
+When writing an UdonSharp behaviour that is intended to run on pooled objects, it should follow this convention so the pool can set ownership correctly:
+
+```csharp
+using UdonSharp;
+using VRC.SDKBase;
+
+public class PooledObject : UdonSharpBehaviour
+{
+    // Set by the pool manager after TryToSpawn(); null when unassigned
+    public VRCPlayerApi Owner;
+
+    // Called on all clients when the object is assigned to a new owner
+    public void _OnOwnerSet()
+    {
+        // React to ownership assignment here
+        if (Utilities.IsValid(Owner))
+        {
+            Debug.Log($"Object assigned to: {Owner.displayName}");
+        }
+    }
+
+    void OnEnable()
+    {
+        // OnEnable fires before Start() when the pool activates this object.
+        // Use this instead of the deprecated OnSpawn event.
+    }
+
+    void OnDisable()
+    {
+        // Fired when Return() deactivates this object.
+        Owner = null;
+    }
+}
+```
+
+> **Note**: `OnSpawn` is **deprecated**. Use `OnEnable` to react to an object being activated by the pool.
+
+### Usage Pattern: Master-Managed Pool
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Components;
+using VRC.SDKBase;
+using VRC.Udon.Common.Interfaces;
+
+[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+public class PoolManager : UdonSharpBehaviour
+{
+    public VRCObjectPool objectPool;
+
+    public override void OnPlayerJoined(VRCPlayerApi player)
+    {
+        // Only the pool owner (e.g. master) calls TryToSpawn
+        if (!Networking.IsOwner(objectPool.gameObject)) return;
+
+        GameObject spawned = objectPool.TryToSpawn();
+        if (spawned == null)
+        {
+            Debug.LogWarning("No objects available in pool");
+            return;
+        }
+
+        // Transfer ownership of the spawned object to the joining player
+        Networking.SetOwner(player, spawned);
+
+        PooledObject pooledBehaviour = (PooledObject)spawned.GetComponent(typeof(PooledObject));
+        if (Utilities.IsValid(pooledBehaviour))
+        {
+            pooledBehaviour.Owner = player;
+            pooledBehaviour.SendCustomNetworkEvent(NetworkEventTarget.All, "_OnOwnerSet");
+        }
+    }
+
+    public override void OnPlayerLeft(VRCPlayerApi player)
+    {
+        if (!Networking.IsOwner(objectPool.gameObject)) return;
+
+        // Find and return the object assigned to the leaving player
+        foreach (GameObject obj in objectPool.Pool)
+        {
+            if (!obj.activeInHierarchy) continue;
+
+            PooledObject pooledBehaviour = (PooledObject)obj.GetComponent(typeof(PooledObject));
+            if (Utilities.IsValid(pooledBehaviour) && pooledBehaviour.Owner == player)
+            {
+                objectPool.Return(obj);
+                break;
+            }
+        }
+    }
+}
+```
+
+### VRCObjectPool vs VRCInstantiate
+
+| | VRCObjectPool | VRCInstantiate |
+|---|---|---|
+| **Sync** | Network-synchronized across all players | Local only — not synced |
+| **Ownership** | Managed by pool owner; spawned object ownership must be set manually | No ownership concept |
+| **Late joiners** | Receive correct state automatically | Miss any previously instantiated objects |
+| **Object reuse** | Pre-allocated pool; `Return()` makes objects available again | Objects persist until destroyed |
+| **Use when** | Spawning networked bullets, per-player data containers, shared world objects | Local particle effects, client-side previews, non-networked decorations |
+
+#### Decision Flow
+
+```text
+Does every player need to see the spawned object?
+├── No  --> VRCInstantiate (local, no sync overhead)
+└── Yes --> VRCObjectPool (synchronized, ownership-aware)
+         Does the object need to be reused frequently?
+         ├── Yes --> VRCObjectPool (pooling avoids repeated allocation)
+         └── No  --> VRCObjectPool still preferred over VRCInstantiate for synced objects
 ```
 
 ## VRCObjectSync
@@ -867,6 +1003,108 @@ public class DroneCheckpoint : UdonSharpBehaviour
     }
 }
 ```
+
+## VRC Camera Dolly API (SDK 3.9.0+)
+
+Defines camera dolly animations applied to the local player's VRChat user camera.
+Three components work together in a fixed parent-child hierarchy.
+
+**Available since**: SDK 3.9.0
+
+> **No ClientSim preview**: Camera dolly animations do not render in ClientSim.
+> Use **Build and Test** to preview animations at runtime.
+
+### Component Hierarchy
+
+```
+GameObject (VRC Camera Dolly Animation)
+├── GameObject (VRC Camera Dolly Path)
+│   ├── GameObject (VRC Camera Dolly Point)
+│   └── GameObject (VRC Camera Dolly Point)
+└── GameObject (VRC Camera Dolly Path)
+    ├── GameObject (VRC Camera Dolly Point)
+    ├── GameObject (VRC Camera Dolly Point)
+    └── GameObject (VRC Camera Dolly Point)
+```
+
+### VRC Camera Dolly Animation — Inspector Parameters
+
+Configure these in the Unity Inspector on the top-level `VRC Camera Dolly Animation` component:
+
+| Parameter | Description |
+|-----------|-------------|
+| `Is Relative To Player` | Anchor animation to the local player's position instead of world origin |
+| `Is Speed Based` | Use speed values per point rather than fixed durations |
+| `Is Using Look At Me` | Enable Look-At-Me horizontal/vertical offsets on points |
+| `Is Using Greenscreen` | Enable Green Screen HSL controls on points |
+| `Is Using Multi Stream` | Enable multi-stream animation mode |
+| `Path Type` | Interpolation method for the path (linear, smooth, etc.) |
+| `Loop Type` | How the animation loops (none, loop, ping-pong) |
+| `Capture Type` | Capture methodology for the animation |
+| `Focus Mode` | Camera focus mode for this animation |
+| `Anchor Mode` | Camera anchor mode for this animation |
+| `Paths` | List of `VRC Camera Dolly Path` children; populate via **Collect Paths & Points** |
+
+### VRC Camera Dolly Path — Inspector Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `Points` | List of `VRC Camera Dolly Point` children; populated via **Collect Paths & Points** |
+
+### VRC Camera Dolly Point — Inspector Parameters (Keyframe)
+
+| Parameter | Description |
+|-----------|-------------|
+| `Zoom` | Keyframe zoom value |
+| `Duration` | Duration for this keyframe (time-based mode only) |
+| `Speed` | Speed for this keyframe (speed-based mode only) |
+| `Focal Distance` | Focal distance (manual focus mode) |
+| `Aperture` | Aperture value (manual or semi-auto focus mode) |
+| `Hue` | Greenscreen hue (greenscreen mode) |
+| `Saturation` | Greenscreen saturation (greenscreen mode) |
+| `Lightness` | Greenscreen lightness (greenscreen mode) |
+| `Look At Me X Offset` | Horizontal Look-At-Me offset (Look-At-Me mode) |
+| `Look At Me Y Offset` | Vertical Look-At-Me offset (Look-At-Me mode) |
+
+### UdonSharp API
+
+The scripting surface for Camera Dolly is intentionally minimal. The primary method is:
+
+```csharp
+// Apply the animation to the local player's VRChat user camera
+dollyAnimation.Import();
+```
+
+`Import()` reads all paths and points collected on the `VRC Camera Dolly Animation` component and applies the resulting animation to the camera of the **local client** only. It has no return value.
+
+### Setup and Usage
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+
+public class DollyController : UdonSharpBehaviour
+{
+    // Drag the GameObject that holds VRC Camera Dolly Animation into this field
+    [SerializeField] private VRCCameraDollyAnimation dollyAnimation;
+
+    // Call this to start the camera dolly animation for the local player
+    public void PlayDolly()
+    {
+        if (!Utilities.IsValid(dollyAnimation)) return;
+        dollyAnimation.Import();
+    }
+}
+```
+
+> **Important**: Before entering Play mode or building, select the top-level `VRC Camera Dolly Animation` object and click **Collect Paths & Points** to register all child paths and points. Any time you add, remove, or re-order children, repeat this step.
+
+### Limitations
+
+- The API applies the animation to the **local player only**. To trigger it for all players, use `SendCustomNetworkEvent(NetworkEventTarget.All, nameof(PlayDolly))`.
+- No properties of the animation, paths, or points are readable or writable from UdonSharp at runtime.
+- There is no event callback when the animation completes.
+- No ClientSim preview; Build and Test is required to see the animation.
 
 ## See Also
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -1016,7 +1016,7 @@ Three components work together in a fixed parent-child hierarchy.
 
 ### Component Hierarchy
 
-```
+```text
 GameObject (VRC Camera Dolly Animation)
 ├── GameObject (VRC Camera Dolly Path)
 │   ├── GameObject (VRC Camera Dolly Point)

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -360,7 +360,7 @@ public class PooledObject : UdonSharpBehaviour
     public VRCPlayerApi Owner;
 
     // Called on all clients when the object is assigned to a new owner
-    public void _OnOwnerSet()
+    public void OnOwnerSet()
     {
         // React to ownership assignment here
         if (Utilities.IsValid(Owner))
@@ -418,7 +418,7 @@ public class PoolManager : UdonSharpBehaviour
         if (Utilities.IsValid(pooledBehaviour))
         {
             pooledBehaviour.Owner = player;
-            pooledBehaviour.SendCustomNetworkEvent(NetworkEventTarget.All, "_OnOwnerSet");
+            pooledBehaviour.SendCustomNetworkEvent(NetworkEventTarget.All, nameof(PooledObject.OnOwnerSet));
         }
     }
 

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -1,0 +1,256 @@
+# UdonSharp Testing and Debugging Guide
+
+Practical guide for testing and debugging UdonSharp worlds in VRChat.
+
+**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+
+## Table of Contents
+
+- [ClientSim — Editor Testing](#clientsim--editor-testing)
+- [Build and Test — Runtime Testing](#build-and-test--runtime-testing)
+- [Multi-Client Testing](#multi-client-testing)
+- [Debug.Log Usage](#debuglog-usage)
+- [Testing Checklist](#testing-checklist)
+
+---
+
+## ClientSim — Editor Testing
+
+ClientSim (Client Simulator) replicates VRChat client behavior in the Unity Editor without requiring a live VRChat build. It is included in the VRChat Worlds SDK — no separate installation is needed.
+
+### Starting a ClientSim Session
+
+1. Open your world scene in the Unity Editor.
+2. Press **Play** in the Editor.
+
+ClientSim starts automatically. Use **Mouse + Keyboard** or a **Gamepad** to control the local player.
+
+### Disabling ClientSim
+
+Open **VRChat SDK > ClientSim Settings** and uncheck **Enable ClientSim**.
+
+### What ClientSim Simulates
+
+- Local player movement, pickups, interactions, UI, and station usage
+- Udon variable inspection during Play Mode
+- `OnDeserialization` events for the local player
+- `OnPlayerRestored` when spawning simulated remote players
+- Basic server-time simulation
+
+### What ClientSim Does NOT Simulate
+
+| Not Simulated | Why This Matters |
+|---|---|
+| Remote players (only local player) | Ownership transfers, `OnPlayerJoined`/`OnPlayerLeft` are not realistic |
+| Full networking serialization | `OnPostSerialization` and `OnDeserialization` data structures differ from live VRChat |
+| Network congestion (`Networking.IsClogged`) | Rate limiting and congestion behavior cannot be tested |
+| Multi-user sync conflicts | Race conditions and ownership fights are invisible |
+| Camera dolly animations | Camera dolly has no ClientSim preview support |
+
+> **Critical**: Always test your world in VRChat before publishing. ClientSim catches logic bugs but cannot validate networking behavior.
+
+---
+
+## Build and Test — Runtime Testing
+
+Build and Test launches your world in actual VRChat clients from the Unity Editor, giving full runtime fidelity.
+
+### Prerequisites
+
+1. Sign in via **VRChat SDK > Show Control Panel > Authentication**.
+2. In **VRChat SDK > Show Control Panel > Settings**, specify your VRChat installation path.
+3. In the **Builder** tab, click **Setup Layers for VRChat** and apply the collision matrix.
+
+### Single-Client Build and Test
+
+1. In the **Builder** tab, set **Number of Clients** to `1`.
+2. Click **Build & Test**.
+
+VRChat launches with your world loaded. The local client is the **instance master** and owns all GameObjects by default.
+
+### Build and Reload
+
+Set **Number of Clients** to `0`. This rebuilds the world and moves the already-running client into the new instance — significantly faster for iteration since no login sequence is required.
+
+---
+
+## Multi-Client Testing
+
+Networking bugs (ownership, sync, late joiners) require multiple clients. Build and Test supports this natively.
+
+### Setup
+
+1. Set **Number of Clients** to `2` or higher.
+2. Click **Build & Test**.
+
+Unity launches the specified number of VRChat clients simultaneously. Switch between windows to control each client independently.
+
+### Client Roles
+
+- **First client to load** → instance master and default object owner
+- **Subsequent clients** → non-master; cannot modify objects they do not own
+
+### What to Test with Multiple Clients
+
+| Scenario | What to Verify |
+|---|---|
+| **Ownership transfer** | Call `Networking.SetOwner()` on client A; verify client B sees the update |
+| **Synced variable propagation** | Modify a `[UdonSynced]` field and call `RequestSerialization()`; verify all clients reflect the new value |
+| **NetworkCallable events** | Trigger a `[NetworkCallable]` method from one client; verify it fires on all clients |
+| **SendCustomNetworkEvent** | Send `NetworkEventTarget.All` event; verify it fires on each client |
+| **Late joiner state** | Connect a third client after state has changed; verify the new client receives the current state via `OnDeserialization` |
+| **Master handoff** | Close the master client; verify non-master clients elect a new master and ownership cascades correctly |
+| **Pool behavior** | Call `TryToSpawn()` on the pool owner client; verify spawned objects appear on all clients |
+
+### Late Joiner Testing Procedure
+
+1. Start with 2 clients and modify world state (e.g., toggle a synced bool, change a score).
+2. Without resetting, open a **third** client.
+3. Verify the new client immediately sees the current state — not the initial state.
+
+This is the most reliable way to catch missing `RequestSerialization()` calls and incorrect late-joiner initialization.
+
+---
+
+## Debug.Log Usage
+
+### Basic Logging
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+public class ExampleScript : UdonSharpBehaviour
+{
+    void Start()
+    {
+        Debug.Log("[ExampleScript] Start() called");
+        Debug.Log($"[ExampleScript] Local player: {Networking.LocalPlayer.displayName}");
+    }
+
+    public override void Interact()
+    {
+        Debug.Log("[ExampleScript] Interact() triggered");
+    }
+
+    public override void OnDeserialization()
+    {
+        Debug.Log($"[ExampleScript] OnDeserialization — syncedValue: {syncedValue}");
+    }
+
+    [UdonSynced] private int syncedValue;
+}
+```
+
+### Where Logs Appear
+
+| Environment | Location |
+|---|---|
+| Unity Editor | **Console** window; UdonSharp's runtime exception watcher also highlights the exact line that threw |
+| VRChat client | Output log at `%AppData%\..\LocalLow\VRChat\VRChat\output_log_HH-MM-SS.txt` |
+| VRChat in-game | Press **RShift + Backtick + 3** to open the debug GUI overlay |
+
+### Prefixing Logs
+
+Add a unique prefix to every `Debug.Log` call so you can filter by script in the Console:
+
+```csharp
+// Easy to filter in Console using the search box
+Debug.Log("[MyScriptName] message here");
+Debug.LogWarning("[MyScriptName] unexpected state");
+Debug.LogError("[MyScriptName] critical failure");
+```
+
+### Logging Synced State
+
+Log both the local value and the sync event to diagnose deserialization issues:
+
+```csharp
+[UdonSynced] private bool _isOpen;
+
+public void SetOpen(bool value)
+{
+    if (!Networking.IsOwner(gameObject))
+    {
+        Debug.LogWarning("[Door] SetOpen called but not owner — ignoring");
+        return;
+    }
+    _isOpen = value;
+    RequestSerialization();
+    Debug.Log($"[Door] SetOpen({value}) — RequestSerialization called");
+}
+
+public override void OnDeserialization()
+{
+    Debug.Log($"[Door] OnDeserialization — _isOpen: {_isOpen}");
+    ApplyState();
+}
+```
+
+### Pre-Release Cleanup
+
+Remove or disable all `Debug.Log` calls before publishing:
+
+- Excessive logging reduces runtime performance.
+- Log strings allocate memory on every call, increasing GC pressure.
+- Leaving logs in can expose internal world logic to players who inspect their output files.
+
+**Recommended pattern**: Guard logs behind a serialized flag so you can toggle them from the Inspector without modifying code:
+
+```csharp
+[SerializeField] private bool _debugMode = false;
+
+private void Log(string message)
+{
+    if (_debugMode) Debug.Log(message);
+}
+```
+
+Set `_debugMode = false` on all behaviours before building for release.
+
+---
+
+## Testing Checklist
+
+Run through this checklist before publishing any world.
+
+### Ownership and Sync
+
+- [ ] All `[UdonSynced]` modifications are preceded by `Networking.IsOwner()` checks
+- [ ] All Manual-sync behaviours call `RequestSerialization()` after modifying synced fields
+- [ ] Ownership transfer (`Networking.SetOwner()`) is confirmed via `OnOwnershipTransferred` before writing synced state
+- [ ] No ownership fights: two scripts do not compete for ownership of the same object
+
+### Late Joiner Correctness
+
+- [ ] A player joining after world state has changed sees the current state (not initial defaults)
+- [ ] `OnDeserialization` correctly restores all derived local state from synced variables
+- [ ] Objects managed by `VRCObjectPool` show correct active/inactive state to late joiners
+- [ ] `PlayerData`/`PlayerObject` data is loaded before being read (use `OnPlayerRestored`)
+
+### Network Sync
+
+- [ ] Synced variables reflect changes on all clients within a few seconds
+- [ ] `SendCustomNetworkEvent` fires correctly on `NetworkEventTarget.All` and `NetworkEventTarget.Owner`
+- [ ] `[NetworkCallable]` methods (SDK 3.8.1+) receive correct parameters on all clients
+- [ ] No per-frame `RequestSerialization()` calls that could flood the network budget
+
+### Multi-User Interaction
+
+- [ ] Two players interacting with the same object simultaneously does not corrupt state
+- [ ] Master handoff (closing the master client) does not break world functionality
+- [ ] Ownership transfers complete without leaving objects in an unowned or double-owned state
+
+### Performance
+
+- [ ] No per-frame networking calls (`RequestSerialization`, `SendCustomNetworkEvent`) without throttling
+- [ ] `Debug.Log` calls removed or guarded behind a `_debugMode` flag set to `false`
+- [ ] No `Update()` loops that could be replaced with event-driven callbacks
+
+## See Also
+
+- [networking.md](networking.md) - Ownership model, sync modes, and RequestSerialization
+- [networking-antipatterns.md](networking-antipatterns.md) - Common networking mistakes and how to avoid them
+- [troubleshooting.md](troubleshooting.md) - Common errors and solutions
+- [events.md](events.md) - Complete event list including OnDeserialization and OnPlayerRestored

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -34,14 +34,14 @@ Open **VRChat SDK > ClientSim Settings** and uncheck **Enable ClientSim**.
 - Local player movement, pickups, interactions, UI, and station usage
 - Udon variable inspection during Play Mode
 - `OnDeserialization` events for the local player
-- `OnPlayerRestored` when spawning simulated remote players
+- `OnPlayerRestored` when spawning simulated remote players (event fires only; these simulated players do not perform real network synchronization)
 - Basic server-time simulation
 
 ### What ClientSim Does NOT Simulate
 
 | Not Simulated | Why This Matters |
 |---|---|
-| Remote players (only local player) | Ownership transfers, `OnPlayerJoined`/`OnPlayerLeft` are not realistic |
+| Real networked remote players (ClientSim can add simulated remote players that fire join/restore events, but they do not perform actual network synchronization) | Ownership transfers, sync conflicts, and `OnDeserialization` from a real remote client are not testable |
 | Full networking serialization | `OnPostSerialization` and `OnDeserialization` data structures differ from live VRChat |
 | Network congestion (`Networking.IsClogged`) | Rate limiting and congestion behavior cannot be tested |
 | Multi-user sync conflicts | Race conditions and ownership fights are invisible |

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -250,6 +250,7 @@ Run through this checklist before publishing any world.
 
 ## See Also
 
+- [api.md](api.md) - VRCObjectPool API, VRCPlayerApi methods, and Camera Dolly API reference
 - [networking.md](networking.md) - Ownership model, sync modes, and RequestSerialization
 - [networking-antipatterns.md](networking-antipatterns.md) - Common networking mistakes and how to avoid them
 - [troubleshooting.md](troubleshooting.md) - Common errors and solutions


### PR DESCRIPTION
## Summary

- **Camera Dolly API** (`api.md`): Documents the `VRC_CameraDolly` three-component system (Animation/Path/Point) introduced in SDK 3.9.0, all inspector parameters, and the `Import()` Udon method. Notes no ClientSim preview support and the local-only nature of `Import()`.
- **VRCObjectPool expansion** (`api.md`): Adds ownership behavior (pool owner–only spawn/return), the deprecated `OnSpawn` → `OnEnable` migration note, the pooled object contract (`public VRCPlayerApi Owner` + `_OnOwnerSet`), a master-managed pool usage pattern, and a VRCObjectPool vs VRCInstantiate comparison table with decision flow.
- **Testing guide** (`references/testing.md`): New reference file covering ClientSim (what is and is not simulated), Build and Test single/multi-client setup, Debug.Log best practices with pre-release cleanup, and a testing checklist for ownership, late joiners, network sync, and multi-user interactions.
- **SKILL.md**: `testing.md` added to the references table and Reference Loading Guide.
- **READMEs** (all 5 translations): Reference file count updated from 21 → 22.

Closes #136

## Test plan

- [ ] Verify all internal `See Also` links in `testing.md` resolve to existing files
- [ ] Confirm reference file count in all 5 READMEs matches `ls references/ | wc -l` (22)
- [ ] Run `npm pack --dry-run` to confirm `testing.md` is included in the package
- [ ] Check that no source/community tool names are mentioned in added content
- [ ] Verify Camera Dolly API facts against https://creators.vrchat.com/worlds/components/vrc_cameradolly/
- [ ] Verify VRCObjectPool facts against https://creators.vrchat.com/worlds/udon/networking/network-components/