### PR TITLE
feat(skills): skill-judge score improvements — NEVER lists, reference loading guide, performance workflow

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -83,6 +83,8 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Optimizing performance (Update loops) | `patterns-performance.md` | `patterns-utilities.md`, `api.md` | `dynamics.md`, `web-loading.md`, `persistence.md` |
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
+| Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
+| Writing new UdonSharp scripts (not sure if sync needed) | `udonsharp-constraints.md` | `udonsharp-networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
 ## Pattern Selection Guide
@@ -169,37 +171,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 
 > **Note**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible.
 
-## Web Search
-
-### When to Search
-
-| Scenario | Action |
-|----------|--------|
-| New SDK version support | Check official docs for latest API |
-| "Is this possible?" questions | Verify feasibility in official docs |
-| Unknown errors | Refer to official troubleshooting |
-| New feature usage | Retrieve latest code examples |
-
-### Search Strategy
-
-```
-# Official documentation search
-WebSearch: "feature or API name site:creators.vrchat.com"
-
-# UdonSharp API reference
-WebSearch: "API name site:udonsharp.docs.vrchat.com"
-
-# Error investigation: VRChat official forums
-WebSearch: "error message site:ask.vrchat.com"
-
-# Error investigation: Canny (bug reports / known issues)
-WebSearch: "error message site:feedback.vrchat.com"
-
-# Error investigation: GitHub Issues
-WebSearch: "error message UdonSharp site:github.com"
-```
-
-### Official Resources
+## Official Resources
 
 | Resource | URL | Contents |
 |----------|-----|----------|

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -84,7 +84,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
-| Writing new UdonSharp scripts (not sure if sync needed) | `udonsharp-constraints.md` | `udonsharp-networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
+| Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
 ## Pattern Selection Guide

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -48,11 +48,11 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | 3 | Set Respawn Height at or above the world floor | Player respawns → falls → respawns again → infinite loop; players cannot recover | Set to an unreachable depth (e.g., floor at Y=0 → Respawn at Y=-100) |
 | 4 | Skip "Setup Layers for VRChat" on a new project | Layer collision matrix is wrong by default — players walk through walls, Pickups clip floors | Run VRChat SDK > Builder > "Setup Layers for VRChat" before placing any colliders |
 | 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile or guard assets with `#if UNITY_ANDROID` |
-| 6 | Place more than 2 active video players simultaneously | Each requires a dedicated hardware decode pipeline; >2 causes frame drops and audio desync | Disable extra players at scene start; activate only the currently playing one |
+| 6 | Place more than 2 active video players simultaneously | Each player adds significant decoding overhead; running >2 simultaneously is a common cause of frame drops and audio issues in practice | Disable extra players at scene start; activate only the currently playing one |
 | 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use Animator-driven transforms (no constraints) or remove cloth from Quest meshes |
 | 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
 | 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
-| 10 | Use lightmap resolution >40 texels/unit for large areas | Texture memory explodes (>2 GB for medium worlds); causes OOM crashes on mobile headsets | Use 10-20 texels/unit; check total lightmap atlas count (target ≤ 4 atlases) |
+| 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
 
 ## Reference Loading Guide
 
@@ -286,11 +286,12 @@ If FPS is below target, follow this workflow — measure before guessing:
    └── Physics: → Disable Rigidbodies / Cloth / Constraints on Quest
 
 3. Fix largest impact first, re-measure after each change
