### PR TITLE
docs(skills): SDK 3.10.3 bug-fix notes — marker convention + station-collision flip

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -8,6 +8,14 @@ Step-by-step guide for upgrading UdonSharp worlds across major SDK versions.
 > New world uploads are no longer possible with those versions.
 > Worlds that have not yet migrated past 3.9.0 must update to continue publishing.
 
+## Version markers
+
+Version-specific notes in this skill use three marker forms. Match them verbatim when adding new annotations:
+
+- `(requires SDK X.Y.Z+)` — feature gate. The API, attribute, or component exists only from that version onward.
+- `(fixed in SDK X.Y.Z)` — a bug that existed in earlier SDKs is resolved starting with this version.
+- `(unresolved as of SDK X.Y.Z)` — a bug is still open in this version. Include a tracking link (canny, GitHub issue) when available.
+
 ---
 
 ## SDK 3.7.x to 3.8.x

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -728,7 +728,7 @@ public override void OnContactEnter(ContactEnterInfo info)
 
 When a player sits in a VRCStation, the **PlayerLocal (Layer 10) capsule collider is effectively disabled**. This causes `OnPlayerTriggerEnter`, `OnPlayerTriggerExit`, and `OnPlayerTriggerStay` to **not fire** for seated players.
 
-This is a [known long-standing issue](https://vrchat.canny.io/sdk-bug-reports/p/playerlocal-collision-should-remain-on-players-in-stations). As of SDK 3.10.2, no fix has been released.
+This is a [known long-standing issue](https://vrchat.canny.io/sdk-bug-reports/p/playerlocal-collision-should-remain-on-players-in-stations) (unresolved as of SDK 3.10.3).
 
 ### Symptoms
 


### PR DESCRIPTION
## Summary

Sub-issue B of parent #148 — small, focused docs work introducing the 3-marker version convention and applying it to existing tracked bugs. **2 commits, 2 files, +9/-1.**

## Changes

| Commit | Scope |
|--------|-------|
| `328e3ac` | `docs(udon-sharp)` — Add **version-marker convention** to `sdk-migration.md` (top of file, after "Applies to" / deprecation notice, before first `---` divider). Three markers: `(requires SDK X.Y.Z+)` for feature gates, `(fixed in SDK X.Y.Z)` for past bugfixes, `(unresolved as of SDK X.Y.Z)` for still-open issues. 7 lines total. |
| `bc0ed2b` | `docs(udon-sharp)` — Flip `troubleshooting.md:731` station-collision bug marker. Previous phrasing "As of SDK 3.10.2, no fix has been released" replaced with `(unresolved as of SDK 3.10.3)` using the new convention. canny.io tracking link preserved. |

## B-1 resolution: N/A (no anchors to flip)

Original #150 task listed inline `(fixed in SDK 3.10.3)` markers on ClientSim URL-loading warnings in `web-loading.md` and `image-loading-vram.md`. Implementer performed a rigorous search (patterns: `ClientSim|client.?sim|editor|Play.?mode|simulation|download.?fail|fails|broken|known issue|bug`) across both files and found **no pre-existing warnings matching the 3.10.3 fix scope**.

Decision: **close B-1 as N/A**. Rationale:
- The bug was specific to SDK 3.10.2 → already fixed in 3.10.3 (current target)
- No pre-existing warning means adding a new callout would introduce noise for a bug users on current SDK won't encounter
- The fix record already lives in `sdk-migration.md`'s 3.10.3 section (landed in PR #152)
- Adding a speculative warning would fail skill-judge D1 (Knowledge Delta) — "document things experience teaches, not release-notes transcription"

## B-2 verification evidence

Fetched <https://creators.vrchat.com/releases/release-3-10-3/> directly. Release notes cover: VRCRaycast component, Toon Standard Color Mask, `isVRCPlus`, ClientSim URL-loading fix, Mirror rendering move to `Camera.onPreCull`. **No mention of PlayerLocal/VRCStation/OnPlayerTrigger collision.** Cross-checked the release index page — unchanged.

→ Canny-tracked station-collision bug remains **unresolved as of SDK 3.10.3**.

## Quality review log

- **Combined lightweight pass (architect + skill-judge)**: 10/10 checks PASS. Marker placement verified (lines 11-17 of sdk-migration.md, within budget). Marker phrasing matches exact specified forms. Sentence flow in troubleshooting.md:731 preserved. No scope bleed into #151.
- **D1 Knowledge Delta**: marker-convention doc adds concrete VRChat-specific semantics (SDK version granularity, canny tracking guidance) — acceptable for surgical docs work.

## Parallel work coordination

Sub-issue C (#151) is running in parallel. C touches `troubleshooting.md:5` (version header); B touches `troubleshooting.md:731` (station-collision text). No line-level overlap. Expected git auto-merge on the second-to-land PR.

## Acceptance criteria

- [x] All 3 markers adopted consistently (`(requires X.Y.Z+)`, `(fixed in X.Y.Z)`, `(unresolved as of X.Y.Z)`)
- [x] `troubleshooting.md:731` re-verified against 3.10.3 release notes (not guessed)
- [x] D1 test passes (no release-notes transcription)
- [x] No scope bleed — only `sdk-migration.md` and `troubleshooting.md` touched

## Test plan

- [ ] Maintainer verifies marker convention section renders correctly at top of `sdk-migration.md`
- [ ] Maintainer verifies `troubleshooting.md:731` sentence still reads cleanly with canny link intact
- [ ] CodeRabbit review passes
- [ ] CI (Symlink Integrity, Hook Scripts, npm Pack Test, EditorConfig, Markdown Links) passes

## Related

- Closes #150
- Refs #148 (parent)
- Sibling sub-issues: #151 (version bumps, running in parallel)

## References

- Official release notes: <https://creators.vrchat.com/releases/release-3-10-3/>
