### PR TITLE
Release v1.7.0

### DIFF
--- a/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md
@@ -67,6 +67,7 @@ minor: Bug fixes, small changes
 | 3.10.0 | 2025 | Dynamics for Worlds |
 | 3.10.1 | 2025 | Bug fixes and stability improvements |
 | 3.10.2 | 2026 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | 2026 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ### Checkpoints for Next Update
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
     attributes:
       label: VRChat SDK Version
       description: Which SDK version are you using? (optional)
-      placeholder: "3.10.2"
+      placeholder: "3.10.3"
     validations:
       required: false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ See [LICENSE](LICENSE) for details.
 
 ## VRChat SDK Versions
 
-When reporting issues, please specify the SDK version. This project covers SDK 3.7.1 - 3.10.2.
+When reporting issues, please specify the SDK version. This project covers SDK 3.7.1 - 3.10.3.
 
 ## Language
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 [English](README.md) | **日本語** | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -214,7 +214,8 @@ Q3: 継続的に変化しますか？（位置・回転など）
 | **3.9.0** | Camera Dolly API、Auto Hold Pickup | サポート済み |
 | **3.10.0** | ワールド向けVRChat Dynamics（PhysBones、Contacts、VRC Constraints） | サポート済み |
 | **3.10.1** | バグ修正、安定性の向上 | サポート済み |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | 最新安定版 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | サポート済み |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（アバター）、Mirror 描画タイミング修正 | 最新安定版 |
 
 > **注意**: SDK 3.9.0未満は2025年12月2日に非推奨となりました。新規ワールドのアップロードには3.9.0以上が必要です。
 
