### PR TITLE
Release v1.8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/knowledge_request.yml
+++ b/.github/ISSUE_TEMPLATE/knowledge_request.yml
@@ -28,6 +28,20 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: failure_basis
+    attributes:
+      label: Failure basis
+      description: |
+        What justifies this rule/pattern being added to the skill?
+        See CONTRIBUTING.md "Content Scope" for the policy.
+      options:
+        - Technical — silent failure, compile error, data desync, API ignore, memory leak, etc.
+        - Platform enforcement — VRChat TOS violation with mechanical consequence (world deletion, account restriction)
+        - Design preference / community norm (not covered — skill scope excludes this)
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,43 @@ This project accepts **Issues only**. Pull Requests are **not accepted**.
 
 All fixes and updates are made by the maintainer. If you find an issue, please report it via GitHub Issues and the maintainer will address it.
 
+## Content Scope — Technical Truth, Not Design Prescription
+
+**The skills teach technical truth and present options. They do NOT prescribe what users should build, and they do NOT forbid design choices based on community norms, ethics, or platform policy that lacks mechanical enforcement.**
+
+Users of the skills decide what to build and are responsible for how they use them. The skill's job is to make sure those users have accurate technical information and a working menu of options.
+
+### In scope (the skill rejects it → something technically breaks)
+
+Rules, patterns, and NEVER entries are in scope when the failure is **technical or mechanically enforced**:
+
+- Silent failures (API call ignored, state desync, ownership not transferred)
+- Compile errors (UdonSharp whitelist violations, unsupported language features)
+- Runtime bugs (null reference, index out of range, networking race conditions)
+- Data corruption / desync (late joiner inconsistency, sync var overflow, unsynced state drift)
+- Memory leaks, GC pressure, VRAM blowout, frame-rate pathologies
+- **Platform policy with mechanical enforcement** — VRChat TOS violations that trigger world deletion, account restrictions, or automated takedowns. These have real, measurable consequences and belong in the skill.
+
+### Out of scope (the skill does NOT prescribe this)
+
+Design preferences, community aesthetics, and ethics **without mechanical consequence** are out of scope:
+
+- "VRChat+ gameplay-gating is bad for the community" (design preference — no mechanical failure)
+- "Players shouldn't be able to do X because it feels unfair" (UX preference — no platform enforcement)
+- "Avoid Y because it's considered rude" (community norm — no technical or platform consequence)
+
+Contributors are free to raise these as discussions, but they are not valid grounds for a skill rule. Users make these calls in their own projects.
+
+### Reviewer test
+
+> **Is the failure technical (or platform-enforced), or is it social?** Only technical and platform-enforced failures earn rule slots, NEVER entries, or anti-pattern coverage.
+
+If the only reason "this is bad" is "the community dislikes it" or "it's ethically questionable," the rule belongs in the user's project guidelines, not in this skill.
+
+### Historical reference
+
+**NEVER #19** (removed in v1.7.1 via [PR #157](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/157)) prescribed against VRChat+ gameplay-gating. It was removed because the failure mode was a community/design preference, not a technical or platform-enforced one. That removal is the precedent for this policy: rules whose justification collapses to "social consequence only" are rejected going forward.
+
 ## What to Report
 
 - **Incorrect constraints**: A rule says something is blocked but it actually works (or vice versa)

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -108,7 +108,10 @@ using UdonSharpEditor;
 // Add UdonSharpBehaviour component
 MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
 
