### PR TITLE
chore(skills): SDK 3.10.3 version bumps — 25+ files + calendar-date → version-tag refactor

### DIFF
--- a/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md
@@ -67,6 +67,7 @@ minor: Bug fixes, small changes
 | 3.10.0 | 2025 | Dynamics for Worlds |
 | 3.10.1 | 2025 | Bug fixes and stability improvements |
 | 3.10.2 | 2026 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | 2026 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ### Checkpoints for Next Update
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
     attributes:
       label: VRChat SDK Version
       description: Which SDK version are you using? (optional)
-      placeholder: "3.10.2"
+      placeholder: "3.10.3"
     validations:
       required: false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ See [LICENSE](LICENSE) for details.
 
 ## VRChat SDK Versions
 
-When reporting issues, please specify the SDK version. This project covers SDK 3.7.1 - 3.10.2.
+When reporting issues, please specify the SDK version. This project covers SDK 3.7.1 - 3.10.3.
 
 ## Language
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 [English](README.md) | **日本語** | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -214,7 +214,8 @@ Q3: 継続的に変化しますか？（位置・回転など）
 | **3.9.0** | Camera Dolly API、Auto Hold Pickup | サポート済み |
 | **3.10.0** | ワールド向けVRChat Dynamics（PhysBones、Contacts、VRC Constraints） | サポート済み |
 | **3.10.1** | バグ修正、安定性の向上 | サポート済み |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | 最新安定版 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | サポート済み |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（アバター）、Mirror 描画タイミング修正 | 最新安定版 |
 
 > **注意**: SDK 3.9.0未満は2025年12月2日に非推奨となりました。新規ワールドのアップロードには3.9.0以上が必要です。
 
