### PR TITLE
Release: dev → main

### DIFF
--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -12,6 +12,7 @@ metadata:
     author: niaka3dayo
     version: "1.2.1"
     tags: skill-maintenance, sdk-update, knowledge-management
+    internal: true
 ---
 
 # VRC Skills Renovator

--- a/README.ja.md
+++ b/README.ja.md
@@ -111,7 +111,7 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（21ファイル）
+    references/                          # 詳細ドキュメント（22ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7ファイル）
 templates/                               # AIツール設定テンプレート

--- a/README.ko.md
+++ b/README.ko.md
@@ -112,7 +112,7 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (21개 파일)
+    references/                          # 상세 문서 (22개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7개 파일)
 templates/                               # AI 도구 설정 템플릿

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (21 files)
+    references/                          # Detailed documentation (22 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7 files)
 templates/                               # AI tool config templates

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,7 +112,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（21 个文件）
+    references/                          # 详细文档（22 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 个文件）
 templates/                               # AI 工具配置模板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -112,7 +112,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（21 個檔案）
+    references/                          # 詳細文件（22 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 個檔案）
 templates/                               # AI 工具設定範本

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.2 Coverage** (as of March 2026)
+**SDK 3.7.1 - 3.10.2 Coverage** (as of April 2026)
 
 ## Blocked Features and Alternatives
 
