### PR TITLE
fix(installer): re-install on version mismatch (Issue #164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,19 @@ jobs:
       - name: Test installer list
         run: node bin/install.mjs --list
 
+  installer-tests:
+    name: Installer Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "22"
+
+      - name: Run installer tests
+        run: npm test
+
   editorconfig:
     name: EditorConfig
     runs-on: ubuntu-latest

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -229,6 +229,13 @@ console.log(bold('agent-skills-vrc-udon') + ` v${pkg.version}`);
 
 // Version detection: show upgrade/already-up-to-date message
 const installedVersion = readInstalledVersion();
+// Treat any version mismatch (upgrade or downgrade) as a request to refresh
+// installed content, so .version never drifts ahead of the actual files.
+// Without this, an upgrade re-run without --force would print
+// "Upgrading from..." but keep the old skills/ on disk while bumping .version,
+// permanently masking new rules from existing users (Issue #164).
+const isUpgrade = installedVersion !== null && installedVersion !== pkg.version;
+const shouldOverwrite = force || isUpgrade;
 if (installedVersion !== null) {
   if (installedVersion === pkg.version) {
     console.log(dim(`Already up to date (v${pkg.version}).`));
@@ -244,7 +251,7 @@ let copied = 0;
 let skipped = 0;
 
 // 1. Copy skills/
-if (existsSync(AGENT_DOCS_DEST) && !force) {
+if (existsSync(AGENT_DOCS_DEST) && !shouldOverwrite) {
   console.log(yellow('  SKIP') + ` .agent-skills/skills/ ${dim('(already exists, use --force to overwrite)')}`);
   skipped += countFiles(AGENT_DOCS_SRC);
 } else {
@@ -262,7 +269,7 @@ for (const cf of CONFIG_FILES) {
 
   if (!existsSync(src)) continue;
 
-  if (existsSync(dest) && !force) {
+  if (existsSync(dest) && !shouldOverwrite) {
     console.log(yellow('  SKIP') + ` .agent-skills/${cf} ${dim('(already exists)')}`);
     skipped++;
   } else {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "bin": {
     "agent-skills-vrc-udon": "./bin/install.mjs"
   },
+  "scripts": {
+    "test": "node --test 'tests/**/*.test.mjs'"
+  },
   "files": [
     "bin/",
     "skills/",

--- a/tests/install.test.mjs
+++ b/tests/install.test.mjs
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+const INSTALLER = join(REPO_ROOT, 'bin/install.mjs');
+const PKG_VERSION = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version;
+
+/** A file that exists in the source skills/ tree; used as a sentinel to detect overwrite. */
+const SENTINEL_PATH = join('skills', 'unity-vrc-udon-sharp', 'SKILL.md');
+const STALE_MARKER = '__INSTALLER_TEST_STALE__\n';
+
+function setupTempProject(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-skills-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function runInstaller(cwd, args = []) {
+  return execFileSync('node', [INSTALLER, ...args], {
+    cwd,
+    env: { ...process.env, NO_COLOR: '1' },
+    encoding: 'utf8',
+  });
+}
+
+test('fresh install: copies skills and writes current package version', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+
+  assert.ok(
+    existsSync(join(dir, '.agent-skills', 'skills', 'unity-vrc-udon-sharp')),
+    'skills/ should be copied on fresh install',
+  );
+  assert.equal(
+    readFileSync(join(dir, '.agent-skills', '.version'), 'utf8').trim(),
+    PKG_VERSION,
+    '.version should match current package version',
+  );
+});
+
+test('same-version re-run without --force: preserves existing files (current SKIP behavior)', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
+  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+
+  // .version already equals PKG_VERSION → not an upgrade → SKIP path is correct here
+  runInstaller(dir);
+
+  assert.equal(
+    readFileSync(sentinel, 'utf8'),
+    STALE_MARKER,
+    'same-version re-run should not overwrite (use --force for that)',
+  );
+});
+
+test('upgrade re-run without --force: overwrites stale skills (Issue #164)', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  // Simulate "user installed an older version" by downgrading .version
+  // and corrupting a sentinel file as if it were stale content.
+  writeFileSync(join(dir, '.agent-skills', '.version'), '0.0.0', 'utf8');
+  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
+  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+
+  // Re-run without --force; installer should detect the version mismatch
+  // and overwrite stale skills/ content.
+  runInstaller(dir);
+
+  assert.notEqual(
+    readFileSync(sentinel, 'utf8'),
+    STALE_MARKER,
+    'Issue #164: skills/ was SKIPped during upgrade; content stayed stale',
+  );
+  assert.equal(
+    readFileSync(join(dir, '.agent-skills', '.version'), 'utf8').trim(),
+    PKG_VERSION,
+    '.version should be updated to current package version after upgrade',
+  );
+});
+
+test('upgrade re-run without --force: overwrites stale config reference files (Issue #164)', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  const claudeMd = join(dir, '.agent-skills', 'CLAUDE.md');
+  writeFileSync(claudeMd, STALE_MARKER, 'utf8');
+  writeFileSync(join(dir, '.agent-skills', '.version'), '0.0.0', 'utf8');
+
+  runInstaller(dir);
+
+  assert.notEqual(
+    readFileSync(claudeMd, 'utf8'),
+    STALE_MARKER,
+    'Issue #164: config files were SKIPped during upgrade; content stayed stale',
+  );
+});
+
+test('--force overwrites regardless of version state', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
+  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+
+  // .version still equals PKG_VERSION (no upgrade), but --force overrides
+  runInstaller(dir, ['--force']);
+
+  assert.notEqual(
+    readFileSync(sentinel, 'utf8'),
+    STALE_MARKER,
+    '--force must always overwrite, even on same-version re-run',
+  );
+});


### PR DESCRIPTION
## Summary

Closes #164.

`bin/install.mjs` previously printed `Upgrading from vX to vY...` but **SKIPped** the file copy when `.agent-skills/skills/` already existed (anything but `--force`), while still bumping `.agent-skills/.version` to the new package version. Result: `.version` drifted ahead of the actual on-disk content, and subsequent runs reported `Already up to date` while serving stale rules — most visibly, **Rule 9** added in v1.8.0 silently failed to reach existing users on `npx` re-runs without `--force`. This is more harmful here than in a typical installer because the package's value proposition is exactly "AI agents read the up-to-date NEVER list."

## What changed

- **`bin/install.mjs`** — introduce `isUpgrade = installedVersion !== null && installedVersion !== pkg.version` and `shouldOverwrite = force || isUpgrade`; replace `!force` with `!shouldOverwrite` on **both** the `skills/` copy guard and the config-files copy guard. `writeVersionFile()` position is unchanged — once the overwrite runs, `.version` and content stay in sync.
- **`tests/install.test.mjs`** (new) — `node:test`-based regression suite using `mkdtempSync` + subprocess `execFileSync('node', [INSTALLER, ...])` against a temp project. Five cases:
  1. Fresh install copies skills and writes current version.
  2. Same-version re-run preserves user mutation (current SKIP semantics, locked in).
  3. **Upgrade re-run overwrites stale skills** (was RED before fix, now GREEN). 
  4. **Upgrade re-run overwrites stale config files** (was RED, now GREEN).
  5. `--force` overwrites regardless of version state.
- **`package.json`** — adds `scripts.test = "node --test 'tests/**/*.test.mjs'"` (quoted glob form is the documented Node 22+/24 way; both Node 22 (CI) and Node 24 (local) verified).
- **`.github/workflows/ci.yml`** — new `installer-tests` job runs `npm test` on Node 22 (matches existing `npm-pack` job's pin).

## Reviewer notes

1. **Orphan-file edge case is *not* fixed in this PR.** `cpSync(..., { force: true })` overwrites files in both src and dest, but does **not** delete files that exist only in dest (i.e., a file removed/renamed between releases would linger in the user's tree). The contributor's suggested fix in the issue doesn't address this either; treating it as a separate hardening step keeps the diff minimal and the change set easy to revert if needed.
2. **Symlink path intentionally untouched** — lines 294 / 307 of the post-fix file still use `!force` for `--symlink` path creation. Symlinks point AT the skills target rather than copying content, so `.version`-vs-content drift doesn't apply. Folding them into `shouldOverwrite` would silently recreate symlinks on every upgrade run, which is a behavior change with its own surprise factor — out of scope here.
3. **`package.json#version` shows `1.2.1` even though latest published is v1.8.0.** This is by design: `publish.yml` uses `npm version --no-git-tag-version` to set the version from the release tag at publish time, so `dev`'s `package.json` does not track the latest released version. Tests use `pkg.version` dynamically (`JSON.parse(readFileSync('package.json')).version`), so they remain correct on any branch.

## Test plan

- [x] `npm test` — 5/5 passing locally (Node v24)
- [x] `npm pack --dry-run` — package size unchanged at 283.7 kB / 70 files; tests/ correctly excluded (not in `package.json#files` array, so npm consumers don't ship the test suite)
- [x] `node bin/install.mjs --version` / `--list` / `--help` — manual smoke checks pass
- [x] EditorConfig clean on touched files
- [ ] CI green on PR (Symlinks / Hooks / Markdown / npm Pack / EditorConfig / Version Sync / **Installer Tests**)
- [ ] CodeRabbit review

## Release impact

`release: fix` label → patch bump per Release Drafter.