### PR TITLE
Release v1.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,19 @@ jobs:
       - name: Test installer list
         run: node bin/install.mjs --list
 
+  installer-tests:
+    name: Installer Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "22"
+
+      - name: Run installer tests
+        run: npm test
+
   editorconfig:
     name: EditorConfig
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Bash syntax check
         run: bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
 
+      - name: Smoke test validate-udonsharp.sh
+        run: bash tests/hooks/validate-udonsharp.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -229,6 +229,13 @@ console.log(bold('agent-skills-vrc-udon') + ` v${pkg.version}`);
 
 // Version detection: show upgrade/already-up-to-date message
 const installedVersion = readInstalledVersion();
+// Treat any version mismatch (upgrade or downgrade) as a request to refresh
+// installed content, so .version never drifts ahead of the actual files.
+// Without this, an upgrade re-run without --force would print
+// "Upgrading from..." but keep the old skills/ on disk while bumping .version,
+// permanently masking new rules from existing users (Issue #164).
+const isUpgrade = installedVersion !== null && installedVersion !== pkg.version;
+const shouldOverwrite = force || isUpgrade;
 if (installedVersion !== null) {
   if (installedVersion === pkg.version) {
     console.log(dim(`Already up to date (v${pkg.version}).`));
@@ -244,7 +251,7 @@ let copied = 0;
 let skipped = 0;
 
 // 1. Copy skills/
-if (existsSync(AGENT_DOCS_DEST) && !force) {
+if (existsSync(AGENT_DOCS_DEST) && !shouldOverwrite) {
   console.log(yellow('  SKIP') + ` .agent-skills/skills/ ${dim('(already exists, use --force to overwrite)')}`);
   skipped += countFiles(AGENT_DOCS_SRC);
 } else {
@@ -262,7 +269,7 @@ for (const cf of CONFIG_FILES) {
 
   if (!existsSync(src)) continue;
 
-  if (existsSync(dest) && !force) {
+  if (existsSync(dest) && !shouldOverwrite) {
     console.log(yellow('  SKIP') + ` .agent-skills/${cf} ${dim('(already exists)')}`);
     skipped++;
   } else {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "bin": {
     "agent-skills-vrc-udon": "./bin/install.mjs"
   },
+  "scripts": {
+    "test": "node --test 'tests/**/*.test.mjs'"
+  },
   "files": [
     "bin/",
     "skills/",

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
@@ -9,7 +9,21 @@
 set -e
 
 input=$(cat)
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.filePath // ""')
+
+# Require jq for JSON parsing. Without this guard, jq absence under set -e
+# aborts every PostToolUse hook invocation on .cs edits with a "command not
+# found" message, breaking validation silently for users on minimal Linux
+# images and macOS without Homebrew jq (Issue #165, Case A). Pass input
+# through so the original edit still propagates downstream.
+if ! command -v jq &>/dev/null; then
+    echo "$input"
+    exit 0
+fi
+
+# Tolerate jq parse failures: if the incoming JSON is malformed, fall through
+# to the empty-file_path branch (which exits cleanly) instead of aborting
+# under set -e (Issue #165, Case B).
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.filePath // ""' 2>/dev/null || true)
 
 # Only process .cs files
 if [[ ! "$file_path" =~ \.cs$ ]]; then

--- a/tests/hooks/validate-udonsharp.test.sh
+++ b/tests/hooks/validate-udonsharp.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Smoke test for skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+# Covers the failure modes reported in Issue #165:
+#   Case A: jq absent  → must exit 0 with stdout = input passthrough
+#   Case B: jq present, file_path missing → must exit 0 cleanly (no abort)
+#   Case C: jq present, valid .cs with List<T> → existing WARNING on stderr (happy path)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK="$REPO_ROOT/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh"
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS [$label] exit=$actual"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL [$label] exit: expected=$expected actual=$actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "PASS [$label] contains: $needle"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL [$label] missing: $needle"
+        echo "  haystack (truncated): $(printf '%s' "$haystack" | head -c 200)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ------------------------------------------------------------
+# Case A: jq absent → exit 0, stdout = input passthrough
+# ------------------------------------------------------------
+NOJQ_BIN="$TMPROOT/nojq-bin"
+mkdir -p "$NOJQ_BIN"
+
+# Symlink standard tools the hook needs, but deliberately omit jq.
+for tool in bash cat grep sed sort uniq tr head awk dirname basename rm mkdir; do
+    src=""
+    for dir in /bin /usr/bin /usr/local/bin; do
+        if [ -x "$dir/$tool" ]; then
+            src="$dir/$tool"
+            break
+        fi
+    done
+    if [ -n "$src" ]; then
+        ln -s "$src" "$NOJQ_BIN/$tool"
+    fi
+done
+
+# Confirm jq really is missing in NOJQ_BIN PATH (precondition guard).
+jq_check=$(env -i PATH="$NOJQ_BIN" "$NOJQ_BIN/bash" -c 'command -v jq >/dev/null && echo FOUND || echo MISSING')
+if [ "$jq_check" != "MISSING" ]; then
+    echo "ABORT: precondition failed — NOJQ_BIN PATH still resolves jq ($jq_check)"
+    exit 2
+fi
+
+CASE_A_INPUT='{"tool_input":{"file_path":"Foo.cs"}}'
+A_STDOUT=$(printf '%s' "$CASE_A_INPUT" | env -i PATH="$NOJQ_BIN" HOME="${HOME:-/tmp}" "$NOJQ_BIN/bash" "$HOOK" 2>"$TMPROOT/case_a.err")
+A_RC=$?
+
+assert_exit "A: jq absent → exit 0" 0 "$A_RC"
+assert_contains "A: stdout passes input through" "$A_STDOUT" '"file_path":"Foo.cs"'
+
+# ------------------------------------------------------------
+# Case B: jq present, file_path / filePath both missing → exit 0, no abort
+# ------------------------------------------------------------
+# Precondition: Cases B and C run against the unrestricted environment and
+# require jq to actually be installed. Without this guard, a runner that
+# happens to lack jq would silently fall through Case A's new passthrough
+# and stop testing what B/C claim to test.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ABORT: Cases B/C require jq in PATH (precondition not met)"
+    exit 2
+fi
+
+CASE_B_INPUT='{"tool_input":{}}'
+B_STDOUT=$(printf '%s' "$CASE_B_INPUT" | "$HOOK" 2>"$TMPROOT/case_b.err")
+B_RC=$?
+
+assert_exit "B: jq present + no file_path → exit 0" 0 "$B_RC"
+assert_contains "B: stdout passes input through" "$B_STDOUT" '"tool_input":{}'
+
+# ------------------------------------------------------------
+# Case C: jq present, valid .cs with List<T> → expected WARNING on stderr (happy path)
+# ------------------------------------------------------------
+CASE_C_FILE="$TMPROOT/Sample.cs"
+cat > "$CASE_C_FILE" <<'CSEOF'
+using UdonSharp;
+using System.Collections.Generic;
+public class Sample : UdonSharpBehaviour
+{
+    private List<int> items = new List<int>();
+}
+CSEOF
+CASE_C_INPUT="{\"tool_input\":{\"file_path\":\"$CASE_C_FILE\"}}"
+C_STDOUT=$(printf '%s' "$CASE_C_INPUT" | "$HOOK" 2>"$TMPROOT/case_c.err")
+C_RC=$?
+C_STDERR=$(cat "$TMPROOT/case_c.err")
+
+assert_exit "C: happy path → exit 0" 0 "$C_RC"
+assert_contains "C: List<T> WARNING fires" "$C_STDERR" 'Generic collections (List<T>'
+
+echo ""
+echo "Summary: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/install.test.mjs
+++ b/tests/install.test.mjs
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+const INSTALLER = join(REPO_ROOT, 'bin/install.mjs');
+const PKG_VERSION = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version;
+
+/** A file that exists in the source skills/ tree; used as a sentinel to detect overwrite. */
+const SENTINEL_PATH = join('skills', 'unity-vrc-udon-sharp', 'SKILL.md');
+const STALE_MARKER = '__INSTALLER_TEST_STALE__\n';
+
+function setupTempProject(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-skills-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function runInstaller(cwd, args = []) {
+  return execFileSync('node', [INSTALLER, ...args], {
+    cwd,
+    env: { ...process.env, NO_COLOR: '1' },
+    encoding: 'utf8',
+  });
+}
+
+test('fresh install: copies skills and writes current package version', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+
+  assert.ok(
+    existsSync(join(dir, '.agent-skills', 'skills', 'unity-vrc-udon-sharp')),
+    'skills/ should be copied on fresh install',
+  );
+  assert.equal(
+    readFileSync(join(dir, '.agent-skills', '.version'), 'utf8').trim(),
+    PKG_VERSION,
+    '.version should match current package version',
+  );
+});
+
+test('same-version re-run without --force: preserves existing files (current SKIP behavior)', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
+  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+
+  // .version already equals PKG_VERSION → not an upgrade → SKIP path is correct here
+  runInstaller(dir);
+
+  assert.equal(
+    readFileSync(sentinel, 'utf8'),
+    STALE_MARKER,
+    'same-version re-run should not overwrite (use --force for that)',
+  );
+});
+
+test('upgrade re-run without --force: overwrites stale skills (Issue #164)', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  // Simulate "user installed an older version" by downgrading .version
+  // and corrupting a sentinel file as if it were stale content.
+  writeFileSync(join(dir, '.agent-skills', '.version'), '0.0.0', 'utf8');
+  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
+  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+
+  // Re-run without --force; installer should detect the version mismatch
+  // and overwrite stale skills/ content.
+  runInstaller(dir);
+
+  assert.notEqual(
+    readFileSync(sentinel, 'utf8'),
+    STALE_MARKER,
+    'Issue #164: skills/ was SKIPped during upgrade; content stayed stale',
+  );
+  assert.equal(
+    readFileSync(join(dir, '.agent-skills', '.version'), 'utf8').trim(),
+    PKG_VERSION,
+    '.version should be updated to current package version after upgrade',
+  );
+});
+
+test('upgrade re-run without --force: overwrites stale config reference files (Issue #164)', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  const claudeMd = join(dir, '.agent-skills', 'CLAUDE.md');
+  writeFileSync(claudeMd, STALE_MARKER, 'utf8');
+  writeFileSync(join(dir, '.agent-skills', '.version'), '0.0.0', 'utf8');
+
+  runInstaller(dir);
+
+  assert.notEqual(
+    readFileSync(claudeMd, 'utf8'),
+    STALE_MARKER,
+    'Issue #164: config files were SKIPped during upgrade; content stayed stale',
+  );
+});
+
+test('--force overwrites regardless of version state', (t) => {
+  const dir = setupTempProject(t);
+
+  runInstaller(dir);
+  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
+  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+
+  // .version still equals PKG_VERSION (no upgrade), but --force overrides
+  runInstaller(dir, ['--force']);
+
+  assert.notEqual(
+    readFileSync(sentinel, 'utf8'),
+    STALE_MARKER,
+    '--force must always overwrite, even on same-version re-run',
+  );
+});


### PR DESCRIPTION
## Summary

Release v1.8.1 — two installer/hook hardening fixes reported by @haru0416-dev.

**2 PRs since v1.8.0:**
- #166 — `fix`: Installer re-installs on version mismatch instead of skipping (Issue #164). Prevents `.version` drift that previously left existing users on stale rules after `npx` re-runs.
- #167 — `fix`: `validate-udonsharp.sh` guards against `jq` absence and JSON parse failures (Issue #165). Restores validation on macOS without Homebrew jq and on minimal Linux images.

**Version bump driver**: both PRs carry `release: fix` → patch bump (1.8.0 → 1.8.1) per Release Drafter resolution.

## What changed

### Installer (#166)
- New `isUpgrade = installedVersion !== null && installedVersion !== pkg.version` check; when set, the installer overwrites both `skills/` and config-files paths even without `--force`. `.version` and on-disk content stay in sync.
- Adds Node `node:test` regression suite under `tests/install.test.mjs` covering fresh / same-version SKIP / upgrade overwrite / `--force` paths.
- New `installer-tests` CI job runs the suite on Node 22.

### Validation Hook (#167)
- `command -v jq` guard at top of `skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh` — pass input through and exit 0 when jq is absent (mirrors the existing `.claude/hooks/doc-sync-reminder.sh` precedent).
- `jq -r ... 2>/dev/null || true` so JSON parse failures fall through to the existing empty-`file_path` branch instead of aborting under `set -e`.
- New `tests/hooks/validate-udonsharp.test.sh` smoke test (3 cases: jq absent / file_path missing / List<T> happy path) wired into the existing `hooks` CI job.
- PowerShell parity confirmed (no change needed; already uses `try/catch` + `ConvertFrom-Json`).

## Reporter acknowledgement

Both fixes originate from precision bug reports by @haru0416-dev — exact line numbers, reproduction sequences, and working patches. The release notes will include explicit thanks once the GitHub Release draft is rewritten.

## Merge instructions

**DO NOT SQUASH** — preserve commit history per repo release policy. Use plain merge commit so Release Drafter sees both PR commits.

## Post-merge

1. Release Drafter creates/updates a v1.8.1 draft release on main.
2. The draft notes will be rewritten by hand to follow v1.8.0 format (per-PR sections, install snippet, reporter thank-you).
3. Publishing the GitHub Release triggers `publish.yml` → `npm publish --provenance` to the `npm-publish` environment.

## Test plan

- [ ] CI green on this PR (Symlink Integrity / Hooks / Markdown / npm Pack / Installer Tests / EditorConfig / Version Sync)
- [ ] Merge with merge commit (NOT squash)
- [ ] Release Drafter draft appears on `main`
- [ ] Draft notes rewritten in v1.8.0 format with reporter acknowledgement
- [ ] Publishing the draft triggers `publish.yml` → npm v1.8.1 visible on registry