### PR TITLE
fix(hooks): guard validate-udonsharp.sh against jq absence (Issue #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Bash syntax check
         run: bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
 
+      - name: Smoke test validate-udonsharp.sh
+        run: bash tests/hooks/validate-udonsharp.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
@@ -9,7 +9,21 @@
 set -e
 
 input=$(cat)
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.filePath // ""')
+
+# Require jq for JSON parsing. Without this guard, jq absence under set -e
+# aborts every PostToolUse hook invocation on .cs edits with a "command not
+# found" message, breaking validation silently for users on minimal Linux
+# images and macOS without Homebrew jq (Issue #165, Case A). Pass input
+# through so the original edit still propagates downstream.
+if ! command -v jq &>/dev/null; then
+    echo "$input"
+    exit 0
+fi
+
+# Tolerate jq parse failures: if the incoming JSON is malformed, fall through
+# to the empty-file_path branch (which exits cleanly) instead of aborting
+# under set -e (Issue #165, Case B).
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.filePath // ""' 2>/dev/null || true)
 
 # Only process .cs files
 if [[ ! "$file_path" =~ \.cs$ ]]; then

--- a/tests/hooks/validate-udonsharp.test.sh
+++ b/tests/hooks/validate-udonsharp.test.sh
@@ -75,6 +75,15 @@ assert_contains "A: stdout passes input through" "$A_STDOUT" '"file_path":"Foo.c
 # ------------------------------------------------------------
 # Case B: jq present, file_path / filePath both missing → exit 0, no abort
 # ------------------------------------------------------------
+# Precondition: Cases B and C run against the unrestricted environment and
+# require jq to actually be installed. Without this guard, a runner that
+# happens to lack jq would silently fall through Case A's new passthrough
+# and stop testing what B/C claim to test.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ABORT: Cases B/C require jq in PATH (precondition not met)"
+    exit 2
+fi
+
 CASE_B_INPUT='{"tool_input":{}}'
 B_STDOUT=$(printf '%s' "$CASE_B_INPUT" | "$HOOK" 2>"$TMPROOT/case_b.err")
 B_RC=$?

--- a/tests/hooks/validate-udonsharp.test.sh
+++ b/tests/hooks/validate-udonsharp.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Smoke test for skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+# Covers the failure modes reported in Issue #165:
+#   Case A: jq absent  → must exit 0 with stdout = input passthrough
+#   Case B: jq present, file_path missing → must exit 0 cleanly (no abort)
+#   Case C: jq present, valid .cs with List<T> → existing WARNING on stderr (happy path)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$REPO_ROOT/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh"
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS [$label] exit=$actual"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL [$label] exit: expected=$expected actual=$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "PASS [$label] contains: $needle"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL [$label] missing: $needle"
+        echo "  haystack (truncated): $(printf '%s' "$haystack" | head -c 200)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ------------------------------------------------------------
+# Case A: jq absent → exit 0, stdout = input passthrough
+# ------------------------------------------------------------
+NOJQ_BIN="$TMPROOT/nojq-bin"
+mkdir -p "$NOJQ_BIN"
+
+# Symlink standard tools the hook needs, but deliberately omit jq.
+for tool in bash cat grep sed sort uniq tr head awk dirname basename rm mkdir; do
+    src=""
+    for dir in /bin /usr/bin /usr/local/bin; do
+        if [ -x "$dir/$tool" ]; then
+            src="$dir/$tool"
+            break
+        fi
+    done
+    if [ -n "$src" ]; then
+        ln -s "$src" "$NOJQ_BIN/$tool"
+    fi
+done
+
+# Confirm jq really is missing in NOJQ_BIN PATH (precondition guard).
+jq_check=$(env -i PATH="$NOJQ_BIN" "$NOJQ_BIN/bash" -c 'command -v jq >/dev/null && echo FOUND || echo MISSING')
+if [ "$jq_check" != "MISSING" ]; then
+    echo "ABORT: precondition failed — NOJQ_BIN PATH still resolves jq ($jq_check)"
+    exit 2
+fi
+
+CASE_A_INPUT='{"tool_input":{"file_path":"Foo.cs"}}'
+A_STDOUT=$(printf '%s' "$CASE_A_INPUT" | env -i PATH="$NOJQ_BIN" HOME="${HOME:-/tmp}" "$NOJQ_BIN/bash" "$HOOK" 2>"$TMPROOT/case_a.err")
+A_RC=$?
+
+assert_exit "A: jq absent → exit 0" 0 "$A_RC"
+assert_contains "A: stdout passes input through" "$A_STDOUT" '"file_path":"Foo.cs"'
+
+# ------------------------------------------------------------
+# Case B: jq present, file_path / filePath both missing → exit 0, no abort
+# ------------------------------------------------------------
+CASE_B_INPUT='{"tool_input":{}}'
+B_STDOUT=$(printf '%s' "$CASE_B_INPUT" | "$HOOK" 2>"$TMPROOT/case_b.err")
+B_RC=$?
+
+assert_exit "B: jq present + no file_path → exit 0" 0 "$B_RC"
+assert_contains "B: stdout passes input through" "$B_STDOUT" '"tool_input":{}'
+
+# ------------------------------------------------------------
+# Case C: jq present, valid .cs with List<T> → expected WARNING on stderr (happy path)
+# ------------------------------------------------------------
+CASE_C_FILE="$TMPROOT/Sample.cs"
+cat > "$CASE_C_FILE" <<'CSEOF'
+using UdonSharp;
+using System.Collections.Generic;
+public class Sample : UdonSharpBehaviour
+{
+    private List<int> items = new List<int>();
+}
+CSEOF
+CASE_C_INPUT="{\"tool_input\":{\"file_path\":\"$CASE_C_FILE\"}}"
+C_STDOUT=$(printf '%s' "$CASE_C_INPUT" | "$HOOK" 2>"$TMPROOT/case_c.err")
+C_RC=$?
+C_STDERR=$(cat "$TMPROOT/case_c.err")
+
+assert_exit "C: happy path → exit 0" 0 "$C_RC"
+assert_contains "C: List<T> WARNING fires" "$C_STDERR" 'Generic collections (List<T>'
+
+echo ""
+echo "Summary: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #165.

`validate-udonsharp.sh` invokes `jq` unconditionally under `set -e`, so on systems without `jq` in PATH (macOS without Homebrew jq, minimal Linux images) every PostToolUse invocation on a `.cs` edit aborted with `jq: command not found`, breaking validation noisily. This PR adds a `command -v jq` guard at the top of the hook (passing input through and exiting 0 on absence) and tolerates `jq -r` parse failures so malformed JSON falls through to the existing empty-`file_path` branch instead of aborting.

The fix mirrors the contributor's suggested patch and the existing precedent in `.claude/hooks/doc-sync-reminder.sh:13–16`.

## What changed

- **`skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh`** — adds two guards:
  1. `command -v jq &>/dev/null` early bail-out that echoes input back to stdout and exits 0 (Issue #165, Case A).
  2. `2>/dev/null || true` on the `jq -r` line so a parse failure flows into the existing empty-`file_path` branch instead of aborting under `set -e` (Issue #165, Case B).
- **`tests/hooks/validate-udonsharp.test.sh`** (new, executable) — pure-bash smoke test with three cases:
  - **A**: `jq` absent (built-from-scratch PATH containing `bash`/`cat`/`grep`/`sed`/`sort`/`uniq`/`tr`/etc. but **not** `jq`, sanity-checked with `command -v jq` returning MISSING). RED on `dev`, GREEN after fix.
  - **B**: `jq` present, `tool_input.file_path` and `filePath` both missing. Locks in current silent-skip behavior (regression test).
  - **C**: `jq` present, valid `.cs` containing `List<T>` — confirms the happy-path WARNING (`Generic collections (List<T>...`) still fires, i.e. the new guard hasn't broken existing validation rules.
- **`.github/workflows/ci.yml`** — appends `Smoke test validate-udonsharp.sh` step to the existing `hooks` job (no new job, no new toolchain — bash is already there).

## Reviewer notes

1. **Reporter's second concern (silent skip on missing `file_path`) is preserved by design.** The reporter explicitly flagged this as user-confusing ("ユーザは検証が無効化されていることに気付けません"), but their own suggested patch keeps `// ""` and the silent-skip branch — surfacing a warning on every PostToolUse without `file_path` would create noise for non-`Edit`/non-`Write` tools (Bash, Read, etc.) that legitimately have no file path. Case B's regression test locks this contract in. If a louder failure mode is desired, that would be a separate behavioral change with its own design discussion.
2. **`tests/hooks/` is not shipped to npm consumers** — it sits under `tests/` which is absent from `package.json#files: ["bin/", "skills/", "templates/", "README*", "LICENSE"]`. End users get the fixed hook but not the test suite.
3. **Independent of PR #166's `npm test` infrastructure.** This PR uses the existing `hooks` CI job and runs the test as plain `bash tests/...`. PR #166 (Issue #164) wires `npm test` for `.mjs` tests under `tests/**/*.test.mjs`. The two PRs can land in either order; once both merge, the bash test continues running in `hooks` job and the `installer-tests` job runs `.mjs` tests — no conflict.
4. **PowerShell parity confirmed (no change needed).** `validate-udonsharp.ps1` uses `try/catch` + `ConvertFrom-Json` and has no external `jq` dependency, so the Windows path is unaffected. The reporter explicitly noted this as well.

## Test plan

- [x] `bash tests/hooks/validate-udonsharp.test.sh` — 6/6 passing locally (jq absent, jq present + missing file_path, .cs + List<T>)
- [x] `bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh` — syntax OK
- [x] EditorConfig clean (4-space indent, matches `[*.sh]`)
- [x] Symlink Integrity: temp-dir symlinks created at runtime by the test, never committed — repo stays symlink-free
- [ ] CI green on PR (Symlinks / Hooks / Markdown / npm Pack / EditorConfig / Version Sync)
- [ ] CodeRabbit review

## Release impact

`release: fix` label → patch bump per Release Drafter.