### PR TITLE
refactor(skills): trim redundant content and add sync debugging tree

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -69,6 +69,28 @@ Temporary effect for all players, no state?   -> SendCustomNetworkEvent (no sync
 
 > For detailed decision trees, data budget, and minimization principles, see `rules/udonsharp-sync-selection.md`.
 
+## Sync Debugging Quick Decision
+
+When sync "looks correct locally but doesn't work for others":
+
+```text
+Remote players don't see my state change?
+  ├── Did I call RequestSerialization() after writing? (Manual sync) → Add it
+  ├── Does the local player own the object?                          → Networking.SetOwner() first
+  └── Using Continuous sync for button/toggle state?                → Switch to Manual + RequestSerialization()
+
+RequestSerialization() called but still not syncing?
+  ├── Is Networking.IsClogged == true?           → Throttle; retry after delay
+  └── Writing in OnPreSerialization scope?       → Move write before OnPreSerialization fires
+
+Late joiners don't see current state?
+  ├── State set only on event (e.g., player trigger)?  → Also set in Start() + RequestSerialization() on owner
+  └── Using SendCustomNetworkEvent for persistent state? → Use [UdonSynced] variables instead
+
+OnOwnershipTransferred never fires after SetOwner()?
+  └── SetOwner() is async — write synced vars inside OnOwnershipTransferred callback, not immediately after
+```
+
 ## Reference Loading Guide
 
 Load only what you need. Over-loading wastes tokens; under-loading causes critical mistakes.
@@ -138,10 +160,6 @@ Station + trigger zone detection?       -> troubleshooting.md
 | Auto-generate .asset for new scripts | `UdonSharpProgramAssetAutoGenerator.cs` | AssetPostprocessor, domain-reload-only, auto-compile |
 
 > **Multiple needs?** Start with the template closest to your primary concern, then pull patterns from others. For example, a synced game with undo needs `UndoableGameManager.cs` as the base plus patterns from `RateLimitedSync.cs` for throttling.
-
-## Overview
-
-**SDK Coverage**: 3.7.1 - 3.10.2 (as of March 2026)
 
 ## Rules (Constraints & Networking)
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -416,44 +416,6 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 ---
 
-## Web Search
-
-### Official Documentation (WebSearch)
-
-```
-# Search official documentation
-WebSearch: "component or feature to look up site:creators.vrchat.com"
-```
-
-### Issue Investigation (WebSearch)
-
-```
-# Step 1: Forum search
-WebSearch:
-  query: "issue description site:ask.vrchat.com"
-  allowed_domains: ["ask.vrchat.com"]
-
-# Step 2: Known bug search
-WebSearch:
-  query: "issue description site:feedback.vrchat.com"
-  allowed_domains: ["feedback.vrchat.com"]
-
-# Step 3: GitHub Issues
-WebSearch:
-  query: "issue description site:github.com/vrchat-community"
-```
-
-### Official Resources
-
-| Resource          | URL                                   |
-| ----------------- | ------------------------------------- |
-| VRChat Creators   | https://creators.vrchat.com/worlds/   |
-| VRChat Forums     | https://ask.vrchat.com/               |
-| VRChat Canny      | https://feedback.vrchat.com/          |
-| SDK Release Notes | https://creators.vrchat.com/releases/ |
-
----
-
 ## Templates (`assets/templates/`)
 
 Starter templates for common SDK component patterns. Each template compiles without modification; adjust Inspector fields and extend the event stubs for your world.


### PR DESCRIPTION
## Background

skill-judge Loop 2 evaluation identified two categories of improvement:

1. **world-sdk-3**: Web Search section (36 lines) was pure redundant content — Claude already knows how to search `creators.vrchat.com` and use VRChat's public forums. It dragged down D1 (Knowledge Delta) and D5 (Progressive Disclosure) scores.

2. **udon-sharp**: Redundant "Overview" section duplicated the SDK coverage range already in the frontmatter. More importantly, there was no sync debugging decision tree despite sync bugs being the #1 pain point for UdonSharp developers.

## Changes

### `skills/unity-vrc-world-sdk-3/SKILL.md`

- **Removed**: "Web Search" section (URL list + generic WebSearch query patterns). The URLs remain available via `references/troubleshooting.md` and the NEVER list's inline references.

### `skills/unity-vrc-udon-sharp/SKILL.md`

- **Removed**: Redundant 3-line "Overview" section (SDK coverage already in frontmatter)
- **Added**: "Sync Debugging Quick Decision" tree covering the four most common silent-failure scenarios:
  - Missing `RequestSerialization()` or `SetOwner()`
  - `Networking.IsClogged` congestion
  - Late-joiner state gap (event-only writes miss joining players)
  - Async `SetOwner()` timing (`OnOwnershipTransferred` must gate writes)

## Scope of impact

| File | Before | After | Delta |
|------|--------|-------|-------|
| `skills/unity-vrc-world-sdk-3/SKILL.md` | 477 lines | 439 lines | -38 |
| `skills/unity-vrc-udon-sharp/SKILL.md` | 242 lines | 260 lines | +18 |

## Quality gate

- [x] Code review (no CRITICAL issues)
- [x] No references added/removed (README sync not required)
- [x] Both skills remain within 500-line D5 budget

Closes #(N/A — skill optimization loop, no issue)