@@ -363,4 +363,17 @@ if (VRCJson.TryDeserializeFromJson(result.Result, out DataToken json))
 
 **Dynamic VRCUrl generation: Not possible** -- `new VRCUrl(stringVar)` is blocked by the Udon VM at runtime.
 For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` array (predefined), (3) server-side routing
+
+---
+
+## Reference Index
+
+| Topic | File |
+|-------|------|
+| Camera Dolly API, VRCObjectPool API | [references/api.md](references/api.md) |
+| Testing in Editor (ClientSim), multi-client debugging | [references/testing.md](references/testing.md) |
+| Networking ownership, sync modes, IsMaster migration | [references/networking.md](references/networking.md) |
+| Web / Image loading, VRCUrl constraints | [references/web-loading.md](references/web-loading.md) |
+| UI / Canvas patterns | [references/patterns-ui.md](references/patterns-ui.md) |
+| Video player patterns | [references/patterns-video.md](references/patterns-video.md) |
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -26,6 +26,15 @@ UdonSharp looks like regular Unity C# scripting — until you hit its hidden wal
 
 Every rule in this skill exists because UdonSharp's default behavior is to **fail silently**. Read the Rules before generating any code.
 
+## Before Writing Network Code
+
+Four architectural decisions that must be made before choosing sync modes or writing any synced variable. Changing them mid-implementation typically requires a full rewrite:
+
+- **Who owns this state?** One owner writes; all others read. If two players can both write (e.g., a shared toggle), you need an ownership transfer protocol — writes without ownership are silently discarded.
+- **When does ownership transfer?** On grab? Interact? Game event? `OnPlayerLeft`? Ownership transfer is asynchronous — do not write synced variables immediately after `SetOwner()`; write inside `OnOwnershipTransferred`.
+- **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Persistent state requires `[UdonSynced]` variables; the owner calls `RequestSerialization()` on join events to push current state to newcomers.
+- **What if the owner leaves mid-session?** Without explicit `OnPlayerLeft` handling, the object's synced state can never change again. Decide upfront: auto-transfer to master, reset to a known default, or the next interacting player claims ownership.
+
 ## Core Principles
 
 1. **Constraints First** — Assume standard C# features are blocked until verified. Check `udonsharp-constraints.md` before using any API.
@@ -56,6 +65,8 @@ These constraints cause **silent failures** — no compiler error, no runtime ex
 | 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Events and components do not exist for worlds — code compiles but callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | `PlayerData`, `PlayerObject`, `OnPlayerRestored` do not exist — compile or silent runtime failure | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
 | 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
+| 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
+| 18 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and their simple arrays are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
 
 ## Sync Mode Quick Decision
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -69,6 +69,28 @@ Temporary effect for all players, no state?   -> SendCustomNetworkEvent (no sync
 
 > For detailed decision trees, data budget, and minimization principles, see `rules/udonsharp-sync-selection.md`.
 
+## Sync Debugging Quick Decision
+
+When sync "looks correct locally but doesn't work for others":
+
+```text
+Remote players don't see my state change?
+  ├── Did I call RequestSerialization() after writing? (Manual sync) → Add it
+  ├── Does the local player own the object?                          → Networking.SetOwner() first
+  └── Using Continuous sync for button/toggle state?                → Switch to Manual + RequestSerialization()
+
+RequestSerialization() called but still not syncing?
+  ├── Is Networking.IsClogged == true?           → Throttle; retry after delay
+  └── Writing in OnPreSerialization scope?       → Move write before OnPreSerialization fires
+
+Late joiners don't see current state?
+  ├── State set only on event (e.g., player trigger)?  → Also set in Start() + RequestSerialization() on owner
+  └── Using SendCustomNetworkEvent for persistent state? → Use [UdonSynced] variables instead
+
+OnOwnershipTransferred never fires after SetOwner()?
+  └── SetOwner() is async — write synced vars inside OnOwnershipTransferred callback, not immediately after
+```
+
 ## Reference Loading Guide
 
 Load only what you need. Over-loading wastes tokens; under-loading causes critical mistakes.
@@ -138,10 +160,6 @@ Station + trigger zone detection?       -> troubleshooting.md
 | Auto-generate .asset for new scripts | `UdonSharpProgramAssetAutoGenerator.cs` | AssetPostprocessor, domain-reload-only, auto-compile |
 
 > **Multiple needs?** Start with the template closest to your primary concern, then pull patterns from others. For example, a synced game with undo needs `UndoableGameManager.cs` as the base plus patterns from `RateLimitedSync.cs` for throttling.
-
-## Overview
-
-**SDK Coverage**: 3.7.1 - 3.10.2 (as of March 2026)
 
 ## Rules (Constraints & Networking)
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -82,7 +82,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Using PhysBones/Contacts/Constraints | `dynamics.md`, `events.md` | `patterns-networking.md`, `api.md` | `web-loading.md`, `image-loading-vram.md`, `persistence.md` |
 | Optimizing performance (Update loops) | `patterns-performance.md` | `patterns-utilities.md`, `api.md` | `dynamics.md`, `web-loading.md`, `persistence.md` |
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
-| Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
+| Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
 ## Pattern Selection Guide
@@ -234,6 +234,7 @@ WebSearch: "error message UdonSharp site:github.com"
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |
+| `testing.md` | Testing and debugging guide: ClientSim editor testing, Build and Test (single and multi-client), Debug.Log patterns, pre-release cleanup, testing checklist | ClientSim, Build and Test, multi-client, late joiner test, debug, Debug.Log, ownership test, sync test, testing checklist |
 
 ## Templates (`assets/templates/`)
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -83,6 +83,8 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Optimizing performance (Update loops) | `patterns-performance.md` | `patterns-utilities.md`, `api.md` | `dynamics.md`, `web-loading.md`, `persistence.md` |
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
+| Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
+| Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
 ## Pattern Selection Guide
@@ -169,37 +171,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 
 > **Note**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible.
 
-## Web Search
-
-### When to Search
-
-| Scenario | Action |
-|----------|--------|
-| New SDK version support | Check official docs for latest API |
-| "Is this possible?" questions | Verify feasibility in official docs |
-| Unknown errors | Refer to official troubleshooting |
-| New feature usage | Retrieve latest code examples |
-
-### Search Strategy
-
-```
-# Official documentation search
-WebSearch: "feature or API name site:creators.vrchat.com"
-
-# UdonSharp API reference
-WebSearch: "API name site:udonsharp.docs.vrchat.com"
-
-# Error investigation: VRChat official forums
-WebSearch: "error message site:ask.vrchat.com"
-
-# Error investigation: Canny (bug reports / known issues)
-WebSearch: "error message site:feedback.vrchat.com"
-
-# Error investigation: GitHub Issues
-WebSearch: "error message UdonSharp site:github.com"
-```
-
-### Official Resources
+## Official Resources
 
 | Resource | URL | Contents |
 |----------|-----|----------|

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -313,18 +313,154 @@ station.ExitStation(VRCPlayerApi player);
 
 ## VRCObjectPool
 
-Object pooling for network-aware objects.
+Object pooling for network-aware objects. The pool manages and synchronizes the active state of each held object across all players.
+
+**Class**: `VRC.SDK3.Components.VRCObjectPool`
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Pool` | `GameObject[]` | The objects managed by this pool |
 
 ### Methods
 
 ```csharp
 public VRCObjectPool pool;
 
-// Spawn (owner only)
+// Activate an unused object (pool owner only). Returns null if all objects are in use.
 GameObject spawned = pool.TryToSpawn();
 
-// Return to pool
+// Return an object to the pool (pool owner only). Deactivates the object.
 pool.Return(GameObject obj);
+```
+
+### Ownership Behavior
+
+The VRCObjectPool itself is a networked object; only its **owner** can call `TryToSpawn()` and `Return()`.
+
+- **`TryToSpawn()`** activates an available pooled object and returns it. The ownership of the activated object is **not** automatically transferred to any specific player — call `Networking.SetOwner()` explicitly after spawning if you need the spawned object to be owned by a particular player.
+- **`Return()`** deactivates the object and returns it to the pool. Only the pool owner can call this method.
+
+### Network Synchronization
+
+The pool synchronizes the active/inactive state of every held object across all players. Late joiners automatically receive the correct active or inactive state for each pooled object.
+
+### Pooled Object Contract
+
+When writing an UdonSharp behaviour that is intended to run on pooled objects, it should follow this convention so the pool can set ownership correctly:
+
+```csharp
+using UdonSharp;
+using VRC.SDKBase;
+
+public class PooledObject : UdonSharpBehaviour
+{
+    // Set by the pool manager after TryToSpawn(); null when unassigned
+    public VRCPlayerApi Owner;
+
+    // Called on all clients when the object is assigned to a new owner
+    public void OnOwnerSet()
+    {
+        // React to ownership assignment here
+        if (Utilities.IsValid(Owner))
+        {
+            Debug.Log($"Object assigned to: {Owner.displayName}");
+        }
+    }
+
+    void OnEnable()
+    {
+        // OnEnable fires before Start() when the pool activates this object.
+        // Use this instead of the deprecated OnSpawn event.
+    }
+
+    void OnDisable()
+    {
+        // Fired when Return() deactivates this object.
+        Owner = null;
+    }
+}
+```
+
+> **Note**: `OnSpawn` is **deprecated**. Use `OnEnable` to react to an object being activated by the pool.
+
+### Usage Pattern: Master-Managed Pool
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Components;
+using VRC.SDKBase;
+using VRC.Udon.Common.Interfaces;
+
+[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+public class PoolManager : UdonSharpBehaviour
+{
+    public VRCObjectPool objectPool;
+
+    public override void OnPlayerJoined(VRCPlayerApi player)
+    {
+        // Only the pool owner (e.g. master) calls TryToSpawn
+        if (!Networking.IsOwner(objectPool.gameObject)) return;
+
+        GameObject spawned = objectPool.TryToSpawn();
+        if (spawned == null)
+        {
+            Debug.LogWarning("No objects available in pool");
+            return;
+        }
+
+        // Transfer ownership of the spawned object to the joining player
+        Networking.SetOwner(player, spawned);
+
+        PooledObject pooledBehaviour = (PooledObject)spawned.GetComponent(typeof(PooledObject));
+        if (Utilities.IsValid(pooledBehaviour))
+        {
+            pooledBehaviour.Owner = player;
+            pooledBehaviour.SendCustomNetworkEvent(NetworkEventTarget.All, nameof(PooledObject.OnOwnerSet));
+        }
+    }
+
+    public override void OnPlayerLeft(VRCPlayerApi player)
+    {
+        if (!Networking.IsOwner(objectPool.gameObject)) return;
+
+        // Find and return the object assigned to the leaving player
+        foreach (GameObject obj in objectPool.Pool)
+        {
+            if (!obj.activeInHierarchy) continue;
+
+            PooledObject pooledBehaviour = (PooledObject)obj.GetComponent(typeof(PooledObject));
+            if (Utilities.IsValid(pooledBehaviour) && pooledBehaviour.Owner == player)
+            {
+                objectPool.Return(obj);
+                break;
+            }
+        }
+    }
+}
+```
+
+### VRCObjectPool vs VRCInstantiate
+
+| | VRCObjectPool | VRCInstantiate |
+|---|---|---|
+| **Sync** | Network-synchronized across all players | Local only — not synced |
+| **Ownership** | Managed by pool owner; spawned object ownership must be set manually | No ownership concept |
+| **Late joiners** | Receive correct state automatically | Miss any previously instantiated objects |
+| **Object reuse** | Pre-allocated pool; `Return()` makes objects available again | Objects persist until destroyed |
+| **Use when** | Spawning networked bullets, per-player data containers, shared world objects | Local particle effects, client-side previews, non-networked decorations |
+
+#### Decision Flow
+
+```text
+Does every player need to see the spawned object?
+├── No  --> VRCInstantiate (local, no sync overhead)
+└── Yes --> VRCObjectPool (synchronized, ownership-aware)
+         Does the object need to be reused frequently?
+         ├── Yes --> VRCObjectPool (pooling avoids repeated allocation)
+         └── No  --> VRCObjectPool still preferred over VRCInstantiate for synced objects
 ```
 
 ## VRCObjectSync
@@ -867,6 +1003,108 @@ public class DroneCheckpoint : UdonSharpBehaviour
     }
 }
 ```
+
+## VRC Camera Dolly API (SDK 3.9.0+)
+
+Defines camera dolly animations applied to the local player's VRChat user camera.
+Three components work together in a fixed parent-child hierarchy.
+
+**Available since**: SDK 3.9.0
+
+> **No ClientSim preview**: Camera dolly animations do not render in ClientSim.
+> Use **Build and Test** to preview animations at runtime.
+
+### Component Hierarchy
+
+```text
+GameObject (VRC Camera Dolly Animation)
+├── GameObject (VRC Camera Dolly Path)
+│   ├── GameObject (VRC Camera Dolly Point)
+│   └── GameObject (VRC Camera Dolly Point)
+└── GameObject (VRC Camera Dolly Path)
+    ├── GameObject (VRC Camera Dolly Point)
+    ├── GameObject (VRC Camera Dolly Point)
+    └── GameObject (VRC Camera Dolly Point)
+```
+
+### VRC Camera Dolly Animation — Inspector Parameters
+
+Configure these in the Unity Inspector on the top-level `VRC Camera Dolly Animation` component:
+
+| Parameter | Description |
+|-----------|-------------|
+| `Is Relative To Player` | Anchor animation to the local player's position instead of world origin |
+| `Is Speed Based` | Use speed values per point rather than fixed durations |
+| `Is Using Look At Me` | Enable Look-At-Me horizontal/vertical offsets on points |
+| `Is Using Greenscreen` | Enable Green Screen HSL controls on points |
+| `Is Using Multi Stream` | Enable multi-stream animation mode |
+| `Path Type` | Interpolation method for the path (linear, smooth, etc.) |
+| `Loop Type` | How the animation loops (none, loop, ping-pong) |
+| `Capture Type` | Capture methodology for the animation |
+| `Focus Mode` | Camera focus mode for this animation |
+| `Anchor Mode` | Camera anchor mode for this animation |
+| `Paths` | List of `VRC Camera Dolly Path` children; populate via **Collect Paths & Points** |
+
+### VRC Camera Dolly Path — Inspector Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `Points` | List of `VRC Camera Dolly Point` children; populated via **Collect Paths & Points** |
+
+### VRC Camera Dolly Point — Inspector Parameters (Keyframe)
+
+| Parameter | Description |
+|-----------|-------------|
+| `Zoom` | Keyframe zoom value |
+| `Duration` | Duration for this keyframe (time-based mode only) |
+| `Speed` | Speed for this keyframe (speed-based mode only) |
+| `Focal Distance` | Focal distance (manual focus mode) |
+| `Aperture` | Aperture value (manual or semi-auto focus mode) |
+| `Hue` | Greenscreen hue (greenscreen mode) |
+| `Saturation` | Greenscreen saturation (greenscreen mode) |
+| `Lightness` | Greenscreen lightness (greenscreen mode) |
+| `Look At Me X Offset` | Horizontal Look-At-Me offset (Look-At-Me mode) |
+| `Look At Me Y Offset` | Vertical Look-At-Me offset (Look-At-Me mode) |
+
+### UdonSharp API
+
+The scripting surface for Camera Dolly is intentionally minimal. The primary method is:
+
+```csharp
+// Apply the animation to the local player's VRChat user camera
+dollyAnimation.Import();
+```
+
+`Import()` reads all paths and points collected on the `VRC Camera Dolly Animation` component and applies the resulting animation to the camera of the **local client** only. It has no return value.
+
+### Setup and Usage
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+
+public class DollyController : UdonSharpBehaviour
+{
+    // Drag the GameObject that holds VRC Camera Dolly Animation into this field
+    [SerializeField] private VRCCameraDollyAnimation dollyAnimation;
+
+    // Call this to start the camera dolly animation for the local player
+    public void PlayDolly()
+    {
+        if (!Utilities.IsValid(dollyAnimation)) return;
+        dollyAnimation.Import();
+    }
+}
+```
+
+> **Important**: Before entering Play mode or building, select the top-level `VRC Camera Dolly Animation` object and click **Collect Paths & Points** to register all child paths and points. Any time you add, remove, or re-order children, repeat this step.
+
+### Limitations
+
+- The API applies the animation to the **local player only**. To trigger it for all players, use `SendCustomNetworkEvent(NetworkEventTarget.All, nameof(PlayDolly))`.
+- No properties of the animation, paths, or points are readable or writable from UdonSharp at runtime.
+- There is no event callback when the animation completes.
+- No ClientSim preview; Build and Test is required to see the animation.
 
 ## See Also
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -423,7 +423,7 @@ Know the sizes of synced types for bandwidth optimization:
 | `float` | 4 | |
 | `double` | 8 | |
 | `char` | 2 | UTF-16 |
-| `string` | variable | ~2 bytes per char + overhead, max ~50 chars |
+| `string` | variable | 2 bytes per char; no separate per-string limit — bounded by sync mode budget |
 | `Vector2` | 8 | 2 floats |
 | `Vector3` | 12 | 3 floats |
 | `Vector4` | 16 | 4 floats |
@@ -435,7 +435,7 @@ Know the sizes of synced types for bandwidth optimization:
 ### Bandwidth Limits
 
 - **Continuous sync**: ~200 bytes per UdonBehaviour
-- **Manual sync**: ~282KB per UdonBehaviour
+- **Manual sync**: ~280KB (280,496 bytes) per UdonBehaviour
 - **Total transmission**: ~11 KB/sec
 
 ## SerializationResult

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -33,7 +33,7 @@ UdonSharp transpiles C# source to Udon Assembly, which runs on VRChat's UdonVM. 
 | `Vector3`, `Quaternion`, `Color` | Supported | 3.0+ | Unity struct types; see struct mutation caveat |
 | `GameObject`, `Transform` | Supported | 3.0+ | Unity object types |
 | `T[]` (one-dimensional arrays) | Supported | 3.0+ | Primary collection type |
-| `T[,]` (multi-dimensional arrays) | Supported | 3.0+ | Works but less common |
+| `T[,]` (multi-dimensional arrays) | Blocked | — | Use jagged arrays `T[][]` instead |
 | `T[][]` (jagged arrays) | Supported | 3.0+ | Arrays of arrays |
 
 ### Control Flow
@@ -493,7 +493,12 @@ Udon dispatches events (like `SendCustomEvent`) by searching public method names
 
 ### String Sync Limit
 
-Synced `string` fields (`[UdonSynced]`) have an approximate 50-character limit. For longer strings, split across multiple fields or use a different sync strategy.
+Synced `string` fields (`[UdonSynced]`) are encoded at 2 bytes per character. There is no separate per-string character limit; the practical limit is set by the sync mode's per-serialization buffer:
+
+- **Continuous sync**: ~200 bytes shared across all synced fields on the behaviour. A single synced string can consume the entire budget quickly (e.g., a 100-character string = 200 bytes), leaving no room for other fields.
+- **Manual sync**: 280,496 bytes (~280KB) per serialization, allowing much larger strings.
+
+For Continuous sync, keep synced strings very short or switch to Manual sync.
 
 ---
 
@@ -514,85 +519,6 @@ Before compiling UdonSharp code, verify:
 - [ ] Unity callbacks (OnTriggerEnter, etc.) do not have `override`
 - [ ] VRChat event callbacks (OnPlayerJoined, etc.) do have `override`
 - [ ] `Button.onClick` not used; events configured in Inspector
-
-## Known Limitations and Caveats
-
-### Prefab Field Changes
-
-Changes to serialized fields on prefabs do NOT propagate to instances in the scene or other prefabs that reference them. This is a Unity limitation that affects UdonSharp as well.
-
-**Workaround**: After modifying a prefab, manually update instances or use `PrefabUtility.ApplyPrefabInstance` in editor scripts.
-
-### Field Initializers
-
-Field initializers are evaluated at **compile time**, not runtime. This means:
-
-```csharp
-// WRONG - Random.Range is evaluated once at compile time
-private int randomValue = Random.Range(0, 100); // Same value for all instances!
-
-// CORRECT - Initialize in Start()
-private int randomValue;
-
-void Start()
-{
-    randomValue = Random.Range(0, 100);
-}
-```
-
-### GetComponent and UdonBehaviour
-
-Generic `GetComponent<UdonBehaviour>()` is not directly exposed, but **SDK 3.8+** improved support for inherited types:
-
-```csharp
-// WRONG - Raw UdonBehaviour generic
-UdonBehaviour udon = GetComponent<UdonBehaviour>();
-
-// CORRECT - Cast syntax for raw UdonBehaviour
-UdonBehaviour udon = (UdonBehaviour)GetComponent(typeof(UdonBehaviour));
-
-// CORRECT (SDK 3.8+) - Generic works for UdonSharpBehaviour inheritance
-MyScript script = GetComponent<MyScript>(); // Works for UdonSharpBehaviour types
-
-// CORRECT (SDK 3.8+) - Works with inheritance hierarchy
-public class BaseGimmick : UdonSharpBehaviour { }
-public class DerivedGimmick : BaseGimmick { }
-
-// This now works correctly:
-BaseGimmick gimmick = GetComponent<BaseGimmick>();
-DerivedGimmick derived = GetComponent<DerivedGimmick>();
-```
-
-**Note:** SDK 3.8+ added proper handling for `GetComponent(s)<T>()` on UdonSharpBehaviour types using inheritance.
-
-### Struct Method Mutation (Reiterated)
-
-Methods that mutate structs do NOT modify the original:
-
-```csharp
-// WRONG
-Vector3 v = new Vector3(3, 4, 0);
-v.Normalize(); // v is UNCHANGED!
-
-// CORRECT
-v = v.normalized;
-```
-
-### uGUI Button Event Registration
-
-`Button.onClick.AddListener()` is not available (delegate-based). uGUI button events must be configured in the Unity Inspector.
-
-```csharp
-// WRONG - NotImplementedException at runtime
-button.onClick.AddListener(() => DoSomething());
-button.onClick.AddListener(DoSomething); // Also not possible
-
-// CORRECT - Configure in Unity Inspector:
-// 1. Add to the Button component's OnClick() list
-// 2. Drag the UdonBehaviour
-// 3. Select SendCustomEvent
-// 4. Enter the method name (e.g., "OnButtonClicked")
-```
 
 ## Advanced Constraint Workarounds
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -73,7 +73,7 @@ Explicit synchronization via `RequestSerialization()` calls.
 
 **Characteristics:**
 - Only syncs when `RequestSerialization()` is called
-- Data limit: **65KB -> 280KB** (see release notes for details)
+- Data limit: **280,496 bytes (~280KB)** per serialization (increased from 65,024 bytes in an earlier release)
 - Best for: Game state, scores, settings, infrequent updates
 
 ```csharp
@@ -144,7 +144,7 @@ public class NoSyncExample : UdonSharpBehaviour
 | Mode | Data size | Frequency | Use case |
 |--------|-------------|------|-------------|
 | Continuous | ~200 bytes | High (10Hz) | Position/rotation tracking |
-| Manual | 280KB | On-demand | Game state, scores, settings |
+| Manual | ~280KB (280,496 bytes) | On-demand | Game state, scores, settings |
 | None | N/A | N/A | Event-only communication |
 
 ## VRC_ObjectSync Warning
@@ -591,7 +591,7 @@ Use the `[UdonSynced]` attribute to synchronize fields:
 [UdonSynced] private float health;
 [UdonSynced] private bool isActive;
 [UdonSynced] private Vector3 position;
-[UdonSynced] private string playerName; // Max ~50 characters!
+[UdonSynced] private string playerName; // 2 bytes/char; keep short in Continuous mode (~200 byte shared budget)
 ```
 
 ### Sync Modes
@@ -805,7 +805,7 @@ Only types syncable with `[UdonSynced]` can be used as parameters:
 | `long`, `ulong` | 8 bytes | |
 | `float` | 4 bytes | |
 | `double` | 8 bytes | |
-| `string` | variable | ~50 char limit |
+| `string` | 2 bytes/char | No fixed per-string limit; bounded by NetworkCallable event payload (16 KB/event max, ~18 KB/s throughput). Events >1024 bytes are split into multiple internal packets. Independent of `[UdonSynced]` sync mode budgets. |
 | `Vector2/3/4` | 8/12/16 bytes | |
 | `Quaternion` | 16 bytes | |
 | `Color`, `Color32` | 16/4 bytes | |
@@ -957,8 +957,8 @@ public void CheckMessage()
 ### String Length
 
 Synced strings have no fixed character limit. The practical limit depends on sync buffer size and UTF-16 encoding (2 bytes per character):
-- **Continuous**: ~200 bytes per serialization
-- **Manual**: ~280KB per serialization
+- **Continuous**: ~200 bytes per serialization (shared across all synced fields on the behaviour)
+- **Manual**: 280,496 bytes (~280KB) per serialization
 
 ```csharp
 // Keep synced strings short to conserve sync buffer

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1051,6 +1051,8 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 
 ### Master-Only Actions
 
+> **Warning**: `Networking.IsMaster` is not deprecated, but it is fragile in practice. The instance master is the first player to join. If that player leaves, the master role transfers to another player, creating a brief window where no action runs, or two clients race to act simultaneously. Prefer owner-centric patterns for any logic that must run reliably. See [Owner-Centric Architecture Migration](#owner-centric-architecture-migration) below.
+
 ```csharp
 public void DoMasterAction()
 {
@@ -1103,6 +1105,96 @@ void Update()
 }
 ```
 
+---
+
+## Owner-Centric Architecture Migration
+
+`Networking.IsMaster` checks which player is the **instance master** (the first player to join).
+Using it to gate critical logic creates two failure modes:
+
+1. **Master-leave gap**: When the master disconnects, VRChat transfers the master role to
+   another player. During the brief transition, `Networking.IsMaster` returns `false` on all
+   clients simultaneously — timed events or game-state updates can be silently dropped.
+
+2. **Concurrent master race**: If two clients check `Networking.IsMaster` in the same frame
+   during a handoff, both may act, causing duplicate state mutations.
+
+The **owner-centric** pattern reduces both risks: a specific `GameObject` has exactly one
+owner at all times, so `Networking.IsOwner(gameObject)` typically returns the same result
+across all clients. Note that during ownership transfers (e.g., the current owner leaves),
+there is a brief transient window where clients may briefly disagree on who the owner is
+until the network round-trip completes. The `OnOwnershipTransferred` callback is the correct
+place to handle this case — re-initialize owner-only state and call `RequestSerialization()`
+so all clients converge to the new owner's authoritative state.
+
+### Refactoring Pattern: IsMaster → IsOwner
+
+**Before (IsMaster)**
+
+```csharp
+public void StartGame()
+{
+    if (!Networking.IsMaster) return;  // Fragile: master may leave mid-check
+
+    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    gameRunning = true;
+    RequestSerialization();
+}
+```
+
+**After (owner-centric)**
+
+```csharp
+// Assign one dedicated GameObject as the "game manager" object.
+// Its owner is the authoritative game controller.
+
+public void StartGame()
+{
+    if (!Networking.IsOwner(gameObject)) return;  // Stable: exactly one owner
+
+    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    gameRunning = true;
+    RequestSerialization();
+}
+```
+
+### Handling Owner Leave
+
+When the owner of the manager object leaves, VRChat automatically transfers ownership.
+Resume game-manager duties in `OnOwnershipTransferred`:
+
+```csharp
+public override void OnOwnershipTransferred(VRCPlayerApi player)
+{
+    if (player == null || !player.IsValid()) return;
+
+    if (player.isLocal)
+    {
+        // Inherited ownership — re-broadcast current state so late joiners are covered
+        RequestSerialization();
+
+        // Resume any periodic owner duties here
+        if (gameRunning)
+        {
+            SendCustomEventDelayedSeconds(nameof(OwnerHeartbeat), 1.0f);
+        }
+    }
+}
+```
+
+### Migration Decision Table
+
+| Scenario | Use `IsMaster`? | Use `IsOwner`? |
+|---|---|---|
+| One-off world init (fires once at world launch) | Acceptable | Preferred |
+| Ongoing game logic (timers, spawning, scoring) | No — fragile | Yes |
+| Responding to player join/leave events | No — may double-fire | Yes |
+| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Yes — runs on current owner |
+| Checking if a specific player is the master | `player.isMaster` on `VRCPlayerApi` | N/A |
+
+> **Reference**: VRChat networking documentation — https://creators.vrchat.com/worlds/udon/networking/
+
+---
 
 ## See Also
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -387,8 +387,10 @@ public class ProximityDetector : UdonSharpBehaviour
         VRCPlayerApi[] allPlayers = new VRCPlayerApi[VRCPlayerApi.GetPlayerCount()];
         VRCPlayerApi.GetPlayers(allPlayers);
 
-        // Count players in range first
+        // Single pass: collect matches into an oversized temp array, then copy
+        VRCPlayerApi[] temp = new VRCPlayerApi[allPlayers.Length];
         int count = 0;
+
         foreach (VRCPlayerApi player in allPlayers)
         {
             if (player != null && player.IsValid())
@@ -399,27 +401,16 @@ public class ProximityDetector : UdonSharpBehaviour
                 );
                 if (distance <= detectionRange)
                 {
-                    count++;
+                    temp[count++] = player;
                 }
             }
         }
 