@@ -255,7 +256,7 @@ Q3: 継続的に変化しますか？（位置・回転など）
 - コンテンツは**「現状のまま」**提供されており、いかなる保証もありません。[LICENSE](LICENSE) をご確認ください。
 - これは個人プロジェクトです。**誤り、古くなった情報、または不完全な内容が含まれる可能性があります。** 常に[VRChat公式ドキュメント](https://creators.vrchat.com/)で確認してください。
 - このリポジトリが原因で生じた問題（ビルドエラー、アップロード拒否、予期しないワールドの動作など）について、作者は一切責任を負いません。
-- SDKカバレッジ（3.7.1〜3.10.2）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
+- SDKカバレッジ（3.7.1〜3.10.3）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
 
 ### AI支援による作成
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | **한국어**
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="에이전트 스킬" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="라이선스" />
@@ -215,7 +215,8 @@ Q3: 지속적으로 변하나요? (위치/회전)
 | **3.9.0** | Camera Dolly API, Auto Hold pickup | 지원 |
 | **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | 지원 |
 | **3.10.1** | 버그 수정, 안정성 개선 | 지원 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 최신 안정 버전 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 지원 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (아바타), Mirror 렌더 순서 수정 | 최신 안정 버전 |
 
 > **참고**: SDK 3.9.0 미만은 2025년 12월 2일에 지원이 종료되었습니다. 새로운 월드 업로드에는 3.9.0 이상이 필요합니다.
 
@@ -256,7 +257,7 @@ Q3: 지속적으로 변하나요? (위치/회전)
 - 콘텐츠는 어떠한 보증 없이 **"있는 그대로"** 제공됩니다. [LICENSE](LICENSE)를 참조하세요.
 - 이것은 개인 프로젝트입니다. **오류, 오래된 정보, 불완전한 내용이 있을 수 있습니다.** 반드시 [공식 VRChat 문서](https://creators.vrchat.com/)와 대조하여 확인하세요.
 - 이 리포지토리로 인해 발생하는 문제(빌드 오류, 업로드 거부, 예상치 못한 월드 동작 등)에 대해 저자는 어떠한 책임도 지지 않습니다.
-- SDK 지원 범위(3.7.1 - 3.10.2)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
+- SDK 지원 범위(3.7.1 - 3.10.3)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
 
 ### AI 지원 제작
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **English** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -214,7 +214,8 @@ Supports both **Bash** (`validate-udonsharp.sh`) and **PowerShell** (`validate-u
 | **3.9.0** | Camera Dolly API, Auto Hold pickup | Supported |
 | **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | Supported |
 | **3.10.1** | Bug fixes, stability improvements | Supported |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Latest Stable |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Supported |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Latest Stable |
 
 > **Note**: SDK < 3.9.0 was deprecated on December 2, 2025. New world uploads require 3.9.0+.
 
@@ -255,7 +256,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 - Content is provided **"AS IS"** without warranty. See [LICENSE](LICENSE).
 - This is a personal project. **Errors, outdated information, or incomplete content may exist.** Always verify against [official VRChat documentation](https://creators.vrchat.com/).
 - The author assumes no liability for issues caused by this repository (build errors, upload rejections, unexpected world behavior, etc.).
-- SDK coverage (3.7.1 - 3.10.2) reflects the last update. Behavior may change with new VRChat releases.
+- SDK coverage (3.7.1 - 3.10.3) reflects the last update. Behavior may change with new VRChat releases.
 
 ### AI-Assisted Creation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | **简体中文** | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="AI Agent 技能" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="许可证" />
@@ -215,7 +215,8 @@ Q3: 是否持续变化？（位置/旋转）
 | **3.9.0** | Camera Dolly API、Auto Hold 拾取 | 已支持 |
 | **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支持 |
 | **3.10.1** | Bug 修复、稳定性改进 | 已支持 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 最新稳定版 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 已支持 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（头像）、Mirror 渲染顺序修复 | 最新稳定版 |
 
 > **注意**：SDK < 3.9.0 已于 2025 年 12 月 2 日弃用。上传新世界需要 3.9.0+。
 
@@ -256,7 +257,7 @@ Q3: 是否持续变化？（位置/旋转）
 - 内容以 **"按原样"（AS IS）** 提供，不附带任何保证。请参阅 [LICENSE](LICENSE)。
 - 这是一个个人项目。**可能存在错误、过时信息或不完整的内容。** 请始终以 [VRChat 官方文档](https://creators.vrchat.com/) 为准进行验证。
 - 作者不对因使用本仓库而导致的任何问题（构建错误、上传被拒、意外的世界行为等）承担责任。
-- SDK 覆盖范围（3.7.1 - 3.10.2）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
+- SDK 覆盖范围（3.7.1 - 3.10.3）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
 
 ### AI 辅助创建
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | **繁體中文** | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="授權條款" />
@@ -215,7 +215,8 @@ PostToolUse 掛鉤會在 `.cs` 檔案被編輯時自動執行。
 | **3.9.0** | Camera Dolly API、Auto Hold pickup | 已支援 |
 | **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支援 |
 | **3.10.1** | 錯誤修正、穩定性改善 | 已支援 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 最新穩定版 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 已支援 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（頭像）、Mirror 渲染順序修正 | 最新穩定版 |
 
 > **注意**：SDK 3.9.0 以下版本已於 2025 年 12 月 2 日棄用。新的世界上傳需使用 3.9.0 以上版本。
 
@@ -256,7 +257,7 @@ PostToolUse 掛鉤會在 `.cs` 檔案被編輯時自動執行。
 - 內容以**「現狀」**提供，不附帶任何保證。請參閱 [LICENSE](LICENSE)。
 - 這是一個個人專案。**可能存在錯誤、過時資訊或不完整的內容。** 請務必與 [VRChat 官方文件](https://creators.vrchat.com/) 進行核對。
 - 作者不對本儲存庫造成的問題承擔任何責任（建置錯誤、上傳被拒絕、非預期的世界行為等）。
-- SDK 涵蓋範圍（3.7.1 - 3.10.2）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
+- SDK 涵蓋範圍（3.7.1 - 3.10.3）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
 
 ### AI 輔助建立
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.2 Coverage** (as of April 2026)
+**SDK 3.7.1 - 3.10.3 Coverage** (as of April 2026)
 
 ## Blocked Features and Alternatives
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.3 Coverage** (as of April 2026)
+**SDK 3.7.1 - 3.10.3 Coverage** (SDK coverage: 3.7.1 - 3.10.3)
 
 ## Blocked Features and Alternatives
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.3 Coverage** (SDK coverage: 3.7.1 - 3.10.3)
+**SDK 3.7.1 - 3.10.3 Coverage**
 
 ## Blocked Features and Alternatives
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -7,7 +7,7 @@ description: >
     network sync (UdonSynced, RequestSerialization, FieldChangeCallback, NetworkCallable),
     persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts),
     Web Loading, VRAM management (texture lifecycle, Dispose vs Destroy),
-    and event handling. SDK 3.7.1 - 3.10.2 coverage.
+    and event handling. SDK 3.7.1 - 3.10.3 coverage.
     Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
     NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
     synced variables, VRChat world scripting, C# to Udon.
@@ -198,6 +198,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | 3.10.0 | **VRChat Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 > **Note**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible.
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -2,7 +2,7 @@
 
 Complete reference of VRChat-specific classes, methods, and types available in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 ## VRCPlayerApi
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -2,7 +2,7 @@
 
 Complete reference of VRChat-specific classes, methods, and types available in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## VRCPlayerApi
 

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -3,7 +3,7 @@
 Complete reference of C# features and their availability in UdonSharp, including SDK version availability,
 compiler behavior details, and annotated code examples.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 > For the quick-reference checklist and code generation rules, see `rules/udonsharp-constraints.md`.
 

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -3,7 +3,7 @@
 Complete reference of C# features and their availability in UdonSharp, including SDK version availability,
 compiler behavior details, and annotated code examples.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 > For the quick-reference checklist and code generation rules, see `rules/udonsharp-constraints.md`.
 

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -3,7 +3,7 @@
 Complete reference of C# features and their availability in UdonSharp, including SDK version availability,
 compiler behavior details, and annotated code examples.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 > For the quick-reference checklist and code generation rules, see `rules/udonsharp-constraints.md`.
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -2,7 +2,7 @@
 
 Complete reference of all events available in UdonSharp. Override these methods to respond to events.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 ## Important: override vs Non-override
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -2,7 +2,7 @@
 
 Complete reference of all events available in UdonSharp. Override these methods to respond to events.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 ## Important: override vs Non-override
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -2,7 +2,7 @@
 
 Complete reference of all events available in UdonSharp. Override these methods to respond to events.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## Important: override vs Non-override
 

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,6 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.3
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,6 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.3 (as of March 2026)
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,6 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,6 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide to networking and synchronization in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 > **Warning**: Networking in Udon is a work in progress and can be fragile. Keep implementations simple and test thoroughly with multiple players.
 >

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide to networking and synchronization in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 > **Warning**: Networking in Udon is a work in progress and can be fragile. Keep implementations simple and test thoroughly with multiple players.
 >

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide to networking and synchronization in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 > **Warning**: Networking in Udon is a work in progress and can be fragile. Keep implementations simple and test thoroughly with multiple players.
 >

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -2,7 +2,7 @@
 
 Practical guide for testing and debugging UdonSharp worlds in VRChat.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -2,7 +2,7 @@
 
 Practical guide for testing and debugging UdonSharp worlds in VRChat.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -2,7 +2,7 @@
 
 Practical guide for testing and debugging UdonSharp worlds in VRChat.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common errors, causes, and solutions for VRChat UdonSharp development.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common errors, causes, and solutions for VRChat UdonSharp development.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common errors, causes, and solutions for VRChat UdonSharp development.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -1,6 +1,6 @@
 # Web Loading — Advanced Packed Resource Patterns
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 Advanced techniques for embedding multiple textures in a single `VRCStringDownloader` response
 to work around `VRCImageDownloader` limitations. For the base API reference see

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -1,6 +1,6 @@
 # Web Loading — Advanced Packed Resource Patterns
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 Advanced techniques for embedding multiple textures in a single `VRCStringDownloader` response
 to work around `VRCImageDownloader` limitations. For the base API reference see

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -1,6 +1,6 @@
 # Web Loading — Advanced Packed Resource Patterns
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 Advanced techniques for embedding multiple textures in a single `VRCStringDownloader` response
 to work around `VRCImageDownloader` limitations. For the base API reference see

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -1,6 +1,6 @@
 # Web Loading (String / Image Download)
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -1,6 +1,6 @@
 # Web Loading (String / Image Download)
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -1,6 +1,6 @@
 # Web Loading (String / Image Download)
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -2,7 +2,7 @@
 
 UdonSharp compiles C# to Udon Assembly. Always adhere to these constraints, which differ from standard C#.
 
-**SDK Coverage**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**SDK Coverage**: 3.7.1 - 3.10.3
 
 > For detailed examples, SDK version availability, and compiler behavior explanations,
 > see `references/constraints.md`.

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -2,7 +2,7 @@
 
 UdonSharp compiles C# to Udon Assembly. Always adhere to these constraints, which differ from standard C#.
 
-**SDK Coverage**: 3.7.1 - 3.10.2 (as of March 2026)
+**SDK Coverage**: 3.7.1 - 3.10.3 (as of March 2026)
 
 > For detailed examples, SDK version availability, and compiler behavior explanations,
 > see `references/constraints.md`.

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -2,7 +2,7 @@
 
 UdonSharp compiles C# to Udon Assembly. Always adhere to these constraints, which differ from standard C#.
 
-**SDK Coverage**: 3.7.1 - 3.10.3 (as of March 2026)
+**SDK Coverage**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 > For detailed examples, SDK version availability, and compiler behavior explanations,
 > see `references/constraints.md`.

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -2,7 +2,7 @@
 
 Core networking rules and constraints. See `../references/networking.md` for detailed patterns.
 
-**SDK Coverage**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**SDK Coverage**: 3.7.1 - 3.10.3
 
 ## Ownership Model
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -2,7 +2,7 @@
 
 Core networking rules and constraints. See `../references/networking.md` for detailed patterns.
 
-**SDK Coverage**: 3.7.1 - 3.10.2 (as of March 2026)
+**SDK Coverage**: 3.7.1 - 3.10.3 (as of March 2026)
 
 ## Ownership Model
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -2,7 +2,7 @@
 
 Core networking rules and constraints. See `../references/networking.md` for detailed patterns.
 
-**SDK Coverage**: 3.7.1 - 3.10.3 (as of March 2026)
+**SDK Coverage**: 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 ## Ownership Model
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # VRC World SDK 3 Cheatsheet
 
-**SDK 3.7.1 - 3.10.3 supported** (SDK coverage: 3.7.1 - 3.10.3)
+**SDK 3.7.1 - 3.10.3 supported**
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # VRC World SDK 3 Cheatsheet
 
-**SDK 3.7.1 - 3.10.3 supported** (as of February 2026)
+**SDK 3.7.1 - 3.10.3 supported** (SDK coverage: 3.7.1 - 3.10.3)
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # VRC World SDK 3 Cheatsheet
 
-**SDK 3.7.x - 3.10.x supported** (as of February 2026)
+**SDK 3.7.1 - 3.10.3 supported** (as of February 2026)
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -7,7 +7,7 @@ description: >
     Covers VRC_SceneDescriptor, spawn points, VRC_Pickup, VRC_Station,
     VRC_Mirror, VRC_ObjectSync, VRC_CameraDolly, layer/collision matrix,
     baked lighting, Quest/Android limits, and upload workflow.
-    SDK 3.7.1 - 3.10.2 coverage.
+    SDK 3.7.1 - 3.10.3 coverage.
     Triggers on: VRChat world, VRC SDK, scene setup, VRC_SceneDescriptor,
     spawn point, VRC_Pickup, VRC_Station, VRC_ObjectSync, layer setup,
     optimization, Quest support, light baking, upload, FPS improvement.
@@ -102,7 +102,7 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 
 ## SDK Versions
 
-**Supported versions**: SDK 3.7.1 - 3.10.2 (as of March 2026)
+**Supported versions**: SDK 3.7.1 - 3.10.3 (as of March 2026)
 
 | SDK    | New Features                                                                   | Status         |
 | ------ | ------------------------------------------------------------------------------ | -------------- |
@@ -114,7 +114,8 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 | 3.9.0  | **Camera Dolly API**, Auto Hold simplification, VRCCameraSettings              | ✅             |
 | 3.10.0 | **Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints)                 | ✅             |
 | 3.10.1 | Bug fixes and stability improvements                                           | ✅             |
-| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅ Latest stable |
+| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅             |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix         | ✅ Latest stable |
 
 > **Important**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible with these versions.
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -102,7 +102,7 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 
 ## SDK Versions
 
-**Supported versions**: SDK 3.7.1 - 3.10.3 (as of March 2026)
+**Supported versions**: SDK 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
 
 | SDK    | New Features                                                                   | Status         |
 | ------ | ------------------------------------------------------------------------------ | -------------- |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -102,7 +102,7 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 
 ## SDK Versions
 
-**Supported versions**: SDK 3.7.1 - 3.10.3 (SDK coverage: 3.7.1 - 3.10.3)
+**Supported versions**: SDK 3.7.1 - 3.10.3
 
 | SDK    | New Features                                                                   | Status         |
 | ------ | ------------------------------------------------------------------------------ | -------------- |

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -1,6 +1,6 @@
 # VRChat World Components Complete Reference
 
-Full component reference for SDK 3.7.1 - 3.10.2.
+Full component reference for SDK 3.7.1 - 3.10.3.
 
 ## Table of Contents
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.2)
+## SDK (3.7.1 - 3.10.3)
 
 | Version | Key Features |
 |---------|--------------|
@@ -28,6 +28,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.0 | VRChat Dynamics for Worlds (PhysBones, Contacts) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ## Docs Reference
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.2)
+## SDK (3.7.1 - 3.10.3)
 
 | Version | Key Features |
 |---------|--------------|
@@ -28,6 +28,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.0 | VRChat Dynamics for Worlds (PhysBones, Contacts) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ## Docs Reference
 

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.2)
+## SDK (3.7.1 - 3.10.3)
 
 | Version | Key Features |
 |---------|--------------|
@@ -28,6 +28,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.0 | VRChat Dynamics for Worlds (PhysBones, Contacts) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ## Docs Reference
 


### PR DESCRIPTION
## Summary

Sub-issue C of parent #148 — mechanical version-string updates + calendar-date → version-tag refactor + aesthetic polish. **7 commits, 27 files, +49/-38.** Closes the final 1/3 of parent issue progress.

**Post-merge parent #148 will auto-close** (all 3 sub-issues complete).

## Changes (7 commits)

| Commit | Scope |
|--------|-------|
| `3feca7a` | `docs` — Bump SDK coverage badge + version tables to 3.10.3 across all 5 READMEs (en/ja/zh-CN/zh-TW/ko). Shields.io `VRChat_SDK-3.7.1--3.10.2-00b4d8` → `...-3.10.3-00b4d8` (color/style unchanged). Add 3.10.3 row with feature summary (`VRCPlayerApi.isVRCPlus`, VRCRaycast avatar, Mirror render-order fix) translated per-language. |
| `9285c6a` | `docs` — Bump SDK version headers across 10 udon-sharp reference files and 2 rule files. `api.md` and `sdk-migration.md` intentionally NOT re-edited (already at 3.10.3 from PR #152). |
| `1d220da` | `docs` — Bump SDK version in both SKILL.md frontmatter `description` strings and SDK Versions tables; both CHEATSHEET.md headers. Move `✅ Latest stable` badge from 3.10.2 row to 3.10.3 row in world-sdk-3/SKILL.md. |
| `052d118` | `docs` — Refactor calendar-date `(as of March/April/February 2026)` markers to version-tied `(SDK coverage: 3.7.1 – 3.10.3)` form. |
| `4c7aa08` | `chore` — Bump SDK version in templates (`templates/{CLAUDE,AGENTS,GEMINI}.md`), `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/bug_report.yml` dropdown, and `.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md`. |
| `1b118c6` | `docs` — Remove 14 redundant `(SDK coverage: 3.7.1 – 3.10.3)` parentheticals after the version-tied refactor (identified as Case A duplicates where the line's primary clause already stated the version range). |
| `41d9bff` | `docs` — Polish `image-loading-vram.md:3` to drop awkward `3.7.1+ (image loading), 3.7.1 - 3.10.3` duplication (tautological in a file titled "Image Loading — VRAM & Memory Management"). |

## skill-judge re-score (final state)

Acceptance criterion from #148: both skills ≥ 108/120 (A grade) maintained.

| Skill | Pre-C (post #152) | Post-C | Δ | Grade |
|-------|-------------------|--------|---|-------|
| `unity-vrc-udon-sharp` | 110/120 | **112/120** | **+2** | A (93.3%) |
| `unity-vrc-world-sdk-3` | 108/120 | **109/120** | **+1** | A (90.8%) |

Both improved. D4 Specification Compliance +1 on both (description YAML now internally consistent with body content, `Latest stable` badge re-anchored). D8 Practical Usability +1 on udon-sharp (3.10.3 row in SDK table enables API-availability verification). No regressions.

## Quality review log

- **architect**: structural completeness ✅ (all required files touched, cross-language tables consistent, badge URLs preserved color/style, no accidental re-edit of #152 files, merge-safe with #153)
- **code-reviewer**: mechanical fidelity ✅ (stale-branch BLOCKER caught pre-push → resolved by rebase onto `origin/dev` post-#153)
- **skill-judge**: both skills improved, A grade maintained
- **Polish pass**: 14 Case-A redundancies removed (`1b118c6`) + 1 tautology fix (`41d9bff`)

## Rebase note

Branch was originally cut from `origin/dev` at `430d511` (pre-#153). After PR #153 merged, `code-reviewer` detected a stale-branch regression (the diff against new `origin/dev` would have reverted B's contribution). Resolved by clean rebase onto `bbdc6db`. No conflicts encountered — B and C touched disjoint lines/files.

## Scope exclusions

- `CHANGELOG.md` untouched (Release Drafter managed — confirmed by architect)
- `package.json` version untouched (publish workflow managed)
- No new content added beyond the 3.10.3 version-table rows and their translations

## Acceptance criteria

- [x] No `3.10.2` residue except legitimate historical references (past-version table rows, feature-introduction markers)
- [x] No `(as of <month> 2026)` calendar markers remain (except load-bearing prose exceptions)
- [x] All 5 READMEs consistently localized with 3.10.3 row
- [x] `npm pack --dry-run`: 70 files, 282.0 kB (within ±2 kB of 281.7 kB baseline)
- [x] `bin/install.mjs --list`: enumerates both skills correctly
- [x] skill-judge score for both skills ≥ 108/120 (maintained — actually improved)

## Test plan

- [ ] Maintainer verifies 3.10.3 table row renders correctly in all 5 README translations
- [ ] Maintainer spot-checks that `(SDK coverage: ...)` parentheticals are fully removed from reference headers (polish landed)
- [ ] CodeRabbit review passes
- [ ] CI (Symlink Integrity, Hook Scripts, npm Pack Test, EditorConfig, Markdown Links, GitGuardian, Version Sync) passes

## Related

- Closes #151
- Refs #148 (parent — **this PR closes the final sub-issue, parent will auto-close**)
- Sibling sub-issues completed: #149 (features, merged in #152), #150 (bug-fix notes, merged in #153)
