### PR TITLE
refactor(skills): remove NEVER #19 — leave VRC+ usage decisions to users

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -45,7 +45,7 @@ Four architectural decisions that must be made before choosing sync modes or wri
 
 ## Common Mistakes (NEVER List)
 
-These constraints cause **silent failures** — no compiler error, no runtime exception, just broken behavior — **or** violate VRChat's design norms in ways that compile and run but break player expectations. Check this list before writing any UdonSharp code.
+These constraints cause **silent failures** — no compiler error, no runtime exception, just broken behavior. Check this list before writing any UdonSharp code.
 
 | # | NEVER do this | Why it fails silently | Use instead |
 |---|---------------|----------------------|-------------|
@@ -67,7 +67,6 @@ These constraints cause **silent failures** — no compiler error, no runtime ex
 | 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
 | 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
 | 18 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and their simple arrays are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
-| 19 | Gate core gameplay, safety, or moderation features by `isVRCPlus` | Breaks equitable course-of-play; conflicts with VRChat community norms; players expect gameplay access to be independent of subscription tier | Limit to cosmetic indicators (avatar icons, chat color, non-functional tier badges) |
 
 ## Sync Mode Quick Decision
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -45,7 +45,7 @@ Four architectural decisions that must be made before choosing sync modes or wri
 
 ## Common Mistakes (NEVER List)
 
