### PR TITLE
Release v1.7.1

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -45,7 +45,7 @@ Four architectural decisions that must be made before choosing sync modes or wri
 
 ## Common Mistakes (NEVER List)
 
-These constraints cause **silent failures** — no compiler error, no runtime exception, just broken behavior — **or** violate VRChat's design norms in ways that compile and run but break player expectations. Check this list before writing any UdonSharp code.
+These constraints cause either **compile-time failures** or **silent runtime failures**. Check this list before writing any UdonSharp code.
 
 | # | NEVER do this | Why it fails silently | Use instead |
 |---|---------------|----------------------|-------------|
@@ -67,7 +67,6 @@ These constraints cause **silent failures** — no compiler error, no runtime ex
 | 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
 | 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
 | 18 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and their simple arrays are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
-| 19 | Gate core gameplay, safety, or moderation features by `isVRCPlus` | Breaks equitable course-of-play; conflicts with VRChat community norms; players expect gameplay access to be independent of subscription tier | Limit to cosmetic indicators (avatar icons, chat color, non-functional tier badges) |
 
 ## Sync Mode Quick Decision
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -31,7 +31,7 @@ Two properties of that model drive correct usage:
 - **Timing**: Reading `isVRCPlus` inside `OnPlayerJoined` is not guaranteed to return an authoritative value. `OnPlayerJoined` fires during the network handshake before the player's profile and persistence data have settled; the subscription state may still be unset when the event fires. Gate reads behind `OnPlayerRestored` (or a local `_playerReady` flag set there) — `OnPlayerRestored` fires after persistence data has been loaded, which is the earliest point where account-tied properties are reliable.
 - **Anti-sync**: Do **NOT** store `isVRCPlus` in an `[UdonSynced]` variable and broadcast it. Each client must read `player.isVRCPlus` on its own against the `VRCPlayerApi` it holds. Syncing a single master-evaluated value will misreport the state for every other player and is a correctness bug, not a bandwidth optimisation. (See NEVER #18 for the general form of this anti-pattern; `isVRCPlus` is a new axis — "per-client evaluation" rather than "component reference.")
 
-For an example using the property for cosmetic-only indicators, see `patterns-core.md` (VRC+ Cosmetic Indicator). For the design-axis constraint against gating gameplay by subscription tier, see NEVER #19 in `SKILL.md`.
+For a worked example of reading the property and enabling a local `GameObject` based on it, see `patterns-core.md` (VRC+ Detection — Reading `isVRCPlus`).
 
 ### Movement Methods
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -895,11 +895,11 @@ public class ScoreBoard : UdonSharpBehaviour
 
 ---
 
-## VRC+ Cosmetic Indicator (SDK 3.10.3+)
+## VRC+ Detection — Reading `isVRCPlus` (SDK 3.10.3+)
 
-**Cosmetic only.** This pattern enables a non-functional visual indicator (badge, icon, chat color tint) for players with a VRC+ subscription. Gating gameplay, safety, or moderation features by `isVRCPlus` is forbidden — see NEVER #19 in `SKILL.md`.
+This pattern reads `VRCPlayerApi.isVRCPlus` on the local player and conditionally enables a `GameObject`. Substitute any behaviour you want to condition on subscription status — the code shape is the same regardless of what the target object does. Whether and how to use `isVRCPlus` is a design decision left to the caller.
 
-Two constraints shape the code: `isVRCPlus` must be read after `OnPlayerRestored` (see `api.md` for the timing rationale), and the value must never be `[UdonSynced]` (each client evaluates `player.isVRCPlus` locally).
+Two technical constraints shape the code: `isVRCPlus` must be read after `OnPlayerRestored` (see `api.md` for the timing rationale), and the value must never be `[UdonSynced]` (each client evaluates `player.isVRCPlus` locally, so a synced value would misreport state for every other client).
 
 ```csharp
 using UdonSharp;
@@ -908,20 +908,20 @@ using VRC.SDKBase;
 
 public class LocalVRCPlusBadge : UdonSharpBehaviour
 {
-    [SerializeField] private GameObject plusBadge; // purely visual
+    [SerializeField] private GameObject plusBadge;
 
     public override void OnPlayerRestored(VRCPlayerApi player)
     {
         if (player == null || !player.isLocal) return;
-        plusBadge.SetActive(player.isVRCPlus); // cosmetic display only
+        plusBadge.SetActive(player.isVRCPlus);
     }
 }
 ```
 
 Notes:
-- The badge is on the **local** player and read against the local `VRCPlayerApi`. Applying this to remote players works the same way — iterate `VRCPlayerApi.GetPlayers()` on each client and set each badge locally; never sync the result.
-- Resist the temptation to skip the `OnPlayerRestored` gate. Reading in `OnPlayerJoined` may return an unset / default value while the profile is still being fetched.
-- If you need to react to a hypothetical future subscription change mid-session, re-read inside whatever update hook you already have; still no `[UdonSynced]`.
+- The read is on the **local** player against the local `VRCPlayerApi`. Applying this to remote players works the same way — iterate `VRCPlayerApi.GetPlayers()` on each client and evaluate each player's `isVRCPlus` locally; never sync the result.
+- Do not skip the `OnPlayerRestored` gate. Reading in `OnPlayerJoined` may return an unset / default value while the profile is still being fetched.
+- If you need to react to a subscription change mid-session, re-read inside whatever update hook you already have; still no `[UdonSynced]`.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -351,8 +351,7 @@ Namespace for all VRC Constraints: `VRC.SDK3.Dynamics.Constraint.Components`.
 
 Small surface, but each item has non-obvious consequences documented elsewhere — this entry just routes you to them.
 
-- **`VRCPlayerApi.isVRCPlus`** (bool) added. Evaluated per-client; read after `OnPlayerRestored`, not inside `OnPlayerJoined`. Never `[UdonSynced]` the result. Full timing and anti-sync rationale: `api.md` (VRCPlayerApi Properties > isVRCPlus subsection).
-- **NEVER #19** (design-axis, not silent-failure): do not gate core gameplay, safety, or moderation features by `isVRCPlus`. See SKILL.md NEVER table and the cosmetic-indicator pattern in `patterns-core.md`.
+- **`VRCPlayerApi.isVRCPlus`** (bool) added. Evaluated per-client; read after `OnPlayerRestored`, not inside `OnPlayerJoined`. Never `[UdonSynced]` the result. Full timing and anti-sync rationale: `api.md` (VRCPlayerApi Properties > isVRCPlus subsection). Worked example: `patterns-core.md` (VRC+ Detection — Reading `isVRCPlus`).
 - **VRCRaycast**: avatar-side component (added 3.10.3). Udon runtime access is not indicated by the release notes. World builders should design collider/layer setup with avatar-driven raycasts in mind — see `unity-vrc-world-sdk-3/references/components.md`.
 - **Mirror rendering internals**: VRChat's mirror pipeline moved from `OnWillRenderObject` to `Camera.onPreCull` for 2026.1.3 client parity. Udon scripts do not interact with either hook, so no script-side migration is required.
 - **Toon Standard shader** (avatar-only): not covered by this skill.


### PR DESCRIPTION
## Release v1.7.1

Merges `dev` into `main` to publish v1.7.1 — a patch release that supersedes v1.7.0.

### Why v1.7.1 and not v1.7.0 republish

- v1.7.0 was published to npm on 2026-04-18 with SDK 3.10.3 support, but its GitHub Release was later reverted to draft because the included `NEVER #19` rule (forbidding gameplay/area gating by `isVRCPlus`) overstepped the skill's responsibility — the skill should teach technical correctness and present options, not prescribe design decisions
- PR #157 removed NEVER #19 and reframed surrounding prose neutrally; this PR pushes that correction plus everything from v1.7.0 into a single clean v1.7.1 release
- npm `1.7.0` stays published (immutable); consumers should update to `^1.7.1`

### Contents of v1.7.1 (combined)

- #152 — SDK 3.10.3 feature additions: `isVRCPlus`, VRCRaycast world-side note
- #153 — SDK 3.10.3 bug-fix notes + 3-marker version convention
- #154 — SDK 3.10.3 version bumps across 27 files + calendar-date → version-tag refactor
- #157 — NEVER #19 removal + neutral reframe of VRC+ guidance

### Post-merge plan

1. Release Drafter auto-updates the existing v1.7.0 draft with #157 added
2. Retag the draft `v1.7.0 → v1.7.1` and replace body with the combined user-facing notes (prepared)
3. Publish → `publish.yml` → `npm publish agent-skills-vrc-udon@1.7.1`

### CI-only, CodeRabbit skip

Per `feedback_release_pr_skip_review.md`: release PRs (dev→main) merge after CI passes, no CodeRabbit review required.
