### PR TITLE
chore(skills): Phase 4 final polish - CHEATSHEET sync and pattern improvements

### DIFF
--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.2 Coverage** (as of March 2026)
+**SDK 3.7.1 - 3.10.2 Coverage** (as of April 2026)
 
 ## Blocked Features and Alternatives
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -364,3 +364,16 @@ if (VRCJson.TryDeserializeFromJson(result.Result, out DataToken json))
 **Dynamic VRCUrl generation: Not possible** -- `new VRCUrl(stringVar)` is blocked by the Udon VM at runtime.
 For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` array (predefined), (3) server-side routing
 
+---
+
+## Reference Index
+
+| Topic | File |
+|-------|------|
+| Camera Dolly API, VRCObjectPool API | [references/api.md](references/api.md) |
+| Testing in Editor (ClientSim), multi-client debugging | [references/testing.md](references/testing.md) |
+| Networking ownership, sync modes, IsMaster migration | [references/networking.md](references/networking.md) |
+| Web / Image loading, VRCUrl constraints | [references/web-loading.md](references/web-loading.md) |
+| UI / Canvas patterns | [references/patterns-ui.md](references/patterns-ui.md) |
+| Video player patterns | [references/patterns-video.md](references/patterns-video.md) |
+

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1051,6 +1051,8 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 
 ### Master-Only Actions
 
+> **Warning**: `Networking.IsMaster` is not deprecated, but it is fragile in practice. The instance master is the first player to join. If that player leaves, the master role transfers to another player, creating a brief window where no action runs, or two clients race to act simultaneously. Prefer owner-centric patterns for any logic that must run reliably. See [Owner-Centric Architecture Migration](#owner-centric-architecture-migration) below.
+
 ```csharp
 public void DoMasterAction()
 {
@@ -1103,6 +1105,92 @@ void Update()
 }
 ```
 
+---
+
+## Owner-Centric Architecture Migration
+
+`Networking.IsMaster` checks which player is the **instance master** (the first player to join).
+Using it to gate critical logic creates two failure modes:
+
+1. **Master-leave gap**: When the master disconnects, VRChat transfers the master role to
+   another player. During the brief transition, `Networking.IsMaster` returns `false` on all
+   clients simultaneously — timed events or game-state updates can be silently dropped.
+
+2. **Concurrent master race**: If two clients check `Networking.IsMaster` in the same frame
+   during a handoff, both may act, causing duplicate state mutations.
+
+The **owner-centric** pattern avoids both issues: a specific `GameObject` has exactly one
+owner at all times, and `Networking.IsOwner(gameObject)` is consistent across all clients
+within the same serialization round.
+
+### Refactoring Pattern: IsMaster → IsOwner
+
+**Before (IsMaster)**
+
+```csharp
+public void StartGame()
+{
+    if (!Networking.IsMaster) return;  // Fragile: master may leave mid-check
+
+    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    gameRunning = true;
+    RequestSerialization();
+}
+```
+
+**After (owner-centric)**
+
+```csharp
+// Assign one dedicated GameObject as the "game manager" object.
+// Its owner is the authoritative game controller.
+
+public void StartGame()
+{
+    if (!Networking.IsOwner(gameObject)) return;  // Stable: exactly one owner
+
+    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    gameRunning = true;
+    RequestSerialization();
+}
+```
+
+### Handling Owner Leave
+
+When the owner of the manager object leaves, VRChat automatically transfers ownership.
+Resume game-manager duties in `OnOwnershipTransferred`:
+
+```csharp
+public override void OnOwnershipTransferred(VRCPlayerApi player)
+{
+    if (player == null || !player.IsValid()) return;
+
+    if (player.isLocal)
+    {
+        // Inherited ownership — re-broadcast current state so late joiners are covered
+        RequestSerialization();
+
+        // Resume any periodic owner duties here
+        if (gameRunning)
+        {
+            SendCustomEventDelayedSeconds(nameof(OwnerHeartbeat), 1.0f);
+        }
+    }
+}
+```
+
+### Migration Decision Table
+
+| Scenario | Use `IsMaster`? | Use `IsOwner`? |
+|---|---|---|
+| One-off world init (fires once at world launch) | Acceptable | Preferred |
+| Ongoing game logic (timers, spawning, scoring) | No — fragile | Yes |
+| Responding to player join/leave events | No — may double-fire | Yes |
+| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Yes — runs on current owner |
+| Checking if a specific player is the master | `player.isMaster` on `VRCPlayerApi` | N/A |
+
+> **Reference**: VRChat networking documentation — https://creators.vrchat.com/worlds/udon/networking/
+
+---
 
 ## See Also
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1119,9 +1119,13 @@ Using it to gate critical logic creates two failure modes:
 2. **Concurrent master race**: If two clients check `Networking.IsMaster` in the same frame
    during a handoff, both may act, causing duplicate state mutations.
 
-The **owner-centric** pattern avoids both issues: a specific `GameObject` has exactly one
-owner at all times, and `Networking.IsOwner(gameObject)` is consistent across all clients
-within the same serialization round.
+The **owner-centric** pattern reduces both risks: a specific `GameObject` has exactly one
+owner at all times, so `Networking.IsOwner(gameObject)` typically returns the same result
+across all clients. Note that during ownership transfers (e.g., the current owner leaves),
+there is a brief transient window where clients may briefly disagree on who the owner is
+until the network round-trip completes. The `OnOwnershipTransferred` callback is the correct
+place to handle this case — re-initialize owner-only state and call `RequestSerialization()`
+so all clients converge to the new owner's authoritative state.
 
 ### Refactoring Pattern: IsMaster → IsOwner
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -387,8 +387,10 @@ public class ProximityDetector : UdonSharpBehaviour
         VRCPlayerApi[] allPlayers = new VRCPlayerApi[VRCPlayerApi.GetPlayerCount()];
         VRCPlayerApi.GetPlayers(allPlayers);
 
-        // Count players in range first
+        // Single pass: collect matches into an oversized temp array, then copy
+        VRCPlayerApi[] temp = new VRCPlayerApi[allPlayers.Length];
         int count = 0;
+
         foreach (VRCPlayerApi player in allPlayers)
         {
             if (player != null && player.IsValid())
@@ -399,27 +401,16 @@ public class ProximityDetector : UdonSharpBehaviour
                 );
                 if (distance <= detectionRange)
                 {
-                    count++;
+                    temp[count++] = player;
                 }
             }
         }
 
-        // Create result array
+        // Trim to actual count
         VRCPlayerApi[] result = new VRCPlayerApi[count];
-        int index = 0;
-        foreach (VRCPlayerApi player in allPlayers)
+        for (int i = 0; i < count; i++)
         {
-            if (player != null && player.IsValid())
-            {
-                float distance = Vector3.Distance(
-                    transform.position,
-                    player.GetPosition()
-                );
-                if (distance <= detectionRange)
-                {
-                    result[index++] = player;
-                }
-            }
+            result[i] = temp[i];
         }
 
         return result;

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -374,3 +374,14 @@ site:github.com/vrchat-community "issue keyword"
 | 3.8.1 | [NetworkCallable] |
 | 3.9.0 | Camera Dolly, Auto Hold |
 | 3.10.0 | Dynamics (PhysBones) |
+
+---
+
+## Reference Index
+
+| Topic | File |
+|-------|------|
+| Performance targets, Quest optimization checklist | [references/performance.md](references/performance.md) |
+| Lightmap settings, Quest bake parameter reference | [references/lighting.md](references/lighting.md) |
+| Pickup + Rigidbody template | [assets/templates/VRC_Pickup_Rigidbody.cs](assets/templates/VRC_Pickup_Rigidbody.cs) |
+| Station (sit) template | [assets/templates/VRC_Station_Basic.cs](assets/templates/VRC_Station_Basic.cs) |


### PR DESCRIPTION
## Summary

Phase 4 final polish: synchronize CHEATSHEETs with Phase 1-3 additions and improve existing patterns.

- **CHEATSHEET sync**: Add Reference Index sections to both `CHEATSHEET.md` files, cross-linking the Camera Dolly API, VRCObjectPool, testing guide, Quest optimization, lighting bake parameters, and the two new C# templates added in Phases 1-3
- **ProximityDetector fix**: Replace the double-pass distance calculation (two `foreach` loops each calling `Vector3.Distance`) with a single-pass approach using an oversized temp array — distance is now computed exactly once per player
- **IsMaster migration guide**: Add an `Owner-Centric Architecture Migration` section to `networking.md` covering the two failure modes of `Networking.IsMaster` (master-leave gap, concurrent race), a side-by-side refactor example, ownership-transfer recovery pattern, and a migration decision table

Closes #138

## Test plan

- [ ] Verify CHEATSHEET Reference Index links point to valid relative paths in the repo
- [ ] Confirm ProximityDetector single-pass logic produces the same result as the original double-pass for all valid/invalid player combinations
- [ ] Review IsMaster migration section for accuracy against https://creators.vrchat.com/worlds/udon/networking/
- [ ] CI passes: Symlink Integrity, Hook Scripts, npm Pack Test, Markdown Links