-        // Create result array
+        // Trim to actual count
         VRCPlayerApi[] result = new VRCPlayerApi[count];
-        int index = 0;
-        foreach (VRCPlayerApi player in allPlayers)
+        for (int i = 0; i < count; i++)
         {
-            if (player != null && player.IsValid())
-            {
-                float distance = Vector3.Distance(
-                    transform.position,
-                    player.GetPosition()
-                );
-                if (distance <= detectionRange)
-                {
-                    result[index++] = player;
-                }
-            }
+            result[i] = temp[i];
         }
 
         return result;

--- a/skills/unity-vrc-udon-sharp/references/patterns-performance.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-performance.md
@@ -826,7 +826,7 @@ private void ReplayFromScratch()
 
 **Cross-reference:** The `UndoableGameManager.cs` template uses **full-state snapshots** rather than operation logs — each move saves the complete `currentState` array via `System.Array.Copy`. Use snapshots when state is small and replay is expensive; use the operation-log approach when state is large but individual operations are compact. See [assets/templates/UndoableGameManager.cs](../assets/templates/UndoableGameManager.cs).
 
-> **Note:** The operation-log snippet above is a fragment showing the data layout and replay loop. In a full implementation, wrap it in an `UdonSharpBehaviour` class with `[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]` and add an initialized array (e.g., `private byte[] _opLog = new byte[4000];` for up to 1000 four-byte operations — 4 KB, well within the ~282 KB Manual sync limit).
+> **Note:** The operation-log snippet above is a fragment showing the data layout and replay loop. In a full implementation, wrap it in an `UdonSharpBehaviour` class with `[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]` and add an initialized array (e.g., `private byte[] _opLog = new byte[4000];` for up to 1000 four-byte operations — 4 KB, well within the ~280KB (280,496 bytes) Manual sync limit).
 
 #### Reset vs Cancel
 
@@ -863,7 +863,7 @@ public void ResetToInitial()
 | Keep authoritative data in synced arrays, derived state in local references | Late joiners receive authoritative data via `OnDeserialization` and rebuild locally |
 | One rebuild entry point (`BeginFullRebuild`) for all triggers | Reset, undo, late-joiner sync, and error recovery all use the same path — fewer edge cases |
 | Do not mix rebuild progress with sync serialization | If `RequestSerialization` fires mid-rebuild, the partial derived state is irrelevant — only authoritative data is transmitted |
-| Cap operation logs with a maximum size | `byte[]` sync has a ~282 KB Manual sync limit; a 4-byte-per-op log with 1000 ops = 4 KB — well within budget |
+| Cap operation logs with a maximum size | `byte[]` sync has a ~280KB (280,496 bytes) Manual sync limit; a 4-byte-per-op log with 1000 ops = 4 KB — well within budget |
 | Use cancel for user-initiated abort, reset for state revert | Cancel preserves partial visual progress; reset guarantees a clean starting state |
 
 ---

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -40,7 +40,7 @@ Does another player need to see this value?
 | Layer | Scope | Lifetime | Capacity | Typical use |
 |-------|-------|----------|----------|-------------|
 | **Non-synced field** | Self only | Until scene reload | Unlimited | UI state, timers, cooldown flags |