-// This creates both the UdonBehaviour and the proxy
+// This creates the UdonBehaviour, assigns its programSource (.asset), and creates the proxy.
+// Skipping this helper and calling AddComponent<UdonBehaviour>() directly produces a component
+// with empty programSource — silently does nothing at runtime. See troubleshooting.md
+// "UdonBehaviour with Empty Program Source" for the diagnostic walk-through.
 #endif
 ```
 
@@ -668,3 +671,4 @@ public class UdonSharpProgramAssetAutoGenerator : AssetPostprocessor
 - Abstract classes are intentionally skipped (they cannot have their own UdonSharpProgramAsset)
 - The `Editor` folder placement is required (scripts in `Editor` are not compiled by UdonSharp)
 - Generation only runs after domain reload (`didDomainReload`), not on every asset import
+- **Asset generation does not wire `UdonBehaviour.programSource`** — this generator only creates the `.asset` file. Assigning it to a `UdonBehaviour` on a GameObject is a separate step; use [`AddUdonSharpComponent`](#addudonsharpcomponent) for new components, or see "UdonBehaviour with Empty Program Source" in `troubleshooting.md` for diagnosing existing components

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1149,6 +1149,70 @@ EditorUtility.SetDirty(behaviour);
 
 ---
 
+### UdonBehaviour with Empty Program Source (Silent No-Op)
+
+**Symptoms:**
+
+- `UdonBehaviour` component is attached to the GameObject
+- The corresponding `UdonSharpProgramAsset` (`.asset`) exists in the project
+- The `.cs` script compiles without errors
+- Yet **no Udon events fire** — `Start()`, `Interact()`, `OnPlayerJoined()`, etc. never run
+- No errors, no warnings, no log output
+
+**Cause:**
+
+The `UdonBehaviour.programSource` field is empty. Without this reference, the component has nothing to execute. Unity treats it as a valid component (no missing-script warning), so the failure is invisible until you notice the script does not run.
+
+This commonly happens when AI agents automate Unity setup (Unity MCP servers, custom editor scripts, prefab manipulation tools) and add `UdonBehaviour` components directly without going through `AddUdonSharpComponent`.
+
+**Distinction from "The associated script cannot be loaded":**
+
+- That error fires when the `.asset` is missing entirely (Rule 8 violation)
+- This silent no-op fires when the `.asset` exists but is not assigned to `programSource` (Rule 9 violation)
+
+**Diagnosis:**
+
+1. Select the GameObject in the Hierarchy
+2. Inspect the `UdonBehaviour` component
+3. Check the **Program Source** field — if it shows `None (Abstract Udon Program Asset)`, this is the cause
+
+**Solution:**
+
+Prefer the UdonSharp helper that wires `programSource` automatically:
+
+```csharp
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+using UdonSharpEditor;
+
+    // Creates UdonBehaviour AND sets programSource in one call
+    MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
+#endif
+```
+
+If the `UdonBehaviour` was created without `AddUdonSharpComponent`, assign manually:
+
+```csharp
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+using UnityEditor;
+
+    UdonBehaviour ub = gameObject.GetComponent<UdonBehaviour>();
+    UdonSharpProgramAsset programAsset =
+        AssetDatabase.LoadAssetAtPath<UdonSharpProgramAsset>(
+            "Assets/Path/MyScript.asset");
+    Undo.RecordObject(ub, "Assign UdonSharpProgramAsset");
+    ub.programSource = programAsset;
+    EditorUtility.SetDirty(ub);
+#endif
+```
+
+Or, in the Inspector, drag the `.asset` from the Project window into the `Program Source` slot.
+
+**Prevention:**
+
+When automating UdonBehaviour creation, verify `programSource` is set as a post-step. See [Rule 9 in `rules/udonsharp-constraints.md`](../rules/udonsharp-constraints.md#9-udonbehaviour-component-wiring) for the verification procedure.
+
+---
+
 ## Performance Issues
 
 ### FPS Drop from Many UdonBehaviours
@@ -1540,6 +1604,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | **Contact player is null** | Check `info.isAvatar` before accessing |
 | **Trigger not firing for seated players** | PlayerLocal collider disabled in station — use position check workaround |
 | **.asset missing / script not loaded** | Install auto-generator in `Assets/Editor/`, then reimport the affected `.cs` |
+| **UdonBehaviour silently does nothing** | Check `Program Source` slot — likely empty; assign `.asset` or use `AddUdonSharpComponent` |
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -140,6 +140,34 @@ Every `.cs` UdonSharpBehaviour needs a corresponding `.asset` (UdonSharpProgramA
 
 Do NOT assume the auto-generator is already installed. The agent cannot verify installation status without explicitly checking, so skipping this procedure based on assumption is prohibited. See `references/editor-scripting.md` for the full implementation.
 
+### 9. UdonBehaviour Component Wiring
+
+After the `.asset` file is generated (Rule 8), the GameObject's `UdonBehaviour` component must reference that `.asset` in its **Program Source** field. Without this assignment, the UdonBehaviour exists on the GameObject but executes nothing — no error, no warning, no compile failure. The same silent-failure family as Rule 8, but at the **component layer** instead of the file layer.
+
+| State | `.asset` exists? | `programSource` set? | Symptom |
+|-------|:-:|:-:|---------|
+| Healthy | Yes | Yes | Code runs |
+| Rule 8 violation | No | (n/a) | "The associated script cannot be loaded" |
+| Rule 9 violation | Yes | No | Component present, **no events fire**, no log |
+
+**When the agent creates UdonBehaviour components programmatically (Unity automation, editor scripts, prefab manipulation), it MUST verify after creation:**
+
+1. The GameObject has a `UdonBehaviour` component
+2. That component's `programSource` field references the matching `UdonSharpProgramAsset`
+3. The referenced `.asset` is the one paired with the intended `.cs` (same base name, same folder)
+
+**Preferred API (handles wiring automatically):**
+
+```csharp
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+using UdonSharpEditor;
+    // Creates UdonBehaviour AND sets programSource in one call
+    MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
+#endif
+```
+
+When manipulating `UdonBehaviour` directly without `AddUdonSharpComponent`, the agent is responsible for assigning `programSource` itself. See `references/editor-scripting.md` for proxy-system specifics and `references/troubleshooting.md` for diagnostic steps.
+
 ## Attribute Quick Reference
 
 ### Class Level
@@ -187,3 +215,4 @@ Types that can be used with `[UdonSynced]`:
 - [ ] Not using `AddListener()`
 - [ ] Unity callbacks (OnTriggerEnter, etc.) do not have override
 - [ ] Auto-generator (`UdonSharpProgramAssetAutoGenerator.cs`) confirmed present in `Assets/Editor/` (installed if it was missing)
+- [ ] Every UdonBehaviour created programmatically has its `programSource` populated with the matching `.asset` (Rule 9)


### PR DESCRIPTION
## Summary

Release v1.8.0 — UdonBehaviour wiring (Rule 9) + responsibility-boundary documentation.

**2 PRs since v1.7.1:**
- #160 — `docs`: Responsibility boundary policy in CONTRIBUTING.md + Issue template scoping question
- #162 — `feat`: Rule 9 covering UdonBehaviour `programSource` silent no-op (component-layer wiring)

**Version bump driver**: PR #162 carries `release: feature` → minor bump (1.7.1 → 1.8.0).

## What changed

### UdonSharp Skill
- New **Rule 9: UdonBehaviour Component Wiring** — covers the silent failure mode where the `.asset` is generated but `programSource` is left empty during automation (Unity MCP, editor scripts). Distinct from Rule 8 (file-layer): Rule 9 is component-layer.
- New troubleshooting entry "UdonBehaviour with Empty Program Source (Silent No-Op)" with symptoms / cause / distinction / diagnosis / solution / prevention
- `editor-scripting.md` cross-references between `AddUdonSharpComponent` and the auto-generation Limitations note

### Documentation & Policy
- `CONTRIBUTING.md` — new "Content Scope — Technical Truth, Not Design Prescription" section codifying the in-scope vs out-of-scope reviewer test
- `.github/ISSUE_TEMPLATE/knowledge_request.yml` — new `failure_basis` dropdown surfaces out-of-scope (community-norm-only) requests at submission time

## Merge instructions

**DO NOT SQUASH** — preserve commit history per repo release policy. Use plain merge commit so Release Drafter sees both PR commits.

## Post-merge

1. Release Drafter will create/update a v1.8.0 draft release on main
2. The draft notes will be rewritten by hand to follow v1.7.1 format (Quality Metrics table, install snippet, etc.)
3. Publishing the GitHub Release triggers `publish.yml` which runs `npm publish --provenance`

## Test plan

- [ ] CI green on this PR (Symlink, Hooks, EditorConfig, Markdown Links, npm Pack, Version Sync)
- [ ] Merge with merge commit (NOT squash)
- [ ] Release Drafter draft appears on main with v1.8.0 tag
- [ ] Hand-rewritten release notes match v1.7.1 format
- [ ] Publish triggers npm publish workflow
- [ ] `npm view agent-skills-vrc-udon@1.8.0` confirms publication

## Skipping CodeRabbit

Per project policy (memory: `feedback_release_pr_skip_review`), release PRs (dev → main) skip CodeRabbit review since the constituent feature/fix PRs were already reviewed individually. Merge after CI green.