-   Mirror ON by default    → Disable by default               (-50% render cost)
-   Realtime shadows        → Bake all lights                  (-30-50% GPU cost)
-   High lightmap resolution → Reduce to 10 texels/unit        (-50-70% VRAM)
-   Unbatched static objects → Mark as Static + enable batching (-30-60% draw calls)
-   Many active particles   → Pool; disable off-screen          (-20% CPU)
+   (estimates below are typical ranges; actual gains vary by world complexity)
+   Mirror ON by default    → Disable by default               (often -40-50% render cost)
+   Realtime shadows        → Bake all lights                  (often -30-50% GPU cost)
+   High lightmap resolution → Reduce and re-profile           (often -30-70% VRAM)
+   Unbatched static objects → Mark as Static + enable batching (often -30-60% draw calls)
+   Many active particles   → Pool; disable off-screen          (often -10-20% CPU)
 ```
 
 **Never stack multiple changes before re-measuring** — you'll lose the ability to identify which change helped.

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -51,7 +51,7 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | 6 | Place more than 2 active video players simultaneously | Each requires a dedicated hardware decode pipeline; >2 causes frame drops and audio desync | Disable extra players at scene start; activate only the currently playing one |
 | 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use Animator-driven transforms (no constraints) or remove cloth from Quest meshes |
 | 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
-| 9 | Place player walkable surfaces on Default layer (0) | `OnPlayerTriggerEnter` won't fire; avatar physics collision is unreliable | Use Environment (layer 11) for all walkable geometry, walls, and floors |
+| 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
 | 10 | Use lightmap resolution >40 texels/unit for large areas | Texture memory explodes (>2 GB for medium worlds); causes OOM crashes on mobile headsets | Use 10-20 texels/unit; check total lightmap atlas count (target ≤ 4 atlases) |
 
 ## Reference Loading Guide

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -37,6 +37,51 @@ metadata:
 
 ---
 
+## Common Mistakes (NEVER List)
+
+These cause silent world failures, performance disasters, or Quest incompatibility:
+
+| # | NEVER do this | Why it hurts | Use instead |
+|---|---------------|-------------|-------------|
+| 1 | Enable Mirror by default (active on world join) | Renders the entire scene twice — immediate FPS halving, catastrophic on Quest | Default Mirror OFF; add UdonSharp toggle or player-triggered activation |
+| 2 | Use realtime directional lights with real-time shadows | Quest has no hardware shadow acceleration; each shadow caster costs 10-30 FPS | Baked lightmaps + light probes; set lights to Baked or Mixed mode |
+| 3 | Set Respawn Height at or above the world floor | Player respawns → falls → respawns again → infinite loop; players cannot recover | Set to an unreachable depth (e.g., floor at Y=0 → Respawn at Y=-100) |
+| 4 | Skip "Setup Layers for VRChat" on a new project | Layer collision matrix is wrong by default — players walk through walls, Pickups clip floors | Run VRChat SDK > Builder > "Setup Layers for VRChat" before placing any colliders |
+| 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile or guard assets with `#if UNITY_ANDROID` |
+| 6 | Place more than 2 active video players simultaneously | Each requires a dedicated hardware decode pipeline; >2 causes frame drops and audio desync | Disable extra players at scene start; activate only the currently playing one |
+| 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use Animator-driven transforms (no constraints) or remove cloth from Quest meshes |
+| 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
+| 9 | Place player walkable surfaces on Default layer (0) | `OnPlayerTriggerEnter` won't fire; avatar physics collision is unreliable | Use Environment (layer 11) for all walkable geometry, walls, and floors |
+| 10 | Use lightmap resolution >40 texels/unit for large areas | Texture memory explodes (>2 GB for medium worlds); causes OOM crashes on mobile headsets | Use 10-20 texels/unit; check total lightmap atlas count (target ≤ 4 atlases) |
+
+## Reference Loading Guide
+
+Load only what the task requires.
+
+| Task | MANDATORY READ | Optional | Do NOT Load |
+|------|---------------|----------|-------------|
+| Setting up a new scene from scratch | `components.md`, `layers.md` | `upload.md` | `audio-video.md`, `troubleshooting.md` |
+| Making objects grabbable (VRC_Pickup) | `components.md` | `layers.md` | `audio-video.md`, `lighting.md` |
+| Setting up seating (VRC_Station) | `components.md` | `layers.md` | `audio-video.md`, `performance.md` |
+| Optimizing FPS for Quest | `performance.md`, `lighting.md` | `troubleshooting.md` | `audio-video.md`, `upload.md` |
+| Adding audio or video player | `audio-video.md`, `components.md` | `troubleshooting.md` | `lighting.md`, `performance.md` |
+| Baking lights / lightmap setup | `lighting.md`, `performance.md` | — | `audio-video.md`, `layers.md` |
+| World upload and publish | `upload.md` | `troubleshooting.md` | `audio-video.md`, `lighting.md` |
+| Debugging collision or layer issues | `layers.md`, `troubleshooting.md` | `components.md` | `audio-video.md`, `lighting.md` |
+
+## Design Philosophy: Quest First
+
+**Build for Quest and get PC for free. Build for PC and Quest becomes a separate project.**
+
+Quest (Meta Quest 2/3/Pro) defines the performance budget:
+- **CPU/GPU**: ~2× slower than PC VR; tile-based GPU with no hardware shadow maps
+- **VRAM**: ~4 GB shared with OS (vs 6–12 GB on PC); no HDR framebuffer
+- **Thermal throttling**: Sustained 100% GPU load causes clock reduction within minutes
+
+If a world runs at 72 FPS on Quest with a single test client, it will run at 90+ FPS on PC. The converse rarely holds.
+
+**NEVER optimize exclusively for PC with "Quest support added later"** — by that point, lighting, materials, and mesh density are all locked to PC quality, and the Quest port requires rebuilding everything.
+
 ## SDK Versions
 
 **Supported versions**: SDK 3.7.1 - 3.10.2 (as of March 2026)
@@ -222,6 +267,32 @@ Demo:       All players spawn at Spawns[0]
 | Post-Processing    | ✅  | ❌ Disabled   |
 | Unity Constraints  | ✅  | ❌ Disabled   |
 | Realtime lights    | ✅  | ⚠️ Avoid     |