-| **[UdonSynced]** | All players in instance | Instance lifetime (late joiners receive current value) | ~200 B continuous / ~282 KB manual per behaviour | Shared game state, scores, toggles |
+| **[UdonSynced]** | All players in instance | Instance lifetime (late joiners receive current value) | ~200 B continuous / ~280KB (280,496 bytes) manual per behaviour | Shared game state, scores, toggles |
 | **SendCustomNetworkEvent** | All players in instance | Instant (no persistence, late joiners miss it) | Event name only (no payload) | Sound effects, particle triggers, one-shot notifications |
 | **PlayerData** | Per player, readable by all | Cross-session (permanent until deleted) | 100 KB per player per world | Settings, unlocks, high scores |
 | **PlayerObject** | Per player, synced behaviour | Instance lifetime (+ cross-session if `VRCEnablePersistence` is on) | One UdonBehaviour per player | Complex per-player state with frequent updates |

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -1,0 +1,257 @@
+# UdonSharp Testing and Debugging Guide
+
+Practical guide for testing and debugging UdonSharp worlds in VRChat.
+
+**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+
+## Table of Contents
+
+- [ClientSim — Editor Testing](#clientsim--editor-testing)
+- [Build and Test — Runtime Testing](#build-and-test--runtime-testing)
+- [Multi-Client Testing](#multi-client-testing)
+- [Debug.Log Usage](#debuglog-usage)
+- [Testing Checklist](#testing-checklist)
+
+---
+
+## ClientSim — Editor Testing
+
+ClientSim (Client Simulator) replicates VRChat client behavior in the Unity Editor without requiring a live VRChat build. It is included in the VRChat Worlds SDK — no separate installation is needed.
+
+### Starting a ClientSim Session
+
+1. Open your world scene in the Unity Editor.
+2. Press **Play** in the Editor.
+
+ClientSim starts automatically. Use **Mouse + Keyboard** or a **Gamepad** to control the local player.
+
+### Disabling ClientSim
+
+Open **VRChat SDK > ClientSim Settings** and uncheck **Enable ClientSim**.
+
+### What ClientSim Simulates
+
+- Local player movement, pickups, interactions, UI, and station usage
+- Udon variable inspection during Play Mode
+- `OnDeserialization` events for the local player
+- `OnPlayerRestored` when spawning simulated remote players (event fires only; these simulated players do not perform real network synchronization)
+- Basic server-time simulation
+
+### What ClientSim Does NOT Simulate
+
+| Not Simulated | Why This Matters |
+|---|---|
+| Real networked remote players (ClientSim can add simulated remote players that fire join/restore events, but they do not perform actual network synchronization) | Ownership transfers, sync conflicts, and `OnDeserialization` from a real remote client are not testable |
+| Full networking serialization | `OnPostSerialization` and `OnDeserialization` data structures differ from live VRChat |
+| Network congestion (`Networking.IsClogged`) | Rate limiting and congestion behavior cannot be tested |
+| Multi-user sync conflicts | Race conditions and ownership fights are invisible |
+| Camera dolly animations | Camera dolly has no ClientSim preview support |
+
+> **Critical**: Always test your world in VRChat before publishing. ClientSim catches logic bugs but cannot validate networking behavior.
+
+---
+
+## Build and Test — Runtime Testing
+
+Build and Test launches your world in actual VRChat clients from the Unity Editor, giving full runtime fidelity.
+
+### Prerequisites
+
+1. Sign in via **VRChat SDK > Show Control Panel > Authentication**.
+2. In **VRChat SDK > Show Control Panel > Settings**, specify your VRChat installation path.
+3. In the **Builder** tab, click **Setup Layers for VRChat** and apply the collision matrix.
+
+### Single-Client Build and Test
+
+1. In the **Builder** tab, set **Number of Clients** to `1`.
+2. Click **Build & Test**.
+
+VRChat launches with your world loaded. The local client is the **instance master** and owns all GameObjects by default.
+
+### Build and Reload
+
+Set **Number of Clients** to `0`. This rebuilds the world and moves the already-running client into the new instance — significantly faster for iteration since no login sequence is required.
+
+---
+
+## Multi-Client Testing
+
+Networking bugs (ownership, sync, late joiners) require multiple clients. Build and Test supports this natively.
+
+### Setup
+
+1. Set **Number of Clients** to `2` or higher.
+2. Click **Build & Test**.
+
+Unity launches the specified number of VRChat clients simultaneously. Switch between windows to control each client independently.
+
+### Client Roles
+
+- **First client to load** → instance master and default object owner
+- **Subsequent clients** → non-master; cannot modify objects they do not own
+
+### What to Test with Multiple Clients
+
+| Scenario | What to Verify |
+|---|---|
+| **Ownership transfer** | Call `Networking.SetOwner()` on client A; verify client B sees the update |
+| **Synced variable propagation** | Modify a `[UdonSynced]` field and call `RequestSerialization()`; verify all clients reflect the new value |
+| **NetworkCallable events** | Trigger a `[NetworkCallable]` method from one client; verify it fires on all clients |
+| **SendCustomNetworkEvent** | Send `NetworkEventTarget.All` event; verify it fires on each client |
+| **Late joiner state** | Connect a third client after state has changed; verify the new client receives the current state via `OnDeserialization` |
+| **Master handoff** | Close the master client; verify non-master clients elect a new master and ownership cascades correctly |
+| **Pool behavior** | Call `TryToSpawn()` on the pool owner client; verify spawned objects appear on all clients |
+
+### Late Joiner Testing Procedure
+
+1. Start with 2 clients and modify world state (e.g., toggle a synced bool, change a score).
+2. Without resetting, open a **third** client.
+3. Verify the new client immediately sees the current state — not the initial state.
+
+This is the most reliable way to catch missing `RequestSerialization()` calls and incorrect late-joiner initialization.
+
+---
+
+## Debug.Log Usage
+
+### Basic Logging
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+public class ExampleScript : UdonSharpBehaviour
+{
+    void Start()
+    {
+        Debug.Log("[ExampleScript] Start() called");
+        Debug.Log($"[ExampleScript] Local player: {Networking.LocalPlayer.displayName}");
+    }
+
+    public override void Interact()
+    {
+        Debug.Log("[ExampleScript] Interact() triggered");
+    }
+
+    public override void OnDeserialization()
+    {
+        Debug.Log($"[ExampleScript] OnDeserialization — syncedValue: {syncedValue}");
+    }
+
+    [UdonSynced] private int syncedValue;
+}
+```
+
+### Where Logs Appear
+
+| Environment | Location |
+|---|---|
+| Unity Editor | **Console** window; UdonSharp's runtime exception watcher also highlights the exact line that threw |
+| VRChat client | Output log at `%AppData%\..\LocalLow\VRChat\VRChat\output_log_HH-MM-SS.txt` |
+| VRChat in-game | Press **RShift + Backtick + 3** to open the debug GUI overlay |
+
+### Prefixing Logs
+
+Add a unique prefix to every `Debug.Log` call so you can filter by script in the Console:
+
+```csharp
+// Easy to filter in Console using the search box
+Debug.Log("[MyScriptName] message here");
+Debug.LogWarning("[MyScriptName] unexpected state");
+Debug.LogError("[MyScriptName] critical failure");
+```
+
+### Logging Synced State
+
+Log both the local value and the sync event to diagnose deserialization issues:
+
+```csharp
+[UdonSynced] private bool _isOpen;
+
+public void SetOpen(bool value)
+{
+    if (!Networking.IsOwner(gameObject))
+    {
+        Debug.LogWarning("[Door] SetOpen called but not owner — ignoring");
+        return;
+    }
+    _isOpen = value;
+    RequestSerialization();
+    Debug.Log($"[Door] SetOpen({value}) — RequestSerialization called");
+}
+
+public override void OnDeserialization()
+{
+    Debug.Log($"[Door] OnDeserialization — _isOpen: {_isOpen}");
+    ApplyState();
+}
+```
+
+### Pre-Release Cleanup
+
+Remove or disable all `Debug.Log` calls before publishing:
+
+- Excessive logging reduces runtime performance.
+- Log strings allocate memory on every call, increasing GC pressure.
+- Leaving logs in can expose internal world logic to players who inspect their output files.
+
+**Recommended pattern**: Guard logs behind a serialized flag so you can toggle them from the Inspector without modifying code:
+
+```csharp
+[SerializeField] private bool _debugMode = false;
+
+private void Log(string message)
+{
+    if (_debugMode) Debug.Log(message);
+}
+```
+
+Set `_debugMode = false` on all behaviours before building for release.
+
+---
+
+## Testing Checklist
+
+Run through this checklist before publishing any world.
+
+### Ownership and Sync
+
+- [ ] All `[UdonSynced]` modifications are preceded by `Networking.IsOwner()` checks
+- [ ] All Manual-sync behaviours call `RequestSerialization()` after modifying synced fields
+- [ ] Ownership transfer (`Networking.SetOwner()`) is confirmed via `OnOwnershipTransferred` before writing synced state
+- [ ] No ownership fights: two scripts do not compete for ownership of the same object
+
+### Late Joiner Correctness
+
+- [ ] A player joining after world state has changed sees the current state (not initial defaults)
+- [ ] `OnDeserialization` correctly restores all derived local state from synced variables
+- [ ] Objects managed by `VRCObjectPool` show correct active/inactive state to late joiners
+- [ ] `PlayerData`/`PlayerObject` data is loaded before being read (use `OnPlayerRestored`)
+
+### Network Sync
+
+- [ ] Synced variables reflect changes on all clients within a few seconds
+- [ ] `SendCustomNetworkEvent` fires correctly on `NetworkEventTarget.All` and `NetworkEventTarget.Owner`
+- [ ] `[NetworkCallable]` methods (SDK 3.8.1+) receive correct parameters on all clients
+- [ ] No per-frame `RequestSerialization()` calls that could flood the network budget
+
+### Multi-User Interaction
+
+- [ ] Two players interacting with the same object simultaneously does not corrupt state
+- [ ] Master handoff (closing the master client) does not break world functionality
+- [ ] Ownership transfers complete without leaving objects in an unowned or double-owned state
+
+### Performance
+
+- [ ] No per-frame networking calls (`RequestSerialization`, `SendCustomNetworkEvent`) without throttling
+- [ ] `Debug.Log` calls removed or guarded behind a `_debugMode` flag set to `false`
+- [ ] No `Update()` loops that could be replaced with event-driven callbacks
+
+## See Also
+
+- [api.md](api.md) - VRCObjectPool API, VRCPlayerApi methods, and Camera Dolly API reference
+- [networking.md](networking.md) - Ownership model, sync modes, and RequestSerialization
+- [networking-antipatterns.md](networking-antipatterns.md) - Common networking mistakes and how to avoid them
+- [troubleshooting.md](troubleshooting.md) - Common errors and solutions
+- [events.md](events.md) - Complete event list including OnDeserialization and OnPlayerRestored

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -36,10 +36,9 @@ UdonSharpException: UdonSharp does not currently support [feature]
 | Generics `List<T>` | Arrays `T[]` or `DataList` |
 | LINQ | Manual loops |
 | `dynamic` | Explicit types |
-| `ref`/`out` parameters | Return values or class fields |
 | Multi-dimensional arrays `T[,]` | Jagged arrays `T[][]` |
 | Delegates / Events | `SendCustomEvent()` |
-| `nameof()` on external types | String literals |
+| `nameof()` on types from blocked namespaces (e.g., `System.Net.HttpWebRequest`) | String literals (`"HttpWebRequest"`); `nameof()` works normally for UdonSharp-compatible types and method/property names |
 | `try/catch/finally` | Validate inputs, null checks |
 
 **Solution:**

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -170,7 +170,7 @@ Do NOT assume the auto-generator is already installed. The agent cannot verify i
 Types that can be used with `[UdonSynced]`:
 
 `bool`, `byte`, `sbyte`, `char`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`,
-`float`, `double`, `string` (~50 character limit), `Vector2`, `Vector3`, `Vector4`,
+`float`, `double`, `string` (2 bytes/char; bounded by sync mode budget — keep short in Continuous), `Vector2`, `Vector3`, `Vector4`,
 `Quaternion`, `Color`, `Color32`, `T[]` (arrays of the above types)
 
 ## Validation Checklist

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -25,7 +25,7 @@ RequestSerialization();
 |------|----------------|-----------------|------------|
 | **NoVariableSync** | `BehaviourSyncMode.NoVariableSync` | No variable sync, events only | - |
 | **Continuous** | `BehaviourSyncMode.Continuous` | Automatic sync ~10Hz | ~200 bytes |
-| **Manual** | `BehaviourSyncMode.Manual` | Explicit sync via `RequestSerialization()` | ~282KB |
+| **Manual** | `BehaviourSyncMode.Manual` | Explicit sync via `RequestSerialization()` | ~280KB (280,496 bytes) |
 
 ### Continuous
 
@@ -60,8 +60,12 @@ Manual sync procedure: Acquire ownership -> Update synced variables -> `RequestS
 
 ## String Sync Limitations
 
-- Maximum length for synced strings: **~50 characters**
-- For longer data, consider splitting into chunks or using alternative approaches
+Synced `string` fields are encoded at 2 bytes/char. There is no separate per-string character limit; the practical limit depends on the sync mode's serialization budget:
+
+- **Continuous**: strings share the ~200-byte budget with all other synced fields on the behaviour. Keep synced strings short (a single short word or short code), as even a 20-character string consumes 40 bytes.
+- **Manual**: strings can be much larger within the ~280KB (280,496 byte) per-serialization limit.
+
+For longer data in Continuous mode, consider splitting across multiple fields or switching to Manual sync.
 
 ## NetworkCallable (SDK 3.8.1+)
 
@@ -196,7 +200,7 @@ public override void OnDeserialization()
 
 - [ ] Ownership verified/acquired before modifying synced variables
 - [ ] `RequestSerialization()` called for Manual sync
-- [ ] Synced strings are within 50 characters
+- [ ] Synced strings in Continuous sync are kept short (respect the ~200-byte shared budget; 2 bytes/char)
 - [ ] VRCPlayerApi validity checked
 - [ ] Works correctly for late joiners
 - [ ] NetworkCallable rate limits considered

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md
@@ -39,7 +39,7 @@ Estimate synced data volume before generating code.
 | `float` | 4 | Decimal values |
 | `Vector3` | 12 | Position |
 | `Quaternion` | 16 | Rotation |
-| `string` | ~50B limit | Text (keep short) |
+| `string` | 2 bytes/char | Text (keep short; Continuous budget is ~200B shared) |
 
 **Target**: < 50 bytes per behaviour
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -374,3 +374,14 @@ site:github.com/vrchat-community "issue keyword"
 | 3.8.1 | [NetworkCallable] |
 | 3.9.0 | Camera Dolly, Auto Hold |
 | 3.10.0 | Dynamics (PhysBones) |
+
+---
+
+## Reference Index
+
+| Topic | File |
+|-------|------|
+| Performance targets, Quest optimization checklist | [references/performance.md](references/performance.md) |
+| Lightmap settings, Quest bake parameter reference | [references/lighting.md](references/lighting.md) |
+| Pickup + Rigidbody template | [assets/templates/VRC_Pickup_Rigidbody.cs](assets/templates/VRC_Pickup_Rigidbody.cs) |
+| Station (sit) template | [assets/templates/VRC_Station_Basic.cs](assets/templates/VRC_Station_Basic.cs) |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -27,10 +27,10 @@ metadata:
 | ------------------------------------------ | -------------------------- | ------------------------------- |
 | [Scene Setup](#scene-setup)                | VRC_SceneDescriptor, Spawn | This file                       |
 | [Components](#components)                  | Pickup, Station, Mirror    | `references/components.md`      |
-| [Layers & Collision](#layers--collision)   | Layers, Collision Matrix   | `references/layers.md`          |
+| [Layers & Collision](#layers-collision)   | Layers, Collision Matrix   | `references/layers.md`          |
 | [Performance](#performance)                | Optimization guide         | `references/performance.md`     |
 | [Lighting](#lighting)                      | Lighting settings          | `references/lighting.md`        |
-| [Audio & Video](#audio--video)             | Audio, Video players       | `references/audio-video.md`     |
+| [Audio & Video](#audio-video)             | Audio, Video players       | `references/audio-video.md`     |
 | [World Upload](#world-upload)              | Upload workflow            | `references/upload.md`          |
 | [Troubleshooting](#troubleshooting)        | Problem solving            | `references/troubleshooting.md` |
 | [Cheatsheet](CHEATSHEET.md)               | Quick reference            | `CHEATSHEET.md`                 |
@@ -53,6 +53,7 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
 | 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
 | 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
+| 11 | Add VRC_UIShape to a Screen Space or Overlay Canvas | VRC_UIShape requires World Space Canvas; other modes throw a runtime Unity error in VRChat — the UI renders visually but is not interactive, with no visible error to the world builder | Set Canvas > Render Mode to World Space before adding VRC_UIShape |
 
 ## Reference Loading Guide
 
@@ -69,6 +70,22 @@ Load only what the task requires.
 | World upload and publish | `upload.md` | `troubleshooting.md` | `audio-video.md`, `lighting.md` |
 | Debugging collision or layer issues | `layers.md`, `troubleshooting.md` | `components.md` | `audio-video.md`, `lighting.md` |
 | Mirror setup and configuration | `components.md` | `performance.md` | `audio-video.md`, `upload.md` |
+
+## Before Starting a New World — Design Decisions
+
+These decisions shape every downstream choice. Make them first, before placing any component.
+
+| Decision | Options | Implication |
+|---|---|---|
+| **Quest required?** | Yes / No | Yes → Quest First philosophy applies from day 0, not as a retrofit |
+| **Expected player count?** | 1–8 / 9–40 / 40+ | Affects spawn count, mirror policy, max video players |
+| **Primary interaction?** | Grab (Pickup) / Sit (Station) / Watch (Video) / Explore | Determines which SDK components are mandatory |
+| **Lighting approach?** | Baked / Mixed / Realtime | Realtime is only viable on PC-only worlds; all lights must be baked before upload |
+| **Networked objects?** | None / Physics (Pickup+ObjectSync) / State (UdonSynced) | Determines sync architecture before Udon scripting begins |
+
+> **The most expensive mistake**: Designing for PC and adding Quest "later." By that point, lighting resolution, material complexity, and mesh density are locked. The Quest port then requires rebuilding the entire lighting and material pipeline.
+
+---
 
 ## Design Philosophy: Quest First
 
@@ -122,7 +139,7 @@ Exactly **one** is required in every VRChat world.
 | Property                        | Type        | Description                     | Default           |
 | ------------------------------- | ----------- | ------------------------------- | ------------------ |
 | **Spawns**                      | Transform[] | Array of spawn points           | Descriptor position |
-| **Spawn Order**                 | enum        | Sequential/Random/Demo          | Sequential         |
+| **Spawn Order**                 | enum        | Sequential/Random/Demo (Demo: all players to Spawns[0]) | Sequential |
 | **Respawn Height**              | float       | Respawn height (Y axis)         | -100               |
 | **Object Behaviour At Respawn** | enum        | Respawn/Destroy                 | Respawn            |
 | **Reference Camera**            | Camera      | Player camera settings reference | None              |
@@ -132,14 +149,6 @@ Exactly **one** is required in every VRChat world.
 | **Maximum Capacity**            | int         | Max player count (hard limit)   | -                  |
 | **Recommended Capacity**        | int         | Recommended player count (UI)   | -                  |
 
-#### Spawn Order Behavior
-
-```
-Sequential: 0 → 1 → 2 → 0 → 1 → 2... (in order)
-Random:     Random selection
-Demo:       All players spawn at Spawns[0]
-```
-
 #### Reference Camera Usage
 
 ```csharp
@@ -148,26 +157,22 @@ Demo:       All players spawn at Spawns[0]
 // 2. Apply Post Processing effects
 // 3. Set background color
 
-// Setup steps:
-// 1. Create a Camera (name: "ReferenceCamera")
-// 2. Adjust Camera component settings
-// 3. Disable the Camera (uncheck the component)
-// 4. Assign it to VRC_SceneDescriptor's Reference Camera
+// ⚠️ MUST disable the Camera component after configuring — an active Reference Camera
+//    renders a second viewport. VRChat reads only the camera settings, not its output.
+// Assign the configured (disabled) Camera to VRC_SceneDescriptor > Reference Camera.
 ```
 
 ### Spawn Points Setup
 
 ```csharp
-// Setup steps:
-// 1. Create an empty GameObject
-// 2. Set position and rotation (players face the Z+ direction)
-// 3. Add to the VRC_SceneDescriptor Spawns array
+// Spawn points are empty GameObjects assigned to VRC_SceneDescriptor > Spawns array.
+// Players enter facing the Z+ direction of the spawn Transform.
 
-// Recommendations:
-// - At least 2-3 spawn points (for simultaneous joins)
-// - Slightly above the floor (~0.1m)
-// - Clear of obstacles
-// - Account for VR player guardian boundaries
+// VRChat-specific requirements:
+// - At least 2-3 spawn points (for simultaneous joins — single spawn causes overlap)
+// - Place slightly above the floor (~0.1m) to avoid floor collision on spawn
+// - Keep clear of obstacles (VR player guardian area is larger than their avatar)
+// - Account for VR guardian boundaries — desktop player sizes differ from VR
 ```
 
 ### Required Setup Checklist
@@ -184,6 +189,9 @@ Demo:       All players spawn at Spawns[0]
 ---
 
 ## Components
+
+**MANDATORY READ** [`references/components.md`](references/components.md) (~800 lines) before configuring any VRC component below. Load in full — dependency requirements and Udon event hooks are distributed throughout.
+**Do NOT Load**: `references/audio-video.md`, `references/lighting.md`.
 
 | Component                  | Required Elements        | Purpose                        | SDK  |
 | -------------------------- | ------------------------ | ------------------------------ | ---- |
@@ -206,8 +214,6 @@ Demo:       All players spawn at Spawns[0]
 | State only / complex logic      | ❌             | ✅ Recommended       |
 
 > **SDK 3.8.0+**: `Force Kinematic On Remote` — Makes Rigidbody kinematic on non-owner clients, preventing unexpected physics behavior.
-
-**→ For detailed properties, Udon events, and code examples, see `references/components.md`**
 
 ---
 
@@ -236,7 +242,8 @@ Demo:       All players spawn at Spawns[0]
 4. Collision Matrix is automatically configured
 ```
 
-**→ For details, see `references/layers.md`**
+**MANDATORY READ** [`references/layers.md`](references/layers.md) when setting up collision or debugging physics. The default Unity collision matrix differs from the VRChat-correct one — always verify.
+**Do NOT Load**: `references/audio-video.md`, `references/upload.md`.
 
 ---
 
@@ -296,7 +303,8 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 **Never stack multiple changes before re-measuring** — you'll lose the ability to identify which change helped.
 
-**→ For details, see `references/performance.md`**
+**MANDATORY READ** [`references/performance.md`](references/performance.md) and [`references/lighting.md`](references/lighting.md) for Quest optimization. Run the profiling workflow above first to identify the bottleneck category before consulting references.
+**Do NOT Load**: `references/audio-video.md`, `references/upload.md`.
 
 ---
 
@@ -317,7 +325,8 @@ If FPS is below target, follow this workflow — measure before guessing:
 └── Excessive Reflection Probes
 ```
 
-**→ For details, see `references/lighting.md`**
+**MANDATORY READ** [`references/lighting.md`](references/lighting.md) when configuring lightmaps or light probe placement.
+**Do NOT Load**: `references/audio-video.md`, `references/upload.md`, `references/layers.md`.
 
 ---
 
@@ -342,7 +351,8 @@ If FPS is below target, follow this workflow — measure before guessing:
 | YouTube/Twitch     | ✅    | ❌          |
 | Quest support      | ✅    | ✅          |
 
-**→ For details, see `references/audio-video.md`**
+**MANDATORY READ** [`references/audio-video.md`](references/audio-video.md) for VRC_SpatialAudioSource or video player configuration.
+**Do NOT Load**: `references/lighting.md`, `references/performance.md`.
 
 ---
 
@@ -382,24 +392,66 @@ If FPS is below target, follow this workflow — measure before guessing:
 □ Capacity set
 ```
 
-**→ For details, see `references/upload.md`**
+**MANDATORY READ** [`references/upload.md`](references/upload.md) before running Build & Upload. Verify all pre-upload checklist items first.
+**Do NOT Load**: `references/audio-video.md`, `references/lighting.md`.
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
+### Diagnostic Router
 
-| Issue                           | Cause                      | Solution                   |
-| ------------------------------- | -------------------------- | -------------------------- |
-| Player walks through walls      | Wrong layer                | Set to Environment         |
-| Can't grab Pickup               | Missing Collider/Rigidbody | Add both                   |
-| Pickup doesn't sync             | Missing ObjectSync         | Add VRC_ObjectSync         |
-| Can't sit in Station            | Missing Collider           | Add Collider               |
-| Mirror doesn't reflect          | Layer settings             | Check MirrorReflection     |
-| Build error                     | Validation failure         | Check SDK Panel            |
+Identify the symptom category, then follow the diagnostic path:
 
-**→ For details, see `references/troubleshooting.md`**
+**Physics / Collision**
+- **Player walks through walls or floor**
+  1. Did you run "Setup Layers for VRChat"? (SDK > Builder tab)
+     - No → Run it. The default collision matrix blocks player↔environment collision.
+     - Yes → Is the geometry on the **Environment layer (11)**?
+       - No → Move all walkable surfaces, walls, and floors to layer 11.
+       - Yes → Open Physics > Layer Collision Matrix: Environment × Player row must be **ON**.
+- **Pickup passes through floors / walls**
+  → Pickup must be on **Pickup layer (13)**, not Default (0). In the collision matrix, Pickup × Environment must be ON.
+
+**Grab / Interaction**
+- **Can't grab Pickup at all**
+  1. Collider present? No → Add a Collider component.
+  2. Rigidbody present? No → Add a Rigidbody component.
+  3. VRC_Pickup component present? No → Add it.
+- **Pickup grabbed but immediately released**
+  → Check **DisallowTheft** on VRC_Pickup. If the current holder already owns it, a second grab may be blocked.
+
+**Sync / Network**
+- **Pickup position doesn't update for other players**
+  → Add **VRC_ObjectSync** (requires Rigidbody). Without it, only the local client moves the object.
+- **Pickup returns to original position on drop**
+  → Ownership is not being transferred. Verify VRC_Pickup or UdonSharp script calls `Networking.SetOwner` before moving.
+
+**Seated / Station**
+- **Can't sit in Station (no interaction prompt)**
+  → **VRC_Station requires a Collider** on the same or a child GameObject to register the interaction ray.
+- **Player clips into Station geometry after sitting**
+  → Adjust the **Station Collision Transform** field in the VRC_Station Inspector.
+
+**Mirror**
+- **Mirror doesn't reflect players or world**
+  → Open VRC_MirrorReflection > Layers. Must include: **Player (9)**, **PlayerLocal (10)**, **MirrorReflection (18)**, **Environment (11)**.
+- **Mirror causes severe FPS drop**
+  → Remove unnecessary layers from the Layers mask, and ensure **Mirror is OFF by default** (see NEVER #1).
+
+**Build / Upload**
+- **SDK build error in VRChat Control Panel**
+  → Builder tab lists all ⚠️ and ✖️ blockers with descriptions. Resolve each before building.
+- **"Missing script" on a UdonSharp component**
+  → The `.cs` file must have a matching `.asset` file. See the "missing .asset / script-asset pairing" rule in the `unity-vrc-udon-sharp` skill.
+
+**Editor / Runtime Discrepancy**
+- **World works in Unity Editor Play mode but fails or behaves differently in VRChat**
+  → Unity Play mode does not replicate all SDK behaviors. Use **"Build & Test New Build"** (SDK > Builder tab) — this launches the actual VRChat client locally. Editor Play is useful only for quick UdonSharp iteration.
+- **Interactive UI element is visible but cannot be clicked in VRChat**
+  → VRC_UIShape on a Screen Space or Overlay Canvas (see NEVER #11). Set Canvas > Render Mode to **World Space**.
+
+**MANDATORY READ** [`references/troubleshooting.md`](references/troubleshooting.md) only if the Diagnostic Router above did not resolve the issue. **Do NOT Load** for non-troubleshooting tasks.
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -416,44 +416,6 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 ---
 
-## Web Search
-
-### Official Documentation (WebSearch)
-
-```
-# Search official documentation
-WebSearch: "component or feature to look up site:creators.vrchat.com"
-```
-
-### Issue Investigation (WebSearch)
-
-```
-# Step 1: Forum search
-WebSearch:
-  query: "issue description site:ask.vrchat.com"
-  allowed_domains: ["ask.vrchat.com"]
-
-# Step 2: Known bug search
-WebSearch:
-  query: "issue description site:feedback.vrchat.com"
-  allowed_domains: ["feedback.vrchat.com"]
-
-# Step 3: GitHub Issues
-WebSearch:
-  query: "issue description site:github.com/vrchat-community"
-```
-
-### Official Resources
-
-| Resource          | URL                                   |
-| ----------------- | ------------------------------------- |
-| VRChat Creators   | https://creators.vrchat.com/worlds/   |
-| VRChat Forums     | https://ask.vrchat.com/               |
-| VRChat Canny      | https://feedback.vrchat.com/          |
-| SDK Release Notes | https://creators.vrchat.com/releases/ |
-
----
-
 ## Templates (`assets/templates/`)
 
 Starter templates for common SDK component patterns. Each template compiles without modification; adjust Inspector fields and extend the event stubs for your world.

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -381,6 +381,15 @@ WebSearch:
 
 ---
 
+## Templates (`assets/templates/`)
+
+Starter templates for common SDK component patterns. Each template compiles without modification; adjust Inspector fields and extend the event stubs for your world.
+
+| Template | Purpose |
+|---|---|
+| `VRC_Pickup_Rigidbody.cs` | VRC_Pickup with Rigidbody — OnPickup/OnDrop/OnPickupUseDown/OnPickupUseUp events, ownership transfer, audio feedback |
+| `VRC_Station_Basic.cs` | VRC_Station controller — OnStationEntered/OnStationExited events, PlayerMobility, force-eject API |
+
 ## References
 
 | File                            | Content                   | Approx. Lines |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -37,6 +37,52 @@ metadata:
 
 ---
 
+## Common Mistakes (NEVER List)
+
+These cause silent world failures, performance disasters, or Quest incompatibility:
+
+| # | NEVER do this | Why it hurts | Use instead |
+|---|---------------|-------------|-------------|
+| 1 | Enable Mirror by default (active on world join) | Renders the entire scene twice — immediate FPS halving, catastrophic on Quest | Default Mirror OFF; add UdonSharp toggle or player-triggered activation |
+| 2 | Use realtime directional lights with real-time shadows | Quest has no hardware shadow acceleration; each shadow caster costs 10-30 FPS | Baked lightmaps + light probes; set lights to Baked or Mixed mode |
+| 3 | Set Respawn Height at or above the world floor | Player respawns → falls → respawns again → infinite loop; players cannot recover | Set to an unreachable depth (e.g., floor at Y=0 → Respawn at Y=-100) |
+| 4 | Skip "Setup Layers for VRChat" on a new project | Layer collision matrix is wrong by default — players walk through walls, Pickups clip floors | Run VRChat SDK > Builder > "Setup Layers for VRChat" before placing any colliders |
+| 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile or guard assets with `#if UNITY_ANDROID` |
+| 6 | Place more than 2 active video players simultaneously | Each player adds significant decoding overhead; running >2 simultaneously is a common cause of frame drops and audio issues in practice | Disable extra players at scene start; activate only the currently playing one |
+| 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use Animator-driven transforms (no constraints) or remove cloth from Quest meshes |
+| 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
+| 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
+| 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
+
+## Reference Loading Guide
+
+Load only what the task requires.
+
+| Task | MANDATORY READ | Optional | Do NOT Load |
+|------|---------------|----------|-------------|
+| Setting up a new scene from scratch | `components.md`, `layers.md` | `upload.md` | `audio-video.md`, `troubleshooting.md` |
+| Making objects grabbable (VRC_Pickup) | `components.md` | `layers.md` | `audio-video.md`, `lighting.md` |
+| Setting up seating (VRC_Station) | `components.md` | `layers.md` | `audio-video.md`, `performance.md` |
+| Optimizing FPS for Quest | `performance.md`, `lighting.md` | `troubleshooting.md` | `audio-video.md`, `upload.md` |
+| Adding audio or video player | `audio-video.md`, `components.md` | `troubleshooting.md` | `lighting.md`, `performance.md` |
+| Baking lights / lightmap setup | `lighting.md`, `performance.md` | — | `audio-video.md`, `layers.md` |
+| World upload and publish | `upload.md` | `troubleshooting.md` | `audio-video.md`, `lighting.md` |
+| Debugging collision or layer issues | `layers.md`, `troubleshooting.md` | `components.md` | `audio-video.md`, `lighting.md` |
+| Mirror setup and configuration | `components.md` | `performance.md` | `audio-video.md`, `upload.md` |
+
+## Design Philosophy: Quest First
+
+**Build for Quest and get PC for free. Build for PC and Quest becomes a separate project.**
+
+Quest (Meta Quest 2/3/Pro) defines the performance budget:
+- **CPU/GPU**: ~2× slower than PC VR; tile-based GPU with no hardware shadow maps
+- **VRAM**: ~4 GB shared with OS (vs 6–12 GB on PC); no HDR framebuffer
+- **Thermal throttling**: Sustained 100% GPU load causes clock reduction within minutes
+
+If a world runs at 72 FPS on Quest with a single test client, it will typically run at 90+ FPS on PC — though results vary by shader complexity, CPU-bound workloads, and hardware differences. The converse rarely holds. Verify against the [official VRChat optimization documentation](https://creators.vrchat.com/worlds/udon/performance-and-optimization/) before publishing.
+
+**NEVER optimize exclusively for PC with "Quest support added later"** — by that point, lighting, materials, and mesh density are all locked to PC quality, and the Quest port requires rebuilding everything.
+
 ## SDK Versions
 
 **Supported versions**: SDK 3.7.1 - 3.10.2 (as of March 2026)
@@ -222,6 +268,33 @@ Demo:       All players spawn at Spawns[0]
 | Post-Processing    | ✅  | ❌ Disabled   |
 | Unity Constraints  | ✅  | ❌ Disabled   |
 | Realtime lights    | ✅  | ⚠️ Avoid     |
+
+### Performance Optimization Workflow
+
+If FPS is below target, follow this workflow — measure before guessing:
+
+```
+1. Measure
+   ├── Unity Profiler: standard profiling in Play mode (primary; Deep Profile only for function-level deep dives — avoid on Quest, misleading results)
+   ├── VRChat overlay: type "/perf" in-game
+   └── Stats window: Draw Calls, Triangles, VRAM
+
+2. Identify bottleneck category
+   ├── CPU-bound (high Draw Calls): → Batching / LOD / Culling / Static flags
+   ├── GPU-bound (shader cost): → Mirror / Realtime lights / Post-Processing
+   ├── Memory (VRAM spikes): → Reduce texture resolution / video players
+   └── Physics: → Disable Rigidbodies / Cloth / Constraints on Quest
+
+3. Fix largest impact first, re-measure after each change
+   (estimates below are typical ranges; actual gains vary by world complexity)
+   Mirror ON by default    → Disable by default               (often -40-50% render cost)
+   Realtime shadows        → Bake all lights                  (often -30-50% GPU cost)
+   High lightmap resolution → Reduce and re-profile           (often -30-70% VRAM)
+   Unbatched static objects → Mark as Static + enable batching (often -30-60% draw calls)
+   Many active particles   → Pool; disable off-screen          (often -10-20% CPU)
+```
+
+**Never stack multiple changes before re-measuring** — you'll lose the ability to identify which change helped.
 
 **→ For details, see `references/performance.md`**
 

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
@@ -1,0 +1,181 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.Udon; // Kept for consistency with other UdonSharp templates; not directly referenced here.
+
+/// <summary>
+/// Template for a UdonSharpBehaviour attached to a GameObject with VRC_Pickup and Rigidbody.
+///
+/// Requirements:
+///   - This GameObject MUST have a Rigidbody component (VRC_Pickup will not work without it).
+///   - This GameObject MUST have a Collider component (required for Interact detection).
+///   - Add VRC_ObjectSync if you want position/physics to sync automatically across players.
+///     Without VRC_ObjectSync, ownership is NOT transferred automatically on pickup — you must
+///     call Networking.SetOwner() explicitly (done in OnPickup below). Add [UdonSynced] variables
+///     and call RequestSerialization() in OnPickup for custom sync behaviour
+///     (BehaviourSyncMode.Manual is already set for this).
+///
+/// Sync mode note:
+///   BehaviourSyncMode.Manual is used so that synced variables (if you add any) are
+///   serialised on demand via RequestSerialization. If you add VRC_ObjectSync and have
+///   no UdonSynced variables, you can safely switch to BehaviourSyncMode.None instead.
+///
+/// Ownership note:
+///   VRC_ObjectSync automatically transfers ownership to the grabbing player on pickup.
+///   Without VRC_ObjectSync, ownership is NOT transferred automatically — Networking.SetOwner
+///   is called in OnPickup to handle this case explicitly.
+///
+/// Usage:
+///   1. Add this script, VRC_Pickup, Rigidbody, Collider, and (optionally) VRC_ObjectSync
+///      to the same GameObject.
+///   2. Assign optional audio sources in the Inspector.
+///   3. Override OnPickupUseDown / OnPickupUseUp to implement custom use behaviour.
+/// </summary>
+[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+public class VRC_Pickup_Rigidbody : UdonSharpBehaviour
+{
+    [Header("Audio Feedback")]
+    [Tooltip("Audio source used for pickup and drop sounds")]
+    public AudioSource audioSource;
+
+    [Tooltip("Sound played when the object is picked up")]
+    public AudioClip pickupSound;
+
+    [Tooltip("Sound played when the object is dropped")]
+    public AudioClip dropSound;
+
+    [Tooltip("Sound played when the Use button is pressed while holding")]
+    public AudioClip useSound;
+
+    [Header("Debug")]
+    [Tooltip("Enable debug logging to the Unity console")]
+    public bool debugMode = false;
+
+    // Cached VRC_Pickup component — retrieved once in Start() to avoid repeated GetComponent calls.
+    private VRC_Pickup _pickup;
+
+    // [UdonSynced] private bool _isSynced; // Add UdonSynced fields here if needed, then call RequestSerialization() after changing them.
+
+    // -------------------------------------------------------------------------
+    // Unity lifecycle
+    // -------------------------------------------------------------------------
+
+    private void Start()
+    {
+        _pickup = (VRC_Pickup)GetComponent(typeof(VRC_Pickup));
+    }
+
+    // -------------------------------------------------------------------------
+    // VRC_Pickup events
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Called on the local player when they pick up this object.
+    /// If VRC_ObjectSync is present, ownership has already been transferred automatically.
+    /// If VRC_ObjectSync is absent, the SetOwner call below performs the transfer explicitly.
+    /// </summary>
+    public override void OnPickup()
+    {
+        // Explicit ownership transfer — required when VRC_ObjectSync is NOT present,
+        // because VRC_Pickup alone does NOT auto-transfer ownership on grab.
+        // Safe to leave in even when ObjectSync is present (the condition makes it a no-op).
+        if (!Networking.IsOwner(gameObject))
+        {
+            Networking.SetOwner(Networking.LocalPlayer, gameObject);
+        }
+
+        PlaySound(pickupSound);
+        LogDebug("OnPickup: picked up by " + GetLocalPlayerName());
+    }
+
+    /// <summary>
+    /// Called on the local player when they drop this object.
+    /// Ownership is NOT automatically transferred away on drop — the last holder
+    /// remains owner until another player picks it up.
+    /// </summary>
+    public override void OnDrop()
+    {
+        PlaySound(dropSound);
+        LogDebug("OnDrop: dropped by " + GetLocalPlayerName());
+    }
+
+    /// <summary>
+    /// Called when the local player presses the Use button while holding this object.
+    /// On desktop this is the left mouse button; in VR this is the trigger.
+    /// NOTE: VRC_Pickup.AutoHold must be set to "Yes" for this event to fire on desktop.
+    /// </summary>
+    public override void OnPickupUseDown()
+    {
+        PlaySound(useSound);
+        LogDebug("OnPickupUseDown");
+
+        // Add your Use-button logic here.
+        // To broadcast an effect to all players, use SendCustomNetworkEvent:
+        //   SendCustomNetworkEvent(VRC.Udon.Common.Interfaces.NetworkEventTarget.All, "OnUsed");
+        //   (Replace "OnUsed" with the actual name of your public networked method.)
+    }
+
+    /// <summary>
+    /// Called when the local player releases the Use button while holding this object.
+    /// NOTE: VRC_Pickup.AutoHold must be set to "Yes" for this event to fire on desktop.
+    /// </summary>
+    public override void OnPickupUseUp()
+    {
+        LogDebug("OnPickupUseUp");
+
+        // Add your Use-button release logic here.
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Forcibly drops the pickup from the local player's hand.
+    /// Has no effect if this player is not currently holding the object.
+    /// </summary>
+    public void ForceDropPickup()
+    {
+        if (_pickup != null)
+        {
+            _pickup.Drop();
+            LogDebug("ForceDropPickup called");
+        }
+    }
+
+    /// <summary>
+    /// Returns whether the local player is currently holding this pickup.
+    /// </summary>
+    public bool IsHeld()
+    {
+        if (_pickup == null) return false;
+        return _pickup.IsHeld;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void PlaySound(AudioClip clip)
+    {
+        if (audioSource != null && clip != null)
+        {
+            audioSource.PlayOneShot(clip);
+        }
+    }
+
+    private string GetLocalPlayerName()
+    {
+        VRCPlayerApi localPlayer = Networking.LocalPlayer;
+        if (localPlayer == null || !localPlayer.IsValid()) return "Unknown";
+        return localPlayer.displayName;
+    }
+
+    private void LogDebug(string message)
+    {
+        if (debugMode)
+        {
+            Debug.Log("[VRC_Pickup_Rigidbody:" + gameObject.name + "] " + message);
+        }
+    }
+}

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs
@@ -1,0 +1,203 @@
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+using VRC.Udon;
+
+/// <summary>
+/// Template for controlling a VRC_Station component from UdonSharp.
+///
+/// Requirements:
+///   - This GameObject MUST have a Collider (required for Interact to fire).
+///   - Add a VRC_Station component to the same or a child GameObject.
+///
+/// Station behaviour notes:
+///   - OnStationEntered and OnStationExited fire on ALL clients for any player
+///     who enters or exits the station.
+///   - Disable Station Exit prevents the default exit gesture; you must call
+///     station.ExitStation(player) manually from Udon to release the player.
+///   - ImmobilizeForVehicle: Use this mobility mode when the station is on a
+///     moving platform (e.g. vehicle). The player view follows the station transform.
+///   - Real-time lights and post-processing are unavailable on Quest — ensure
+///     any visual effects triggered here use baked or lightweight alternatives.
+///
+/// Sync mode note:
+///   BehaviourSyncMode.None is intentional — this script has no UdonSynced
+///   variables. All state tracking (_isOccupied) is local-only; see the field
+///   comment below for late-joiner implications.
+///
+/// Usage:
+///   1. Add this script, a Collider, and VRC_Station to the same GameObject.
+///   2. Assign the stationComponent field in the Inspector.
+///   3. Optionally set PlayerMobility in the Inspector to control movement.
+///   4. Extend OnStationEntered / OnStationExited with your world logic.
+/// </summary>
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+public class VRC_Station_Basic : UdonSharpBehaviour
+{
+    [Header("Station Reference")]
+    [Tooltip("VRC_Station component to control. Must be on the same or a child GameObject.")]
+    public VRCStation stationComponent;
+
+    [Header("Mobility Settings")]
+    [Tooltip(
+        "Mobile = player can move freely.\n" +
+        "Immobilize = player is fixed at the entry point (chairs, benches).\n" +
+        "ImmobilizeForVehicle = fixed, but view follows the station (vehicles).")]
+    public VRCStation.Mobility playerMobility = VRCStation.Mobility.Immobilize;
+
+    [Header("Audio Feedback")]
+    [Tooltip("Audio source for enter and exit sounds")]
+    public AudioSource audioSource;
+
+    [Tooltip("Sound played when any player enters this station")]
+    public AudioClip enterSound;
+
+    [Tooltip("Sound played when any player exits this station")]
+    public AudioClip exitSound;
+
+    [Header("Debug")]
+    [Tooltip("Enable debug logging to the Unity console")]
+    public bool debugMode = false;
+
+    // Tracks whether a player is currently in this station (local approximation only).
+    // This value is NOT synced across the network. Late-joining players always start
+    // with _isOccupied = false and will only see the correct state after the next
+    // OnStationEntered/OnStationExited event fires.
+    // To persist occupancy state for late joiners, add:
+    //   [UdonSynced] private bool _isOccupiedSynced;
+    // and call RequestSerialization() inside OnStationEntered/OnStationExited.
+    // Switch BehaviourSyncMode to Manual when adding UdonSynced variables.
+    private bool _isOccupied = false;
+
+    // -------------------------------------------------------------------------
+    // Unity lifecycle
+    // -------------------------------------------------------------------------
+
+    private void Start()
+    {
+        // Apply the configured mobility mode to the station at startup.
+        if (stationComponent != null)
+        {
+            stationComponent.PlayerMobility = playerMobility;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // VRChat interaction (seat the local player on Interact)
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Called when the local player interacts with (clicks) this object.
+    /// Seats the local player in the station.
+    /// </summary>
+    public override void Interact()
+    {
+        if (stationComponent == null)
+        {
+            LogDebug("Interact: stationComponent is not assigned");
+            return;
+        }
+
+        VRCPlayerApi localPlayer = Networking.LocalPlayer;
+        if (localPlayer == null || !localPlayer.IsValid()) return;
+
+        stationComponent.UseStation(localPlayer);
+        LogDebug("Interact: " + localPlayer.displayName + " entering station");
+    }
+
+    // -------------------------------------------------------------------------
+    // VRC_Station events
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Called on ALL clients when any player enters this station.
+    /// Use player.isLocal to distinguish the sitting player from observers.
+    /// </summary>
+    public override void OnStationEntered(VRCPlayerApi player)
+    {
+        if (player == null || !player.IsValid()) return;
+
+        _isOccupied = true;
+        PlaySound(enterSound);
+        LogDebug("OnStationEntered: " + player.displayName + " (local=" + player.isLocal + ")");
+
+        // Add your on-enter logic here.
+        // Example: disable the Interact prompt while occupied
+        //   DisableInteractive = true;
+    }
+
+    /// <summary>
+    /// Called on ALL clients when any player exits this station.
+    /// </summary>
+    public override void OnStationExited(VRCPlayerApi player)
+    {
+        if (player == null || !player.IsValid()) return;
+
+        _isOccupied = false;
+        PlaySound(exitSound);
+        LogDebug("OnStationExited: " + player.displayName + " (local=" + player.isLocal + ")");
+
+        // Add your on-exit logic here.
+        // Example: re-enable the Interact prompt
+        //   DisableInteractive = false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Ejects the specified player from this station.
+    /// Call this to force-exit a player when Disable Station Exit is enabled.
+    /// </summary>
+    public void EjectPlayer(VRCPlayerApi player)
+    {
+        if (stationComponent == null || player == null || !player.IsValid()) return;
+        stationComponent.ExitStation(player);
+        LogDebug("EjectPlayer: ejecting " + player.displayName);
+    }
+
+    /// <summary>
+    /// Changes the mobility mode at runtime.
+    /// Must be called before the player enters for it to take effect.
+    /// </summary>
+    public void SetMobility(VRCStation.Mobility mobility)
+    {
+        playerMobility = mobility;
+        if (stationComponent != null)
+        {
+            stationComponent.PlayerMobility = mobility;
+        }
+        LogDebug("SetMobility: " + mobility.ToString());
+    }
+
+    /// <summary>
+    /// Returns whether any player is currently in this station.
+    /// This is a local approximation based on received events and may be
+    /// briefly inconsistent for late-joining players.
+    /// </summary>
+    public bool IsOccupied()
+    {
+        return _isOccupied;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void PlaySound(AudioClip clip)
+    {
+        if (audioSource != null && clip != null)
+        {
+            audioSource.PlayOneShot(clip);
+        }
+    }
+
+    private void LogDebug(string message)
+    {
+        if (debugMode)
+        {
+            Debug.Log("[VRC_Station_Basic:" + gameObject.name + "] " + message);
+        }
+    }
+}

--- a/skills/unity-vrc-world-sdk-3/references/lighting.md
+++ b/skills/unity-vrc-world-sdk-3/references/lighting.md
@@ -285,6 +285,120 @@ Recommended shaders:
 | Reflection Probe Res | 256 | 128 |
 | Realtime Lights | 0-1 | 0 |
 
+---
+
+## Quest Bake Parameter Reference
+
+Detailed recommended parameters for baking lightmaps targeting Quest/Android. These supplement the Quick Reference table with rationale and acceptable ranges.
+
+### Lightmap Resolution: PC vs Quest
+
+| Setting | PC | Quest | Why |
+|---|---|---|---|
+| Lightmap Resolution | 10–20 texels/unit | **5–10 texels/unit** | Lower resolution keeps lightmap textures within 1024×1024 and reduces build size |
+| Max Lightmap Size | 2048×2048 | **1024×1024** | Quest GPU memory is limited; oversized lightmaps cause stuttering and load failures |
+| Directional Mode | Directional or Non-Directional | **Non-Directional (required)** | Directional mode stores an extra texture per lightmap; not worth the cost on Quest |
+| Compress Lightmaps | Optional | **Required** | Uncompressed lightmaps can exceed the 100 MB Android build limit |
+
+> If your world still looks dark or blurry at 5 texels/unit, increase to 10 before raising Max Size.
+> Raising resolution is cheaper in quality terms; raising size increases memory consumption more.
+
+### Bounce Count
+
+Bounces control how many times indirect light reflects off surfaces. More bounces improve realism but increase bake time and can add unwanted light bleed.
+
+| Platform | Recommended Bounces | Notes |
+|---|---|---|
+| Quest | **2–3** | Sufficient for enclosed interiors; 2 is often enough outdoors (approximate guideline — adjust based on profiling) |
+| PC | 3–4 | Use 4 only for complex interiors with many reflective surfaces (approximate guideline — adjust based on profiling) |
+
+In Unity Lighting Settings:
+```text
+Window > Rendering > Lighting > Lightmapping Settings
+└── Indirect Bounces: 2  (Quest)  /  3  (PC)
+```
+
+### Baked vs Mixed Lighting: Quest Guidance
+
+On Quest, **Baked lighting is strongly preferred over Mixed**. Use this decision guide:
+
+```text
+Does the world have any moving lights or real-time shadows?
+├── Yes → Is this required? (gameplay mechanic, not just aesthetics)
+│   ├── Yes → Use Mixed (PC only); remove or replace with Baked on Android build
+│   └── No  → Switch to Baked and use light probes for dynamics
+└── No  → Use Baked for everything
+```
+
+| Mode | Quest Support | Notes |
+|---|---|---|
+| **Baked** | Full support | Required for Quest builds; zero runtime cost |
+| **Mixed (Subtractive)** | Partial support | Shadowmask not fully supported; avoid |
+| **Mixed (Shadowmask)** | Not recommended | Extra memory, inconsistent shadow behaviour |
+| **Realtime** | Avoid | No shadow support on Quest; significant GPU cost even without shadows |
+
+Practical rule: **convert all Mixed lights to Baked before the Android build**. Use the Platform Override workflow (Unity Build Settings → Android) to maintain separate PC and Quest lighting if needed.
+
+### Baked Ambient Occlusion
+
+Baked AO adds depth cues where surfaces meet, at zero runtime cost. Screen-space AO (SSAO) is unavailable on Quest.
+
+```text
+Window > Rendering > Lighting > Lightmapping Settings
+
+Recommended settings for Quest:
+├── Ambient Occlusion: ✓ Enabled
+├── Max Distance:       1.0–2.0 m  (larger = broader but softer AO)
+├── Indirect AO:        0.5–1.0
+└── Direct AO:          0 (default — direct AO can look artificial)
+
+PC can use higher Max Distance (2–3 m) for richer results.
+```
+
+> Baked AO is included in the base lightmap texture — no extra textures or memory.
+> Enable it for all Quest builds without hesitation.
+
+### Light Probe Density (Quest)
+
+Light probes provide baked lighting influence to dynamic objects (players, pickups). More probes improve quality; excessive probes increase bake time and CPU cost.
+
+| Area Type | Quest Recommended Spacing | Notes |
+|---|---|---|
+| Narrow corridors | 2–3 m intervals | Players fill most of the space |
+| Open indoor areas | 3–4 m intervals | Sufficient for smooth transitions |
+| Light/shadow boundaries | ≤ 1 m intervals | Tight clustering prevents hard edges |
+| Outdoor areas | 4–6 m intervals | Light varies slowly outdoors |
+
+Vertical placement: place probes at multiple heights (floor level ~0.5 m, mid-body ~1.5 m, head ~2 m) to capture the full player silhouette.
+
+### Reflection Probe Settings (Quest)
+
+| Setting | Quest Recommended | Notes |
+|---|---|---|
+| Type | **Baked** | Realtime probes re-render every frame — avoid on Quest |
+| Resolution | **128** | 256 is acceptable for hero areas only |
+| HDR | Disabled | Saves ~50% reflection texture memory; enable only for hero areas with highly reflective metallic or glossy surfaces that require HDR reflections |
+| Box Projection | Only when needed | Adds overdraw; use only in box-shaped rooms |
+
+Aim for one probe per enclosed room and one large probe outdoors. Avoid overlapping more than 2–3 probes in any one area.
+
+---
+
+## Lighting Workflow Summary: PC vs Quest
+
+```text
+PC Build                           Quest/Android Build
+────────────────────────────────   ──────────────────────────────────
+Resolution: 10–20 texels/unit      Resolution: 5–10 texels/unit
+Max Size:   2048×2048              Max Size:   1024×1024
+Bounces:    3–4                    Bounces:    2–3
+Direction:  Directional (opt.)     Direction:  Non-Directional (required)
+Compress:   Optional               Compress:   Required
+AO:         Optional (baked)       AO:         Baked only (no SSAO)
+Refl. res:  256                    Refl. res:  128
+Lights:     Mixed or Baked         Lights:     Baked only
+```
+
 ## See Also
 
 - [performance.md](performance.md) - Overall performance targets and Quest optimization checklist that governs lighting budgets

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -413,7 +413,7 @@ In-game checks:
 Cross-platform worlds (PC + Quest) require stricter constraints on the Quest/Android build.
 These limits apply to the Android build target and are enforced at upload time or at runtime.
 
-Reference: https://creators.vrchat.com/worlds/udon/
+Reference: https://creators.vrchat.com/platforms/android/quest-content-optimization
 
 ### Hard Limits
 
@@ -421,7 +421,7 @@ Reference: https://creators.vrchat.com/worlds/udon/
 |-----------|-------|-------|
 | World build size (compressed) | 100 MB max | Aim for 5–8 MB in practice |
 | Texture resolution | 1024×1024 recommended max | Higher resolutions increase memory and load time |
-| Custom shaders | Not supported | Standard or Mobile shaders only |
+| Custom shaders | Supported with caution | Custom shaders are allowed for worlds; use mobile-compatible shaders to avoid GPU overload. Avatars are restricted to VRChat Mobile shaders. |
 | Post-processing effects | Not supported | Bloom, depth of field, color grading unavailable |
 | Real-time shadows | Not supported | Baked lighting only |
 | Video player (AVPro) | Not supported | Use Unity Video Player component instead |
@@ -430,7 +430,7 @@ Reference: https://creators.vrchat.com/worlds/udon/
 ### Features Not Available on Quest
 
 ```
-❌ Custom shaders (HLSL/ShaderLab beyond Mobile subset)
+⚠️ Custom shaders (worlds only: allowed with caution; avoid complex HLSL/ShaderLab features that stress the mobile GPU. Avatar shaders are restricted to VRChat Mobile shaders.)
 ❌ Post-processing stack (any effect)
 ❌ Real-time shadow casting and receiving
 ❌ AVPro video player
@@ -656,6 +656,76 @@ Verify all items below before uploading a Quest-compatible world build.
 □ All interactive elements (pickups, triggers) work correctly on Quest
 □ No crashes or memory warnings during extended play session
 ```
+
+---
+
+## World Performance Rating
+
+VRChat does **not** have a formal in-client performance ranking system for worlds (unlike avatars which display Excellent/Good/Medium/Poor badges). There is no SDK-enforced ranking threshold that blocks world uploads based on polygon count or draw calls.
+
+In practice, use the **FPS tiers** at the top of this document as the pass/fail criteria, and apply the Quest/Android hard limits below as mandatory constraints.
+
+### Official World Triangle Budget (Quest)
+
+From the official Android Content Optimization documentation:
+<https://creators.vrchat.com/platforms/android/android-content-optimization/>
+
+```text
+Total world triangle budget (Quest/Android): ~250,000 triangles
+```
+
+> This is the official guideline figure. The 200K hard cap listed in the Mesh Optimization
+> section above is a conservative community target; 250K is the documented upper boundary.
+> Staying within 50K–100K provides the best frame rate headroom for worlds with many players.
+
+### Per-Object Polygon Guidelines (Quest)
+
+These are approximate guidelines based on community practice and the official optimization guide:
+<https://creators.vrchat.com/platforms/android/android-content-optimization/>
+
+| Object Category | Triangle Target | Notes |
+|---|---|---|
+| Hero / focal interactive objects | ≤ 5,000 | Pickups, NPCs, key props |
+| Background / decorative objects | ≤ 1,000 | Furniture, environmental details |
+| Ground / floor planes | Minimal subdivision | Avoid dense meshes; bake detail into textures |
+| Total scene (ideal) | 50K–100K | Leaves headroom for players and avatars |
+| Total scene (upper limit) | ~250K | Official documented budget |
+
+### Draw Call Targets (Quest)
+
+No hard SDK limit exists for draw calls. The targets below are community-derived approximate
+guidelines, not official VRChat thresholds. Verify current recommendations against the
+official documentation: <https://creators.vrchat.com/platforms/android/android-content-optimization/>
+
+> These are community-derived approximate guidelines, not official VRChat thresholds.
+
+| Tier | Draw Calls | Expected Result |
+|---|---|---|
+| Excellent | < 50 | Stable 72 FPS with multiple players |
+| Acceptable | 50–100 | Achievable with batching and instancing |
+| Problematic | > 100 | Frame rate drops; optimization required |
+
+Reduce draw calls with Static Batching, GPU Instancing, and texture atlasing (see Draw Call Reduction section above).
+
+### Texture Compression Format (Quest)
+
+Quest uses the Qualcomm Adreno GPU, which natively supports **ASTC** (Adaptive Scalable Texture Compression). Always override textures to ASTC for the Android platform:
+
+```
+Inspector → Texture → Android override:
+├── Format: ASTC 6x6 block  (diffuse, albedo — good quality/size balance)
+├── Format: ASTC 4x4 block  (UI, normal maps — higher quality)
+└── Format: ASTC 8x8 block  (distant/minor textures — smaller size)
+
+ETC2 is the fallback when ASTC is unavailable. Prefer ASTC for all new content.
+```
+
+### Lightmap Resolution and Size (Quest)
+
+For detailed lightmap resolution and size recommendations (texels/unit, max size, directional mode, compression, AO settings), see:
+
+- **[Baked Lighting Workflow for Quest](#baked-lighting-workflow-for-quest)** — full settings table in this file
+- **[references/lighting.md — Quest Bake Parameter Reference](lighting.md#quest-bake-parameter-reference)** — rationale, acceptable ranges, and Baked vs Mixed decision guide
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Merge dev into main for npm release.

### Changes since v1.5.1

- feat(skills): skill-judge Loop 3 — A grade optimization for both VRC skills (#146)
  - world-sdk-3: 93→108/120 (C+→A); udon-sharp: 104→108/120 (B+→A)
  - world-sdk-3: 7-category Diagnostic Router Tree, MANDATORY READ triggers, Before Starting decision table
  - udon-sharp: "Before Writing Network Code" design-time frame, NEVER #17/#18
- refactor(skills): trim dead-weight content and add sync debugging tree (#144)
- feat(skills): skill-judge score improvements — NEVER lists, reference loading guide, performance workflow (#143)
- feat(skills): Phase 4 final polish — CHEATSHEET sync, ProximityDetector optimization, networking guides (#142)
- feat(udon-sharp): add Camera Dolly API, VRCObjectPool details, and testing guide (#141)
- feat(world-sdk): add VRC_Pickup/Station templates and Quest optimization guidance (#140)
- fix(udon-sharp): resolve documentation contradictions in constraints and networking rules (#139)
- fix(installer): mark unity-vrc-skills-renovator as internal (#133)
- fix(udon-sharp): enforce mandatory auto-generator check (#130)

## Test plan

- [ ] CI passes (Symlink Integrity, Hook Scripts, EditorConfig, npm Pack Test, Markdown Links)
- [ ] CodeRabbit approves
- [ ] After merge: Release Drafter creates draft → publish to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)