-These constraints cause **silent failures** — no compiler error, no runtime exception, just broken behavior. Check this list before writing any UdonSharp code.
+These constraints cause either **compile-time failures** or **silent runtime failures**. Check this list before writing any UdonSharp code.
 
 | # | NEVER do this | Why it fails silently | Use instead |
 |---|---------------|----------------------|-------------|

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -31,7 +31,7 @@ Two properties of that model drive correct usage:
 - **Timing**: Reading `isVRCPlus` inside `OnPlayerJoined` is not guaranteed to return an authoritative value. `OnPlayerJoined` fires during the network handshake before the player's profile and persistence data have settled; the subscription state may still be unset when the event fires. Gate reads behind `OnPlayerRestored` (or a local `_playerReady` flag set there) — `OnPlayerRestored` fires after persistence data has been loaded, which is the earliest point where account-tied properties are reliable.
 - **Anti-sync**: Do **NOT** store `isVRCPlus` in an `[UdonSynced]` variable and broadcast it. Each client must read `player.isVRCPlus` on its own against the `VRCPlayerApi` it holds. Syncing a single master-evaluated value will misreport the state for every other player and is a correctness bug, not a bandwidth optimisation. (See NEVER #18 for the general form of this anti-pattern; `isVRCPlus` is a new axis — "per-client evaluation" rather than "component reference.")
 
-For an example using the property for cosmetic-only indicators, see `patterns-core.md` (VRC+ Cosmetic Indicator). For the design-axis constraint against gating gameplay by subscription tier, see NEVER #19 in `SKILL.md`.
+For a worked example of reading the property and enabling a local `GameObject` based on it, see `patterns-core.md` (VRC+ Detection — Reading `isVRCPlus`).
 
 ### Movement Methods
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -895,11 +895,11 @@ public class ScoreBoard : UdonSharpBehaviour
 
 ---
 
-## VRC+ Cosmetic Indicator (SDK 3.10.3+)
+## VRC+ Detection — Reading `isVRCPlus` (SDK 3.10.3+)
 
-**Cosmetic only.** This pattern enables a non-functional visual indicator (badge, icon, chat color tint) for players with a VRC+ subscription. Gating gameplay, safety, or moderation features by `isVRCPlus` is forbidden — see NEVER #19 in `SKILL.md`.
+This pattern reads `VRCPlayerApi.isVRCPlus` on the local player and conditionally enables a `GameObject`. Substitute any behaviour you want to condition on subscription status — the code shape is the same regardless of what the target object does. Whether and how to use `isVRCPlus` is a design decision left to the caller.
 
-Two constraints shape the code: `isVRCPlus` must be read after `OnPlayerRestored` (see `api.md` for the timing rationale), and the value must never be `[UdonSynced]` (each client evaluates `player.isVRCPlus` locally).
+Two technical constraints shape the code: `isVRCPlus` must be read after `OnPlayerRestored` (see `api.md` for the timing rationale), and the value must never be `[UdonSynced]` (each client evaluates `player.isVRCPlus` locally, so a synced value would misreport state for every other client).
 
 ```csharp
 using UdonSharp;
@@ -908,20 +908,20 @@ using VRC.SDKBase;
 
 public class LocalVRCPlusBadge : UdonSharpBehaviour
 {
-    [SerializeField] private GameObject plusBadge; // purely visual
+    [SerializeField] private GameObject plusBadge;
 
     public override void OnPlayerRestored(VRCPlayerApi player)
     {
         if (player == null || !player.isLocal) return;
-        plusBadge.SetActive(player.isVRCPlus); // cosmetic display only
+        plusBadge.SetActive(player.isVRCPlus);
     }
 }
 ```
 
 Notes:
-- The badge is on the **local** player and read against the local `VRCPlayerApi`. Applying this to remote players works the same way — iterate `VRCPlayerApi.GetPlayers()` on each client and set each badge locally; never sync the result.
-- Resist the temptation to skip the `OnPlayerRestored` gate. Reading in `OnPlayerJoined` may return an unset / default value while the profile is still being fetched.
-- If you need to react to a hypothetical future subscription change mid-session, re-read inside whatever update hook you already have; still no `[UdonSynced]`.
+- The read is on the **local** player against the local `VRCPlayerApi`. Applying this to remote players works the same way — iterate `VRCPlayerApi.GetPlayers()` on each client and evaluate each player's `isVRCPlus` locally; never sync the result.
+- Do not skip the `OnPlayerRestored` gate. Reading in `OnPlayerJoined` may return an unset / default value while the profile is still being fetched.
+- If you need to react to a subscription change mid-session, re-read inside whatever update hook you already have; still no `[UdonSynced]`.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -351,8 +351,7 @@ Namespace for all VRC Constraints: `VRC.SDK3.Dynamics.Constraint.Components`.
 
 Small surface, but each item has non-obvious consequences documented elsewhere — this entry just routes you to them.
 
-- **`VRCPlayerApi.isVRCPlus`** (bool) added. Evaluated per-client; read after `OnPlayerRestored`, not inside `OnPlayerJoined`. Never `[UdonSynced]` the result. Full timing and anti-sync rationale: `api.md` (VRCPlayerApi Properties > isVRCPlus subsection).
-- **NEVER #19** (design-axis, not silent-failure): do not gate core gameplay, safety, or moderation features by `isVRCPlus`. See SKILL.md NEVER table and the cosmetic-indicator pattern in `patterns-core.md`.
+- **`VRCPlayerApi.isVRCPlus`** (bool) added. Evaluated per-client; read after `OnPlayerRestored`, not inside `OnPlayerJoined`. Never `[UdonSynced]` the result. Full timing and anti-sync rationale: `api.md` (VRCPlayerApi Properties > isVRCPlus subsection). Worked example: `patterns-core.md` (VRC+ Detection — Reading `isVRCPlus`).
 - **VRCRaycast**: avatar-side component (added 3.10.3). Udon runtime access is not indicated by the release notes. World builders should design collider/layer setup with avatar-driven raycasts in mind — see `unity-vrc-world-sdk-3/references/components.md`.
 - **Mirror rendering internals**: VRChat's mirror pipeline moved from `OnWillRenderObject` to `Camera.onPreCull` for 2026.1.3 client parity. Udon scripts do not interact with either hook, so no script-side migration is required.
 - **Toon Standard shader** (avatar-only): not covered by this skill.


### PR DESCRIPTION
## Summary

Removes **NEVER #19** (design-axis VRC+ gating prohibition) from `unity-vrc-udon-sharp/SKILL.md` and reframes surrounding `isVRCPlus` guidance as neutral technical options.

**Principle applied**: the skill's responsibility is technical truth and option presentation, not design gatekeeping. Whether to build a VRC+-gated area, a VRC+-only gimmick, or a cosmetic badge is the user's business — not the skill's.

**2 commits, 4 files, +11/-13.**

## Changes

| Commit | Scope |
|--------|-------|
| `bebb816` | `refactor(udon-sharp)` — Delete NEVER #19 row from `SKILL.md`; revert NEVER table intro to silent-failure-only framing (was updated in #152 to straddle both axes). |
| `4d8cc07` | `docs(udon-sharp)` — Reframe `api.md` `isVRCPlus` section, `patterns-core.md` pattern section, and `sdk-migration.md` 3.10.3 entry as neutral technical content. Rename pattern section `VRC+ Cosmetic Indicator` → `VRC+ Detection — Reading isVRCPlus`. |

## What was kept (technical truth)

- ✅ `isVRCPlus` API entry with `(requires SDK 3.10.3+)` marker
- ✅ Timing constraint: evaluate after `OnPlayerRestored`, not `OnPlayerJoined` (technical correctness — avoids stale reads)
- ✅ Anti-sync constraint: per-client evaluation, don't `[UdonSynced]` the result (technical correctness — different clients get different values; syncing causes data desync)
- ✅ Cross-reference to NEVER #18 (component-reference anti-sync) — pure technical comparison, no moralizing
- ✅ Code example in `patterns-core.md` — only surrounding prose reframed, not the code

## What was removed (design prescription)

- ❌ NEVER #19 (`Gate core gameplay, safety, or moderation features by isVRCPlus`)
- ❌ Intro line framing that included "violate VRChat's design norms"
- ❌ "Cosmetic only" editorial labels in prose and inline code comments
- ❌ "Forbidden to gate gameplay" / "community norms" / "equitable course-of-play" justifications
- ❌ Cross-references to NEVER #19 throughout the skill

## Alignment with existing memories

This change aligns with `feedback_skill_design_antipattern.md`:

> Never use unverifiable assumptions as escape hatches in skill rules/checklists

"VRChat community norms" is a social-unverifiable appeal, not a technical failure mode. Removing it closes an internal consistency gap.

## Neutrality verification

```bash
grep -rn "NEVER #19\|gating.*gameplay\|forbid.*gameplay\|cosmetic only\|community norms\|equitable course" skills/unity-vrc-udon-sharp/
# Result: zero matches
```

No pro-gating language introduced either — the skill is silent on design choices and lets users decide.

## skill-judge impact

Estimated: unity-vrc-udon-sharp 112 → 111/120 (−1 on D3 from removed design-axis NEVER). Still A grade. unity-vrc-world-sdk-3 unchanged at 109/120.

## Test plan

- [ ] Maintainer verifies NEVER table rows 1–18 scan correctly with intro reverted
- [ ] Maintainer verifies `patterns-core.md` section heading + first paragraph read neutrally
- [ ] Maintainer verifies zero prohibitive language remains (grep above)
- [ ] CodeRabbit review passes (or Opus fallback if rate-limited)
- [ ] CI (Symlink Integrity, Hook Scripts, npm Pack Test, EditorConfig, Markdown Links, Version Sync, GitGuardian) passes

## Related

- Closes #156
- Reverses a rule introduced in #152 (v1.7.0, merged 2026-04-18)
- No breaking changes — purely removes prohibition + reframes prose

## References

- User directive: "やるかどうかはユーザーに判断を投げかけるものであり、我々Skills製作者およびSkillsのもつ責務ではない"
- Memory alignment: `feedback_skill_design_antipattern.md`