@@ -255,7 +256,7 @@ Q3: 継続的に変化しますか？（位置・回転など）
 - コンテンツは**「現状のまま」**提供されており、いかなる保証もありません。[LICENSE](LICENSE) をご確認ください。
 - これは個人プロジェクトです。**誤り、古くなった情報、または不完全な内容が含まれる可能性があります。** 常に[VRChat公式ドキュメント](https://creators.vrchat.com/)で確認してください。
 - このリポジトリが原因で生じた問題（ビルドエラー、アップロード拒否、予期しないワールドの動作など）について、作者は一切責任を負いません。
-- SDKカバレッジ（3.7.1〜3.10.2）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
+- SDKカバレッジ（3.7.1〜3.10.3）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
 
 ### AI支援による作成
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | **한국어**
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="에이전트 스킬" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="라이선스" />
@@ -215,7 +215,8 @@ Q3: 지속적으로 변하나요? (위치/회전)
 | **3.9.0** | Camera Dolly API, Auto Hold pickup | 지원 |
 | **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | 지원 |
 | **3.10.1** | 버그 수정, 안정성 개선 | 지원 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 최신 안정 버전 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 지원 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (아바타), Mirror 렌더 순서 수정 | 최신 안정 버전 |
 
 > **참고**: SDK 3.9.0 미만은 2025년 12월 2일에 지원이 종료되었습니다. 새로운 월드 업로드에는 3.9.0 이상이 필요합니다.
 
@@ -256,7 +257,7 @@ Q3: 지속적으로 변하나요? (위치/회전)
 - 콘텐츠는 어떠한 보증 없이 **"있는 그대로"** 제공됩니다. [LICENSE](LICENSE)를 참조하세요.
 - 이것은 개인 프로젝트입니다. **오류, 오래된 정보, 불완전한 내용이 있을 수 있습니다.** 반드시 [공식 VRChat 문서](https://creators.vrchat.com/)와 대조하여 확인하세요.
 - 이 리포지토리로 인해 발생하는 문제(빌드 오류, 업로드 거부, 예상치 못한 월드 동작 등)에 대해 저자는 어떠한 책임도 지지 않습니다.
-- SDK 지원 범위(3.7.1 - 3.10.2)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
+- SDK 지원 범위(3.7.1 - 3.10.3)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
 
 ### AI 지원 제작
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **English** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -214,7 +214,8 @@ Supports both **Bash** (`validate-udonsharp.sh`) and **PowerShell** (`validate-u
 | **3.9.0** | Camera Dolly API, Auto Hold pickup | Supported |
 | **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | Supported |
 | **3.10.1** | Bug fixes, stability improvements | Supported |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Latest Stable |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Supported |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Latest Stable |
 
 > **Note**: SDK < 3.9.0 was deprecated on December 2, 2025. New world uploads require 3.9.0+.
 
@@ -255,7 +256,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 - Content is provided **"AS IS"** without warranty. See [LICENSE](LICENSE).
 - This is a personal project. **Errors, outdated information, or incomplete content may exist.** Always verify against [official VRChat documentation](https://creators.vrchat.com/).
 - The author assumes no liability for issues caused by this repository (build errors, upload rejections, unexpected world behavior, etc.).
-- SDK coverage (3.7.1 - 3.10.2) reflects the last update. Behavior may change with new VRChat releases.
+- SDK coverage (3.7.1 - 3.10.3) reflects the last update. Behavior may change with new VRChat releases.
 
 ### AI-Assisted Creation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | **简体中文** | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="AI Agent 技能" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="许可证" />
@@ -215,7 +215,8 @@ Q3: 是否持续变化？（位置/旋转）
 | **3.9.0** | Camera Dolly API、Auto Hold 拾取 | 已支持 |
 | **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支持 |
 | **3.10.1** | Bug 修复、稳定性改进 | 已支持 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 最新稳定版 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 已支持 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（头像）、Mirror 渲染顺序修复 | 最新稳定版 |
 
 > **注意**：SDK < 3.9.0 已于 2025 年 12 月 2 日弃用。上传新世界需要 3.9.0+。
 
@@ -256,7 +257,7 @@ Q3: 是否持续变化？（位置/旋转）
 - 内容以 **"按原样"（AS IS）** 提供，不附带任何保证。请参阅 [LICENSE](LICENSE)。
 - 这是一个个人项目。**可能存在错误、过时信息或不完整的内容。** 请始终以 [VRChat 官方文档](https://creators.vrchat.com/) 为准进行验证。
 - 作者不对因使用本仓库而导致的任何问题（构建错误、上传被拒、意外的世界行为等）承担责任。
-- SDK 覆盖范围（3.7.1 - 3.10.2）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
+- SDK 覆盖范围（3.7.1 - 3.10.3）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
 
 ### AI 辅助创建
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | **繁體中文** | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.2-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="授權條款" />
@@ -215,7 +215,8 @@ PostToolUse 掛鉤會在 `.cs` 檔案被編輯時自動執行。
 | **3.9.0** | Camera Dolly API、Auto Hold pickup | 已支援 |
 | **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支援 |
 | **3.10.1** | 錯誤修正、穩定性改善 | 已支援 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 最新穩定版 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 已支援 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（頭像）、Mirror 渲染順序修正 | 最新穩定版 |
 
 > **注意**：SDK 3.9.0 以下版本已於 2025 年 12 月 2 日棄用。新的世界上傳需使用 3.9.0 以上版本。
 
@@ -256,7 +257,7 @@ PostToolUse 掛鉤會在 `.cs` 檔案被編輯時自動執行。
 - 內容以**「現狀」**提供，不附帶任何保證。請參閱 [LICENSE](LICENSE)。
 - 這是一個個人專案。**可能存在錯誤、過時資訊或不完整的內容。** 請務必與 [VRChat 官方文件](https://creators.vrchat.com/) 進行核對。
 - 作者不對本儲存庫造成的問題承擔任何責任（建置錯誤、上傳被拒絕、非預期的世界行為等）。
-- SDK 涵蓋範圍（3.7.1 - 3.10.2）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
+- SDK 涵蓋範圍（3.7.1 - 3.10.3）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
 
 ### AI 輔助建立
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.2 Coverage** (as of April 2026)
+**SDK 3.7.1 - 3.10.3 Coverage**
 
 ## Blocked Features and Alternatives
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -7,7 +7,7 @@ description: >
     network sync (UdonSynced, RequestSerialization, FieldChangeCallback, NetworkCallable),
     persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts),
     Web Loading, VRAM management (texture lifecycle, Dispose vs Destroy),
-    and event handling. SDK 3.7.1 - 3.10.2 coverage.
+    and event handling. SDK 3.7.1 - 3.10.3 coverage.
     Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
     NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
     synced variables, VRChat world scripting, C# to Udon.
@@ -198,6 +198,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | 3.10.0 | **VRChat Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 > **Note**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible.
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -45,7 +45,7 @@ Four architectural decisions that must be made before choosing sync modes or wri
 
 ## Common Mistakes (NEVER List)
 
-These constraints cause **silent failures** — no compiler error, no runtime exception, just broken behavior. Check this list before writing any UdonSharp code.
+These constraints cause **silent failures** — no compiler error, no runtime exception, just broken behavior — **or** violate VRChat's design norms in ways that compile and run but break player expectations. Check this list before writing any UdonSharp code.
 
 | # | NEVER do this | Why it fails silently | Use instead |
 |---|---------------|----------------------|-------------|
@@ -61,12 +61,13 @@ These constraints cause **silent failures** — no compiler error, no runtime ex
 | 10 | Use `Button.onClick.AddListener()` | Not available in Udon — no runtime delegate support | Configure `SendCustomEvent` via Inspector OnClick |
 | 11 | Mix Continuous and Manual sync concerns on one behaviour | Wastes bandwidth (discrete values in Continuous) or loses control (redundant `RequestSerialization` in Continuous) | Separate behaviours: Continuous for position/rotation, Manual for discrete state |
 | 12 | Write synced variables before `OnOwnershipTransferred` confirms ownership | `SetOwner` is async — writes before confirmation are silently discarded | Store intent locally, write + serialize in `OnOwnershipTransferred` callback |
-| 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Attribute compiles but is **silently ignored** — methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
-| 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Events and components do not exist for worlds — code compiles but callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
-| 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | `PlayerData`, `PlayerObject`, `OnPlayerRestored` do not exist — compile or silent runtime failure | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
+| 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compiles but silently ignored at runtime — the attribute has no effect and methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
+| 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
+| 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
 | 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
 | 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
 | 18 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and their simple arrays are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
+| 19 | Gate core gameplay, safety, or moderation features by `isVRCPlus` | Breaks equitable course-of-play; conflicts with VRChat community norms; players expect gameplay access to be independent of subscription tier | Limit to cosmetic indicators (avatar icons, chat color, non-functional tier badges) |
 
 ## Sync Mode Quick Decision
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -2,7 +2,7 @@
 
 Complete reference of VRChat-specific classes, methods, and types available in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
 
 ## VRCPlayerApi
 
@@ -20,6 +20,18 @@ Player information and actions. Obtained from `Networking.LocalPlayer` or event 
 | `isUserInVR` | `bool` | True if using VR |
 | `isSuspended` | `bool` | True if suspended (tabbed out) |
 | `isGrounded` | `bool` | True if grounded on the floor |
+| `isVRCPlus` | `bool` | True if the player has an active VRC+ subscription (requires SDK 3.10.3+) |
+
+#### `isVRCPlus` — Timing and Per-Client Evaluation (SDK 3.10.3+)
+
+`isVRCPlus` is evaluated **per-client, on the local machine**. Each client reads its own value from VRChat account data — the value for a remote player is whatever that player's client has reported to the network.
+
+Two properties of that model drive correct usage:
+
+- **Timing**: Reading `isVRCPlus` inside `OnPlayerJoined` is not guaranteed to return an authoritative value. `OnPlayerJoined` fires during the network handshake before the player's profile and persistence data have settled; the subscription state may still be unset when the event fires. Gate reads behind `OnPlayerRestored` (or a local `_playerReady` flag set there) — `OnPlayerRestored` fires after persistence data has been loaded, which is the earliest point where account-tied properties are reliable.
+- **Anti-sync**: Do **NOT** store `isVRCPlus` in an `[UdonSynced]` variable and broadcast it. Each client must read `player.isVRCPlus` on its own against the `VRCPlayerApi` it holds. Syncing a single master-evaluated value will misreport the state for every other player and is a correctness bug, not a bandwidth optimisation. (See NEVER #18 for the general form of this anti-pattern; `isVRCPlus` is a new axis — "per-client evaluation" rather than "component reference.")
+
+For an example using the property for cosmetic-only indicators, see `patterns-core.md` (VRC+ Cosmetic Indicator). For the design-axis constraint against gating gameplay by subscription tier, see NEVER #19 in `SKILL.md`.
 
 ### Movement Methods
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -2,7 +2,7 @@
 
 Complete reference of VRChat-specific classes, methods, and types available in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## VRCPlayerApi
 

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -3,7 +3,7 @@
 Complete reference of C# features and their availability in UdonSharp, including SDK version availability,
 compiler behavior details, and annotated code examples.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 > For the quick-reference checklist and code generation rules, see `rules/udonsharp-constraints.md`.
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -2,7 +2,7 @@
 
 Complete reference of all events available in UdonSharp. Override these methods to respond to events.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## Important: override vs Non-override
 

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,6 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1+ (image loading), 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide to networking and synchronization in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 > **Warning**: Networking in Udon is a work in progress and can be fragile. Keep implementations simple and test thoroughly with multiple players.
 >

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -895,6 +895,36 @@ public class ScoreBoard : UdonSharpBehaviour
 
 ---
 
+## VRC+ Cosmetic Indicator (SDK 3.10.3+)
+
+**Cosmetic only.** This pattern enables a non-functional visual indicator (badge, icon, chat color tint) for players with a VRC+ subscription. Gating gameplay, safety, or moderation features by `isVRCPlus` is forbidden — see NEVER #19 in `SKILL.md`.
+
+Two constraints shape the code: `isVRCPlus` must be read after `OnPlayerRestored` (see `api.md` for the timing rationale), and the value must never be `[UdonSynced]` (each client evaluates `player.isVRCPlus` locally).
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+public class LocalVRCPlusBadge : UdonSharpBehaviour
+{
+    [SerializeField] private GameObject plusBadge; // purely visual
+
+    public override void OnPlayerRestored(VRCPlayerApi player)
+    {
+        if (player == null || !player.isLocal) return;
+        plusBadge.SetActive(player.isVRCPlus); // cosmetic display only
+    }
+}
+```
+
+Notes:
+- The badge is on the **local** player and read against the local `VRCPlayerApi`. Applying this to remote players works the same way — iterate `VRCPlayerApi.GetPlayers()` on each client and set each badge locally; never sync the result.
+- Resist the temptation to skip the `OnPlayerRestored` gate. Reading in `OnPlayerJoined` may return an unset / default value while the profile is still being fetched.
+- If you need to react to a hypothetical future subscription change mid-session, re-read inside whatever update hook you already have; still no `[UdonSynced]`.
+
+---
+
 
 ## See Also
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -2,7 +2,7 @@
 
 Step-by-step guide for upgrading UdonSharp worlds across major SDK versions.
 
-**Applies to**: SDK 3.7.x through 3.10.2
+**Applies to**: SDK 3.7.x through 3.10.3
 
 > **Deprecation Notice**: SDK versions below 3.9.0 were deprecated on **December 2, 2025**.
 > New world uploads are no longer possible with those versions.
@@ -338,6 +338,16 @@ Namespace for all VRC Constraints: `VRC.SDK3.Dynamics.Constraint.Components`.
 - [ ] Audit `SendCustomEventDelayed*` calls: use `EventTiming.FixedUpdate` for physics-coupled callbacks, `EventTiming.PostLateUpdate` for camera/IK callbacks, instead of frame-delay workarounds
 - [ ] For worlds using PhysBones in world space: avoid placing them inside `Instantiate()`-created objects (PhysBones in instantiated objects may not be network-synced; use scene-placed objects or VRChat Object Pool instead)
 - [ ] Test the Contact-based interactions with multiple players; `Allow Self` / `Allow Others` settings on `VRC Contact Receiver` do not apply to world-object senders
+
+#### SDK 3.10.3 changes
+
+Small surface, but each item has non-obvious consequences documented elsewhere — this entry just routes you to them.
+
+- **`VRCPlayerApi.isVRCPlus`** (bool) added. Evaluated per-client; read after `OnPlayerRestored`, not inside `OnPlayerJoined`. Never `[UdonSynced]` the result. Full timing and anti-sync rationale: `api.md` (VRCPlayerApi Properties > isVRCPlus subsection).
+- **NEVER #19** (design-axis, not silent-failure): do not gate core gameplay, safety, or moderation features by `isVRCPlus`. See SKILL.md NEVER table and the cosmetic-indicator pattern in `patterns-core.md`.
+- **VRCRaycast**: avatar-side component (added 3.10.3). Udon runtime access is not indicated by the release notes. World builders should design collider/layer setup with avatar-driven raycasts in mind — see `unity-vrc-world-sdk-3/references/components.md`.
+- **Mirror rendering internals**: VRChat's mirror pipeline moved from `OnWillRenderObject` to `Camera.onPreCull` for 2026.1.3 client parity. Udon scripts do not interact with either hook, so no script-side migration is required.
+- **Toon Standard shader** (avatar-only): not covered by this skill.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -8,6 +8,14 @@ Step-by-step guide for upgrading UdonSharp worlds across major SDK versions.
 > New world uploads are no longer possible with those versions.
 > Worlds that have not yet migrated past 3.9.0 must update to continue publishing.
 
+## Version markers
+
+Version-specific notes in this skill use three marker forms. Match them verbatim when adding new annotations:
+
+- `(requires SDK X.Y.Z+)` — feature gate. The API, attribute, or component exists only from that version onward.
+- `(fixed in SDK X.Y.Z)` — a bug that existed in earlier SDKs is resolved starting with this version.
+- `(unresolved as of SDK X.Y.Z)` — a bug is still open in this version. Include a tracking link (canny, GitHub issue) when available.
+
 ---
 
 ## SDK 3.7.x to 3.8.x

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -2,7 +2,7 @@
 
 Practical guide for testing and debugging UdonSharp worlds in VRChat.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common errors, causes, and solutions for VRChat UdonSharp development.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -728,7 +728,7 @@ public override void OnContactEnter(ContactEnterInfo info)
 
 When a player sits in a VRCStation, the **PlayerLocal (Layer 10) capsule collider is effectively disabled**. This causes `OnPlayerTriggerEnter`, `OnPlayerTriggerExit`, and `OnPlayerTriggerStay` to **not fire** for seated players.
 
-This is a [known long-standing issue](https://vrchat.canny.io/sdk-bug-reports/p/playerlocal-collision-should-remain-on-players-in-stations). As of SDK 3.10.2, no fix has been released.
+This is a [known long-standing issue](https://vrchat.canny.io/sdk-bug-reports/p/playerlocal-collision-should-remain-on-players-in-stations) (unresolved as of SDK 3.10.3).
 
 ### Symptoms
 

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -1,6 +1,6 @@
 # Web Loading — Advanced Packed Resource Patterns
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 Advanced techniques for embedding multiple textures in a single `VRCStringDownloader` response
 to work around `VRCImageDownloader` limitations. For the base API reference see

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -1,6 +1,6 @@
 # Web Loading (String / Image Download)
 
-**Supported SDK Versions**: 3.7.1 - 3.10.2 (as of March 2026)
+**Supported SDK Versions**: 3.7.1 - 3.10.3
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -2,7 +2,7 @@
 
 UdonSharp compiles C# to Udon Assembly. Always adhere to these constraints, which differ from standard C#.
 
-**SDK Coverage**: 3.7.1 - 3.10.2 (as of March 2026)
+**SDK Coverage**: 3.7.1 - 3.10.3
 
 > For detailed examples, SDK version availability, and compiler behavior explanations,
 > see `references/constraints.md`.

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -2,7 +2,7 @@
 
 Core networking rules and constraints. See `../references/networking.md` for detailed patterns.
 
-**SDK Coverage**: 3.7.1 - 3.10.2 (as of March 2026)
+**SDK Coverage**: 3.7.1 - 3.10.3
 
 ## Ownership Model
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # VRC World SDK 3 Cheatsheet
 
-**SDK 3.7.x - 3.10.x supported** (as of February 2026)
+**SDK 3.7.1 - 3.10.3 supported**
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -7,7 +7,7 @@ description: >
     Covers VRC_SceneDescriptor, spawn points, VRC_Pickup, VRC_Station,
     VRC_Mirror, VRC_ObjectSync, VRC_CameraDolly, layer/collision matrix,
     baked lighting, Quest/Android limits, and upload workflow.
-    SDK 3.7.1 - 3.10.2 coverage.
+    SDK 3.7.1 - 3.10.3 coverage.
     Triggers on: VRChat world, VRC SDK, scene setup, VRC_SceneDescriptor,
     spawn point, VRC_Pickup, VRC_Station, VRC_ObjectSync, layer setup,
     optimization, Quest support, light baking, upload, FPS improvement.
@@ -102,7 +102,7 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 
 ## SDK Versions
 
-**Supported versions**: SDK 3.7.1 - 3.10.2 (as of March 2026)
+**Supported versions**: SDK 3.7.1 - 3.10.3
 
 | SDK    | New Features                                                                   | Status         |
 | ------ | ------------------------------------------------------------------------------ | -------------- |
@@ -114,7 +114,8 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 | 3.9.0  | **Camera Dolly API**, Auto Hold simplification, VRCCameraSettings              | ✅             |
 | 3.10.0 | **Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints)                 | ✅             |
 | 3.10.1 | Bug fixes and stability improvements                                           | ✅             |
-| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅ Latest stable |
+| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅             |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix         | ✅ Latest stable |
 
 > **Important**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible with these versions.
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -1,6 +1,6 @@
 # VRChat World Components Complete Reference
 
-Full component reference for SDK 3.7.1 - 3.10.2.
+Full component reference for SDK 3.7.1 - 3.10.3.
 
 ## Table of Contents
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -15,6 +15,7 @@ Full component reference for SDK 3.7.1 - 3.10.2.
 - [VRC_AvatarPedestal](#vrc_avatarpedestal)
 - [VRC_CameraDolly](#vrc_cameradolly)
 - [VRCCameraSettings API](#vrccamerasettings-api)
+- [Avatar-driven features that read world colliders](#avatar-driven-features-that-read-world-colliders)
 - [Allowed Unity Components](#allowed-unity-components)
 
 ---
@@ -696,6 +697,12 @@ public class CameraMonitor : UdonSharpBehaviour
     }
 }
 ```
+
+---
+
+## Avatar-driven features that read world colliders
+
+Some avatar-side features fire rays or cast queries into the world and react to whatever collider they hit. `VRCRaycast` (SDK 3.10.3+) is one such feature: avatars can emit rays that intersect world colliders and players. World builders do not author or script `VRCRaycast` — it lives on the avatar side — but **collider presence, layer assignment, and IsTrigger settings on world geometry determine whether those avatar rays produce a "hit" and therefore whether visitors' avatars react as their authors intended**. Treat your interactable/solid geometry's collider+layer setup as an implicit contract with avatar-side tooling, not just with Udon interactions.
 
 ---
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.2)
+## SDK (3.7.1 - 3.10.3)
 
 | Version | Key Features |
 |---------|--------------|
@@ -28,6 +28,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.0 | VRChat Dynamics for Worlds (PhysBones, Contacts) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ## Docs Reference
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.2)
+## SDK (3.7.1 - 3.10.3)
 
 | Version | Key Features |
 |---------|--------------|
@@ -28,6 +28,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.0 | VRChat Dynamics for Worlds (PhysBones, Contacts) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ## Docs Reference
 

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.2)
+## SDK (3.7.1 - 3.10.3)
 
 | Version | Key Features |
 |---------|--------------|
@@ -28,6 +28,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.0 | VRChat Dynamics for Worlds (PhysBones, Contacts) |
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
 
 ## Docs Reference
 


### PR DESCRIPTION
## Release v1.7.0 — VRChat SDK 3.10.3 support

Merges `dev` into `main` to publish v1.7.0.

### Scope

Full VRChat SDK 3.10.3 integration via parent issue #148 and 3 sub-issues (all merged):

- **#152** — Feature additions: `VRCPlayerApi.isVRCPlus`, VRCRaycast world-side note, NEVER #19 (design-axis)
- **#153** — Bug-fix notes: 3-marker version convention, PlayerLocal station-collision status refreshed
- **#154** — Version bumps: 27 files, calendar-date → version-tag refactor, aesthetic polish

### Version resolution

Highest PR label in this range: `release: feature` (#152) → **minor bump**: v1.6.0 → **v1.7.0**. Handled automatically by Release Drafter.

### Post-merge plan

1. Release Drafter auto-generates draft on `main` push
2. I will **rewrite the draft release notes for human readability** (per repo convention — raw Release Drafter output has internal PR noise and duplication)
3. Publish → triggers `publish.yml` → npm publish `agent-skills-vrc-udon@1.7.0`

### Quality checkpoints already cleared on `dev`

- Both VRC skills at **A grade**: unity-vrc-udon-sharp 112/120, unity-vrc-world-sdk-3 109/120 (both improved over v1.6.0 baseline of 108/108)
- `npm pack --dry-run`: 70 files, 282.0 kB
- All CI checks green on every merged PR

### Test plan

- [ ] CI on this release PR passes (Symlink Integrity, Hook Scripts, npm Pack Test, EditorConfig, Markdown Links, Version Sync, GitGuardian)
- [ ] Per `feedback_release_pr_skip_review.md`: CodeRabbit review can be skipped on release PRs (dev→main merge preserving commit history)