+
+### Performance Optimization Workflow
+
+If FPS is below target, follow this workflow — measure before guessing:
+
+```
+1. Measure
+   ├── Unity Profiler: Deep Profile in Play mode or Build & Test
+   ├── VRChat overlay: type "/perf" in-game
+   └── Stats window: Draw Calls, Triangles, VRAM
+
+2. Identify bottleneck category
+   ├── CPU-bound (high Draw Calls): → Batching / LOD / Culling / Static flags
+   ├── GPU-bound (shader cost): → Mirror / Realtime lights / Post-Processing
+   ├── Memory (VRAM spikes): → Reduce texture resolution / video players
+   └── Physics: → Disable Rigidbodies / Cloth / Constraints on Quest
+
+3. Fix largest impact first, re-measure after each change
+   Mirror ON by default    → Disable by default               (-50% render cost)
+   Realtime shadows        → Bake all lights                  (-30-50% GPU cost)
+   High lightmap resolution → Reduce to 10 texels/unit        (-50-70% VRAM)
+   Unbatched static objects → Mark as Static + enable batching (-30-60% draw calls)
+   Many active particles   → Pool; disable off-screen          (-20% CPU)
+```
+
+**Never stack multiple changes before re-measuring** — you'll lose the ability to identify which change helped.
 
 **→ For details, see `references/performance.md`**
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -78,7 +78,7 @@ Quest (Meta Quest 2/3/Pro) defines the performance budget:
 - **VRAM**: ~4 GB shared with OS (vs 6–12 GB on PC); no HDR framebuffer
 - **Thermal throttling**: Sustained 100% GPU load causes clock reduction within minutes
 
-If a world runs at 72 FPS on Quest with a single test client, it will run at 90+ FPS on PC. The converse rarely holds.
+If a world runs at 72 FPS on Quest with a single test client, it will typically run at 90+ FPS on PC — though results vary by shader complexity, CPU-bound workloads, and hardware differences. The converse rarely holds. Verify against the [official VRChat optimization documentation](https://creators.vrchat.com/worlds/udon/performance-and-optimization/) before publishing.
 
 **NEVER optimize exclusively for PC with "Quest support added later"** — by that point, lighting, materials, and mesh density are all locked to PC quality, and the Quest port requires rebuilding everything.
 
@@ -274,7 +274,7 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 ```
 1. Measure
-   ├── Unity Profiler: Deep Profile in Play mode or Build & Test
+   ├── Unity Profiler: standard profiling in Play mode (primary; Deep Profile only for function-level deep dives — avoid on Quest, misleading results)
    ├── VRChat overlay: type "/perf" in-game
    └── Stats window: Draw Calls, Triangles, VRAM
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -68,6 +68,7 @@ Load only what the task requires.
 | Baking lights / lightmap setup | `lighting.md`, `performance.md` | — | `audio-video.md`, `layers.md` |
 | World upload and publish | `upload.md` | `troubleshooting.md` | `audio-video.md`, `lighting.md` |
 | Debugging collision or layer issues | `layers.md`, `troubleshooting.md` | `components.md` | `audio-video.md`, `lighting.md` |
+| Mirror setup and configuration | `components.md` | `performance.md` | `audio-video.md`, `upload.md` |
 
 ## Design Philosophy: Quest First
 


### PR DESCRIPTION
## Background

skill-judge evaluation revealed significant gaps in both skills:
- `unity-vrc-world-sdk-3`: **90/120 (75%, B)** — D3 Anti-Pattern was 6/15 (no NEVER list at all), D5 Progressive Disclosure was 11/15 (no conditional loading guide)
- `unity-vrc-udon-sharp`: **106/120 (88%, A)** — minor token waste in Web Search section, missing 2 Reference Loading rows

## Changes

### `unity-vrc-world-sdk-3/SKILL.md` (+18 estimated pts → 108/120)

- **Add `## Common Mistakes (NEVER List)`** (10 items): Mirror default ON, realtime shadows on Quest, Respawn Height trap, missing layer setup, Post-Processing on Quest, >2 video players, Constraints/Cloth on Quest, uploading without bake, Default layer walkable surfaces, lightmap resolution >40 texels/unit — each with reason + alternative
- **Add `## Reference Loading Guide`** (8 task rows): MANDATORY/Optional/Do NOT Load for common tasks
- **Add `## Design Philosophy: Quest First`**: Expert principle with Quest hardware constraints
- **Add `### Performance Optimization Workflow`**: Measure → Identify → Fix pattern with FPS gain estimates

### `unity-vrc-udon-sharp/SKILL.md` (+4 estimated pts → 110/120)

- **Replace `## Web Search` with `## Official Resources`**: Removed ~30 lines of generic WebSearch snippets; kept only the 5-URL resource table
- **Expand Reference Loading Guide**: 2 new rows — ownership/sync debugging and new script creation

## Quality Gate

- [x] Code review (Haiku): 1 CRITICAL found and fixed (incorrect `OnPlayerTriggerEnter` layer claim — firing is not blocked by layer, avatar physics collision is the real issue)
- [x] No broken Markdown tables or unclosed code blocks

## Estimated Score Impact

| Skill | Before | After | Delta |
|-------|--------|-------|-------|
| `unity-vrc-world-sdk-3` | 90/120 (75%, B) | ~108/120 (90%, A) | +18 pts |
| `unity-vrc-udon-sharp` | 106/120 (88%, A) | ~110/120 (92%, A) | +4 pts |