### PR TITLE
feat(skills): cover UdonBehaviour programSource silent no-op (Rule 9)

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -108,7 +108,10 @@ using UdonSharpEditor;
 // Add UdonSharpBehaviour component
 MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
 
-// This creates both the UdonBehaviour and the proxy
+// This creates the UdonBehaviour, assigns its programSource (.asset), and creates the proxy.
+// Skipping this helper and calling AddComponent<UdonBehaviour>() directly produces a component
+// with empty programSource — silently does nothing at runtime. See troubleshooting.md
+// "UdonBehaviour with Empty Program Source" for the diagnostic walk-through.
 #endif
 ```
 
@@ -668,3 +671,4 @@ public class UdonSharpProgramAssetAutoGenerator : AssetPostprocessor
 - Abstract classes are intentionally skipped (they cannot have their own UdonSharpProgramAsset)
 - The `Editor` folder placement is required (scripts in `Editor` are not compiled by UdonSharp)
 - Generation only runs after domain reload (`didDomainReload`), not on every asset import
+- **Asset generation does not wire `UdonBehaviour.programSource`** — this generator only creates the `.asset` file. Assigning it to a `UdonBehaviour` on a GameObject is a separate step; use [`AddUdonSharpComponent`](#addudonsharpcomponent) for new components, or see "UdonBehaviour with Empty Program Source" in `troubleshooting.md` for diagnosing existing components

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1199,6 +1199,7 @@ UdonBehaviour ub = gameObject.GetComponent<UdonBehaviour>();
 UdonSharpProgramAsset programAsset =
     AssetDatabase.LoadAssetAtPath<UdonSharpProgramAsset>(
         "Assets/Path/MyScript.asset");
+Undo.RecordObject(ub, "Assign UdonSharpProgramAsset");
 ub.programSource = programAsset;
 EditorUtility.SetDirty(ub);
 #endif

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1184,8 +1184,8 @@ Prefer the UdonSharp helper that wires `programSource` automatically:
 #if UNITY_EDITOR && !COMPILER_UDONSHARP
 using UdonSharpEditor;
 
-// Creates UdonBehaviour AND sets programSource in one call
-MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
+    // Creates UdonBehaviour AND sets programSource in one call
+    MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
 #endif
 ```
 
@@ -1195,13 +1195,13 @@ If the `UdonBehaviour` was created without `AddUdonSharpComponent`, assign manua
 #if UNITY_EDITOR && !COMPILER_UDONSHARP
 using UnityEditor;
 
-UdonBehaviour ub = gameObject.GetComponent<UdonBehaviour>();
-UdonSharpProgramAsset programAsset =
-    AssetDatabase.LoadAssetAtPath<UdonSharpProgramAsset>(
-        "Assets/Path/MyScript.asset");
-Undo.RecordObject(ub, "Assign UdonSharpProgramAsset");
-ub.programSource = programAsset;
-EditorUtility.SetDirty(ub);
+    UdonBehaviour ub = gameObject.GetComponent<UdonBehaviour>();
+    UdonSharpProgramAsset programAsset =
+        AssetDatabase.LoadAssetAtPath<UdonSharpProgramAsset>(
+            "Assets/Path/MyScript.asset");
+    Undo.RecordObject(ub, "Assign UdonSharpProgramAsset");
+    ub.programSource = programAsset;
+    EditorUtility.SetDirty(ub);
 #endif
 ```
 
@@ -1209,7 +1209,7 @@ Or, in the Inspector, drag the `.asset` from the Project window into the `Progra
 
 **Prevention:**
 
