### PR TITLE
docs: document Skills responsibility boundary in CONTRIBUTING and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/knowledge_request.yml
+++ b/.github/ISSUE_TEMPLATE/knowledge_request.yml
@@ -28,6 +28,20 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: failure_basis
+    attributes:
+      label: Failure basis
+      description: |
+        What justifies this rule/pattern being added to the skill?
+        See CONTRIBUTING.md "Content Scope" for the policy.
+      options:
+        - Technical — silent failure, compile error, data desync, API ignore, memory leak, etc.
+        - Platform enforcement — VRChat TOS violation with mechanical consequence (world deletion, account restriction)
+        - Design preference / community norm (not covered — skill scope excludes this)
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,43 @@ This project accepts **Issues only**. Pull Requests are **not accepted**.
 
 All fixes and updates are made by the maintainer. If you find an issue, please report it via GitHub Issues and the maintainer will address it.
 
+## Content Scope — Technical Truth, Not Design Prescription
+
+**The skills teach technical truth and present options. They do NOT prescribe what users should build, and they do NOT forbid design choices based on community norms, ethics, or platform policy that lacks mechanical enforcement.**
+
+Users of the skills decide what to build and are responsible for how they use them. The skill's job is to make sure those users have accurate technical information and a working menu of options.
+
+### In scope (the skill rejects it → something technically breaks)
+
+Rules, patterns, and NEVER entries are in scope when the failure is **technical or mechanically enforced**:
+
+- Silent failures (API call ignored, state desync, ownership not transferred)
+- Compile errors (UdonSharp whitelist violations, unsupported language features)
+- Runtime bugs (null reference, index out of range, networking race conditions)
+- Data corruption / desync (late joiner inconsistency, sync var overflow, unsynced state drift)
+- Memory leaks, GC pressure, VRAM blowout, frame-rate pathologies
+- **Platform policy with mechanical enforcement** — VRChat TOS violations that trigger world deletion, account restrictions, or automated takedowns. These have real, measurable consequences and belong in the skill.
+
+### Out of scope (the skill does NOT prescribe this)
+
+Design preferences, community aesthetics, and ethics **without mechanical consequence** are out of scope:
+
+- "VRChat+ gameplay-gating is bad for the community" (design preference — no mechanical failure)
+- "Players shouldn't be able to do X because it feels unfair" (UX preference — no platform enforcement)
+- "Avoid Y because it's considered rude" (community norm — no technical or platform consequence)
+
+Contributors are free to raise these as discussions, but they are not valid grounds for a skill rule. Users make these calls in their own projects.
+
+### Reviewer test
+
+> **Is the failure technical (or platform-enforced), or is it social?** Only technical and platform-enforced failures earn rule slots, NEVER entries, or anti-pattern coverage.
+
+If the only reason "this is bad" is "the community dislikes it" or "it's ethically questionable," the rule belongs in the user's project guidelines, not in this skill.
+
+### Historical reference
+
+**NEVER #19** (removed in v1.7.1 via [PR #157](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/157)) prescribed against VRChat+ gameplay-gating. It was removed because the failure mode was a community/design preference, not a technical or platform-enforced one. That removal is the precedent for this policy: rules whose justification collapses to "social consequence only" are rejected going forward.
+
 ## What to Report
 
 - **Incorrect constraints**: A rule says something is blocked but it actually works (or vice versa)


### PR DESCRIPTION
## Summary

Documents the Skills responsibility boundary policy in-repo via `CONTRIBUTING.md` + Issue template scoping question. **Defensive line** against future community-norm-based PRs submitted by external contributors (or AI agents without session memory).

**2 commits, 2 files, +51 lines.** No skill content changes.

## Context

After v1.7.1 removed NEVER #19 (experimental design-axis rule forbidding VRC+ gameplay-gating) as overreach, the working policy was established:

> Skills teach technical truth and present options. They do NOT prescribe design choices based on community norms, ethics, or platform policy without mechanical enforcement.

That policy was recorded in auto-memory (`feedback_skills_responsibility_boundary.md`) — protecting the primary maintainer's workflow — but **nothing in-repo documented it**. External contributors and fresh AI sessions had no durable reference.

## Changes

| Commit | Scope |
|--------|-------|
| `b4fa5a0` | `docs` — New `## Content Scope — Technical Truth, Not Design Prescription` section in `CONTRIBUTING.md`. Includes in-scope examples, out-of-scope examples, the reviewer test question ("technical vs social?"), platform-policy carve-out (TOS with mechanical enforcement = in-scope; community norms = out-of-scope), and reference to NEVER #19 / PR #157 as precedent. |
| `da85adb` | `chore` — New required `failure_basis` dropdown in `.github/ISSUE_TEMPLATE/knowledge_request.yml` with 3 options: Technical / Platform enforcement / Design preference (not covered). Surfaces out-of-scope requests at submission time. |

## Judgment calls documented in the implementation

- `bug_report.yml` **skipped** — bugs are technical by definition; scoping dropdown would add friction with zero filtering value
- `quick_feedback.yml` **skipped** — free-form catch-all; required dropdown defeats its purpose
- README pointer **skipped** — 5 language translations (`README.ja.md`, `README.ko.md`, `README.zh-CN.md`, `README.zh-TW.md`) would require synchronized edits. CONTRIBUTING.md already linked from READMEs via existing PR-policy line, so discoverability is preserved.
- Out-of-scope option text uses Issue author's phrasing "(not covered — skill scope excludes this)" — treating Issue author voice as the policy source of truth

## Why the dropdown's third option is "self-disqualifying"

If a contributor selects "Design preference / community norm (not covered — skill scope excludes this)", they're declaring their own request is out of scope. This is intentional design: surface out-of-scope requests at submission time so reviewers see a clear signal for courteous close, rather than debating scope after a lengthy PR.

## Quality review

6-axis lightweight review PASSED (policy clarity, template validity, YAML parseability, scope discipline, tone consistency, intentional-design verification).

## Test plan

- [ ] Maintainer verifies `CONTRIBUTING.md` section renders correctly and reads self-contained
- [ ] Maintainer submits a test knowledge_request Issue (can close immediately) to confirm the dropdown renders and is required
- [ ] CI (EditorConfig, Markdown Links, etc.) passes

## Related

- Closes #159
- Policy precedent: PR #157 (v1.7.1, NEVER #19 removal)
- Related memory (maintainer-side): `feedback_skills_responsibility_boundary.md`

## Out of scope (explicit)

- No changes to `skills/` — v1.7.1 already cleaned skill content
- No changes to `templates/*.md` — those are distributed to end-users, not contributors
- No `CHANGELOG.md` changes (Release Drafter managed)
