### PR TITLE
chore(version): catch up package.json and skill metadata to 1.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "1.2.1"
+    "version": "1.8.1"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.2.1"
+    version: "1.8.1"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.2.1",
+  "version": "1.8.1",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.2.1"
+    version: "1.8.1"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.2.1"
+    version: "1.8.1"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 


### PR DESCRIPTION
## Summary

Catch-up PR for a long-standing source-of-truth drift discovered after v1.8.1 was published.

The git tree had been frozen at `1.2.1` across these 5 fields ever since the v1.2.1 release:

| File | Field |
|---|---|
| `package.json` | `.version` |
| `.claude-plugin/marketplace.json` | `.metadata.version` |
| `skills/unity-vrc-udon-sharp/SKILL.md` | YAML frontmatter `metadata.version` |
| `skills/unity-vrc-world-sdk-3/SKILL.md` | YAML frontmatter `metadata.version` |
| `.claude/skills/unity-vrc-skills-renovator/SKILL.md` | YAML frontmatter `metadata.version` |

Six release cycles (v1.6.0 / v1.6.1 / v1.7.0 / v1.7.1 / v1.8.0 / v1.8.1) shipped correct versions to npm because `publish.yml` runs `npm version "$VERSION" --no-git-tag-version` and the SKILL.md / marketplace.json sed pass in the CI runner *before* `npm publish`. But those edits never get committed back, so the runner-side values disappear with the runner. As a side effect, the Version Sync CI job has been trivially passing on `1.2.1 == 1.2.1 == 1.2.1` for months — three places agree, but they all agree at the wrong value.

This PR is a one-shot text replacement to bring dev's source-of-truth in line with the latest published version (`1.8.1`). It carries no functional change.

## Verification

- `node bin/install.mjs --version` from this branch now reports `1.8.1` (previously reported `1.2.1` from a clone, even though npm `latest` was `1.8.1`).
- `npm test` — 5/5 passing
- All 5 fields verified updated to `1.8.1` (`grep -E '\"version\":\\s*\"[0-9.]+\"' ...`)
- EditorConfig clean

## Why I didn't catch this in PR #166

In PR #166 I noted in the reviewer notes: *"`package.json#version` shows `1.2.1` even though latest published is v1.8.0. This is by design: `publish.yml` uses `npm version --no-git-tag-version --allow-same-version` to set the version from the release tag at publish time."* That rationalization was wrong — the npm tarball being correct masked the fact that the source-of-truth in git was drifting. Apologies for the bad framing.

## Follow-up

A separate PR will update the release flow to require version bumping in dev *before* opening the release PR (option **C** from the discussion: hybrid manual bump + CLAUDE.md / PR template guardrails). `publish.yml`'s runner-side mutation will be kept as a safety net but no longer the primary mechanism.

## Release impact

`release: maintenance` label → patch bump per Release Drafter (so the next release should be v1.8.2 unless additional `release: feature` work lands). No user-facing change.

## Test plan

- [ ] CI green (Symlinks / Hooks / Markdown / npm Pack / Installer Tests / EditorConfig / Version Sync)
- [ ] Version Sync CI verifies all 3 SKILL.md + marketplace.json + package.json all read `1.8.1` (this is the first time that check actually validates anything meaningful)
- [ ] CodeRabbit review (LGTM expected — purely mechanical text replacement)