-When automating UdonBehaviour creation, verify `programSource` is set as a post-step. See [Rule 9 in `rules/udonsharp-constraints.md`](../rules/udonsharp-constraints.md) for the verification procedure.
+When automating UdonBehaviour creation, verify `programSource` is set as a post-step. See [Rule 9 in `rules/udonsharp-constraints.md`](../rules/udonsharp-constraints.md#9-udonbehaviour-component-wiring) for the verification procedure.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1149,6 +1149,69 @@ EditorUtility.SetDirty(behaviour);
 
 ---
 
+### UdonBehaviour with Empty Program Source (Silent No-Op)
+
+**Symptoms:**
+
+- `UdonBehaviour` component is attached to the GameObject
+- The corresponding `UdonSharpProgramAsset` (`.asset`) exists in the project
+- The `.cs` script compiles without errors
+- Yet **no Udon events fire** — `Start()`, `Interact()`, `OnPlayerJoined()`, etc. never run
+- No errors, no warnings, no log output
+
+**Cause:**
+
+The `UdonBehaviour.programSource` field is empty. Without this reference, the component has nothing to execute. Unity treats it as a valid component (no missing-script warning), so the failure is invisible until you notice the script does not run.
+
+This commonly happens when AI agents automate Unity setup (Unity MCP servers, custom editor scripts, prefab manipulation tools) and add `UdonBehaviour` components directly without going through `AddUdonSharpComponent`.
+
+**Distinction from "The associated script cannot be loaded":**
+
+- That error fires when the `.asset` is missing entirely (Rule 8 violation)
+- This silent no-op fires when the `.asset` exists but is not assigned to `programSource` (Rule 9 violation)
+
+**Diagnosis:**
+
+1. Select the GameObject in the Hierarchy
+2. Inspect the `UdonBehaviour` component
+3. Check the **Program Source** field — if it shows `None (Abstract Udon Program Asset)`, this is the cause
+
+**Solution:**
+
+Prefer the UdonSharp helper that wires `programSource` automatically:
+
+```csharp
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+using UdonSharpEditor;
+
+// Creates UdonBehaviour AND sets programSource in one call
+MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
+#endif
+```
+
+If the `UdonBehaviour` was created without `AddUdonSharpComponent`, assign manually:
+
+```csharp
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+using UnityEditor;
+
+UdonBehaviour ub = gameObject.GetComponent<UdonBehaviour>();
+UdonSharpProgramAsset programAsset =
+    AssetDatabase.LoadAssetAtPath<UdonSharpProgramAsset>(
+        "Assets/Path/MyScript.asset");
+ub.programSource = programAsset;
+EditorUtility.SetDirty(ub);
+#endif
+```
+
+Or, in the Inspector, drag the `.asset` from the Project window into the `Program Source` slot.
+
+**Prevention:**
+
+When automating UdonBehaviour creation, verify `programSource` is set as a post-step. See [Rule 9 in `rules/udonsharp-constraints.md`](../rules/udonsharp-constraints.md) for the verification procedure.
+
+---
+
 ## Performance Issues
 
 ### FPS Drop from Many UdonBehaviours
@@ -1540,6 +1603,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | **Contact player is null** | Check `info.isAvatar` before accessing |
 | **Trigger not firing for seated players** | PlayerLocal collider disabled in station — use position check workaround |
 | **.asset missing / script not loaded** | Install auto-generator in `Assets/Editor/`, then reimport the affected `.cs` |
+| **UdonBehaviour silently does nothing** | Check `Program Source` slot — likely empty; assign `.asset` or use `AddUdonSharpComponent` |
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -140,6 +140,34 @@ Every `.cs` UdonSharpBehaviour needs a corresponding `.asset` (UdonSharpProgramA
 
 Do NOT assume the auto-generator is already installed. The agent cannot verify installation status without explicitly checking, so skipping this procedure based on assumption is prohibited. See `references/editor-scripting.md` for the full implementation.
 
+### 9. UdonBehaviour Component Wiring
+
+After the `.asset` file is generated (Rule 8), the GameObject's `UdonBehaviour` component must reference that `.asset` in its **Program Source** field. Without this assignment, the UdonBehaviour exists on the GameObject but executes nothing — no error, no warning, no compile failure. The same silent-failure family as Rule 8, but at the **component layer** instead of the file layer.
+
+| State | `.asset` exists? | `programSource` set? | Symptom |
+|-------|:-:|:-:|---------|
+| Healthy | Yes | Yes | Code runs |
+| Rule 8 violation | No | (n/a) | "The associated script cannot be loaded" |
+| Rule 9 violation | Yes | No | Component present, **no events fire**, no log |
+
+**When the agent creates UdonBehaviour components programmatically (Unity automation, editor scripts, prefab manipulation), it MUST verify after creation:**
+
+1. The GameObject has a `UdonBehaviour` component
+2. That component's `programSource` field references the matching `UdonSharpProgramAsset`
+3. The referenced `.asset` is the one paired with the intended `.cs` (same base name, same folder)
+
+**Preferred API (handles wiring automatically):**
+
+```csharp
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+using UdonSharpEditor;
+// Creates UdonBehaviour AND sets programSource in one call
+MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
+#endif
+```
+
+When manipulating `UdonBehaviour` directly without `AddUdonSharpComponent`, the agent is responsible for assigning `programSource` itself. See `references/editor-scripting.md` for proxy-system specifics and `references/troubleshooting.md` for diagnostic steps.
+
 ## Attribute Quick Reference
 
 ### Class Level
@@ -187,3 +215,4 @@ Types that can be used with `[UdonSynced]`:
 - [ ] Not using `AddListener()`
 - [ ] Unity callbacks (OnTriggerEnter, etc.) do not have override
 - [ ] Auto-generator (`UdonSharpProgramAssetAutoGenerator.cs`) confirmed present in `Assets/Editor/` (installed if it was missing)
+- [ ] Every UdonBehaviour created programmatically has its `programSource` populated with the matching `.asset` (Rule 9)

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -161,8 +161,8 @@ After the `.asset` file is generated (Rule 8), the GameObject's `UdonBehaviour` 
 ```csharp
 #if UNITY_EDITOR && !COMPILER_UDONSHARP
 using UdonSharpEditor;
-// Creates UdonBehaviour AND sets programSource in one call
-MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
+    // Creates UdonBehaviour AND sets programSource in one call
+    MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
 #endif
 ```
 


### PR DESCRIPTION
## Summary

Adds coverage for a new failure mode reported in **Unity automation contexts** (Unity MCP, custom editor scripts, prefab manipulation tools): the agent successfully creates the `.cs` script and the auto-generated `UdonSharpProgramAsset` (`.asset`), but leaves the **`UdonBehaviour.programSource` field empty** on the GameObject. Result: silent no-op — component appears attached, no errors, no warnings, but no Udon events ever fire.

This is **distinct** from the existing NEVER #16 / "The associated script cannot be loaded" coverage:

| State | `.asset` exists? | `programSource` set? | Symptom |
|-------|:-:|:-:|---------|
| Healthy | Yes | Yes | Code runs |
| Rule 8 / NEVER #16 (file layer) | No | (n/a) | "The associated script cannot be loaded" |
| **Rule 9 (component layer, this PR)** | Yes | No | Component present, **no events fire**, no log |

Closes #161.

## Scope discipline

Per the recently codified `CONTRIBUTING.md` responsibility boundary:

> Silent failures (API call ignored, state desync, ownership not transferred) — in scope

This is a textbook silent failure. Programmatically verifiable. Technical, not social. Earns a rule slot cleanly.

**Intentional non-changes**:
- No NEVER list addition to `SKILL.md` (would re-inflate after v1.7.1 #19 removal; rules in `rules/udonsharp-constraints.md` are already always-loaded so visibility is preserved without duplication)
- No `CHEATSHEET.md` change (wiring is not a one-page-quick-reference topic)
- No `templates/*.md` change (no rule file added/renamed, only existing rules extended)
- No SDK version table update (this is independent of SDK version)

## Changes

| File | Change |
|------|--------|
| `skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md` | + Rule 9 with three-step verification procedure and a comparison table; + one Validation Checklist line |
| `skills/unity-vrc-udon-sharp/references/troubleshooting.md` | + new "UdonBehaviour with Empty Program Source (Silent No-Op)" section under Editor Issues with symptoms / cause / distinction / diagnosis / solution / prevention; + Quick Reference table row |
| `skills/unity-vrc-udon-sharp/references/editor-scripting.md` | Expanded `AddUdonSharpComponent` comment to clarify it wires `programSource` automatically; + cross-reference bullet under Auto-Generation Limitations clarifying that asset generation does NOT wire components |

Total: +99/-1 across 3 files (no new files, no deletions).

## Independent review pre-PR

Two parallel agents reviewed the diff before this PR was opened:

- **`oh-my-claudecode:critic`** (8-dimension skill-judge rubric): **VERDICT: RAISE-1** — all dimensions flat or positive vs the prior 112/120 baseline; expected post-merge band 113-114/120, still A grade.
- **`everything-claude-code:code-reviewer`**: **VERDICT: APPROVE-WITH-NITS** — 0 CRITICAL, 0 HIGH, 1 MEDIUM (pre-existing convention not introduced by this diff), 1 LOW (missing `Undo.RecordObject` — fixed in commit `5c55702`), 1 NIT (table row casing, intentionally matches existing fragment-style entries like "Contact player is null").

The score-must-not-drop user constraint should be satisfied; the second commit addresses the only owned reviewer finding.

## Editor-context note (pre-empting future review confusion)

The manual fallback snippet uses `gameObject.GetComponent<UdonBehaviour>()` inside `#if UNITY_EDITOR && !COMPILER_UDONSHARP`. Rule 4 of `udonsharp-constraints.md` says `GetComponent<UdonBehaviour>()` requires cast syntax — but **Rule 4 applies to Udon runtime code only**, not to editor-side C# scripts. The existing `editor-scripting.md:76` already establishes this same pattern, so it is consistent with the file's pre-existing convention.

## Test plan

- [x] `npm pack --dry-run` succeeds (70 files, 283.4 kB, no unexpected file changes)
- [ ] CI: Symlink Integrity passes
- [ ] CI: Hook Scripts passes
- [ ] CI: EditorConfig passes (all additions use spaces, not tabs)
- [ ] CI: Markdown Links (lychee) passes — relative path `../rules/udonsharp-constraints.md` and in-page anchor `#addudonsharpcomponent` both verified by reviewer
- [ ] CI: npm Pack Test passes
- [ ] CI: Version Sync passes (no version bumps in this PR)
- [ ] CodeRabbit review approval

## Out of scope

- Score re-verification by skill-judge in CI (would require new tooling — relying on critic's pre-PR review for now)
- New tooling for AI/Unity automation (this is knowledge that belongs in the existing skill, not a new tool integration layer)
- Hook-level static check for empty `programSource` in `.unity`/`.prefab` files (YAML parsing too fragile; deferred until repeated occurrences justify it)