### PR TITLE
docs(release): require version bump on dev before release PR (Option C)

### DIFF
--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -27,8 +27,19 @@ Any change to these paths requires a documentation sync check:
 ## What NOT to Update
 
 - `CHANGELOG.md` — managed by Release Drafter, not manual edits
-- `package.json` version — managed by publish workflow
-- `SKILL.md` version fields — managed by publish workflow
+
+## What to Update Together (Release Flow)
+
+These fields must be bumped together on `dev` via a `chore(version): bump to vX.Y.Z` PR
+**before** opening the release PR. See CLAUDE.md "Release Guide" Step 1 for the exact procedure.
+`publish.yml` does mutate them in the CI runner as a safety net, but those edits are not
+committed back, so the source-of-truth must be kept current by hand:
+
+- `package.json` → `.version`
+- `.claude-plugin/marketplace.json` → `.metadata.version`
+- `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
+- `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
+- `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`
 
 ## Checklist (run mentally before committing)
 

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,58 @@
+# Release PR Template
+
+> Open a release PR with this template by appending `?template=release.md` to the new-PR URL,
+> or by editing the body after creation. See `CLAUDE.md` "Release Guide" for the full flow.
+
+## Pre-flight checklist (Step 1 must be done BEFORE this PR is opened)
+
+- [ ] **Version bumped on `dev`** via a separate `chore(version): bump to vX.Y.Z` PR, already merged.
+  Verify with `node -p "require('./package.json').version"` on `dev` — it must equal the target version.
+- [ ] All 5 version fields are in sync (Version Sync CI checks this; verify locally too):
+  - `package.json` → `.version`
+  - `.claude-plugin/marketplace.json` → `.metadata.version`
+  - `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
+  - `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
+  - `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`
+
+## Summary
+
+Release vX.Y.Z — short one-line punchline.
+
+**N PRs since vPREVIOUS:**
+- #NNN — `<type>`: <one-sentence summary>
+- ...
+
+**Version bump driver**: `release: <highest-label>` → `<bump-type>`.
+
+## What changed
+
+### <Skill or Area> (#NNN)
+- ...
+
+## Reporter acknowledgement (if applicable)
+
+If any of the bundled PRs closed an externally-reported Issue, list reporters here. The release notes
+themselves should also include a thank-you (in the reporter's language).
+
+## Merge instructions
+
+**DO NOT SQUASH** — use a plain merge commit so Release Drafter sees each underlying PR.
+
+## Post-merge
+
+1. Release Drafter creates/updates a draft release on `main`.
+2. Rewrite the draft notes (`gh release edit vX.Y.Z --notes "$(cat <<'NOTES' ... NOTES)"`):
+   - Remove the auto-generated "Release vX.Y.Z (#N)" self-reference line.
+   - Convert bare PR titles to user-facing prose.
+   - Add reporter thank-you if applicable, in the reporter's language.
+3. `gh release edit vX.Y.Z --draft=false` to publish — triggers `publish.yml` → `npm publish`.
+
+## Test plan
+
+- [ ] CI green (Symlinks / Hooks / Markdown / npm Pack / Installer Tests / EditorConfig / Version Sync)
+- [ ] Release Drafter draft body reflects the merged PRs
+- [ ] After publish: `npm view agent-skills-vrc-udon version` returns vX.Y.Z
+
+## Release impact
+
+`release: <label>` → `<bump-type>` bump per Release Drafter.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -29,6 +29,7 @@ Release vX.Y.Z — short one-line punchline.
 
 ### `Skill or Area` (#NNN)
 
+
 - ...
 
 ## Reporter acknowledgement (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -19,14 +19,16 @@
 Release vX.Y.Z — short one-line punchline.
 
 **N PRs since vPREVIOUS:**
-- #NNN — `<type>`: <one-sentence summary>
+
+- #NNN — `<type>`: `one-sentence summary`
 - ...
 
 **Version bump driver**: `release: <highest-label>` → `<bump-type>`.
 
 ## What changed
 
-### <Skill or Area> (#NNN)
+### `Skill or Area` (#NNN)
+
 - ...
 
 ## Reporter acknowledgement (if applicable)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,18 +107,26 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
    - Branch off `dev`, run the bump, open a PR back to `dev`:
 
      ```bash
+     set -e
      git checkout dev && git pull
      git checkout -b chore/release-vX.Y.Z
 
+     # OLD: read from local package.json. If your local is stale, prefer:
+     #   OLD=$(npm view agent-skills-vrc-udon version)
      OLD=$(node -p "require('./package.json').version")
      NEW=X.Y.Z
 
      # 5 fields must move together — Version Sync CI verifies parity.
+     # The SKILL.md sed is anchored to the 4-space-indented frontmatter line
+     # so body-text occurrences (e.g. SDK version mentions) are not rewritten.
      sed -i "s/\"version\": \"$OLD\"/\"version\": \"$NEW\"/" package.json .claude-plugin/marketplace.json
-     sed -i "s/version: \"$OLD\"/version: \"$NEW\"/" \
+     sed -i "s/^    version: \"$OLD\"$/    version: \"$NEW\"/" \
        skills/unity-vrc-udon-sharp/SKILL.md \
        skills/unity-vrc-world-sdk-3/SKILL.md \
        .claude/skills/unity-vrc-skills-renovator/SKILL.md
+
+     # Sanity check before commit — only the 5 expected fields should diff.
+     git diff --stat
 
      git commit -am "chore(version): bump to vX.Y.Z"
      git push -u origin chore/release-vX.Y.Z
@@ -127,14 +135,16 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
        --body "Pre-release version bump for Step 2 of the release flow."
      ```
 
-   - Wait for CI green (Version Sync CI verifies all 5 fields agree on `vX.Y.Z`). Merge the bump PR into `dev` (squash is fine here — single-purpose commit).
+   - Wait for **all** CI jobs green — specifically Version Sync, which verifies all 5 fields agree on `vX.Y.Z`. (Branch protection currently enforces only `Symlink Integrity / Hook Scripts / npm Pack Test` as required contexts; do not merge if Version Sync is red even though GitHub allows it.) Merge the bump PR into `dev` (squash is fine here — single-purpose commit). CodeRabbit review is optional on this PR — it's mechanical and Version Sync is the substantive check.
 
 2. **Create a release PR from `dev` to `main`**
+
    ```bash
    gh pr create --base main --head dev \
      --title "Release vX.Y.Z" \
      --body "Merge dev into main for release"
    ```
+
    - Title must include the version that matches `package.json#version` on `dev` after Step 1.
    - Wait for CI to pass. CodeRabbit approval is **not required for release PRs** (per repo convention — release PRs are mechanical merges of already-reviewed commits).
 
@@ -143,6 +153,7 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
    - This triggers Release Drafter to update the draft release on `main`.
 
 4. **Publish the GitHub Release draft**
+
    ```bash
    # List draft releases
    gh release list --exclude-drafts=false
@@ -151,8 +162,11 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
    #   - Remove the "Release vX.Y.Z (#N)" self-reference line
    #   - Replace bare PR titles with user-facing prose
    #   - Add a reporter acknowledgement section if any bundled PR closed an
-   #     externally-reported Issue (mirror the reporter's language: Japanese
-   #     reporter → Japanese acknowledgement, English reporter → English)
+   #     externally-reported Issue. Mirror the reporter's language for the
+   #     release-notes acknowledgement (Japanese reporter → Japanese; English
+   #     reporter → English). Issue/PR titles and bodies remain English-first
+   #     per repo convention; the reporter-language rule applies only to
+   #     user-facing release notes.
    gh release edit vX.Y.Z --notes "$(cat <<'NOTES'
    ## What's New in vX.Y.Z
    ...
@@ -162,6 +176,7 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
    # Publish (this triggers publish.yml → npm publish)
    gh release edit vX.Y.Z --draft=false
    ```
+
    - The `published` event triggers `publish.yml`.
    - `publish.yml` reads the tag, runs `npm version "$VERSION" --allow-same-version` (no-op if Step 1 was done correctly), syncs to SKILL.md / marketplace.json again as a safety net, and runs `npm publish --provenance`.
    - Uses the `npm-publish` environment (requires `NPM_TOKEN` secret).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,42 +95,80 @@ node bin/install.mjs --help
 ### Overview
 
 ```
-dev ──release PR──> main ──Release Drafter draft──> publish ──> npm
+dev ──version-bump PR──> dev ──release PR──> main ──Release Drafter draft──> publish ──> npm
 ```
 
-Version numbers and changelogs are **fully automated** by Release Drafter.
-Do NOT manually edit `package.json` version — `publish.yml` sets it from the release tag.
+Changelogs are automated by Release Drafter. **Version numbers must be bumped manually on `dev` before opening the release PR** (see Step 1 below). `publish.yml` does run `npm version "$VERSION" --no-git-tag-version` in the CI runner as a safety net, but those edits are not committed back, so the git tree's source-of-truth must be kept current by hand.
 
 ### Step-by-step
 
-1. **Create a release PR from `dev` to `main`**
+1. **Bump version fields on `dev`**
+   - Decide the target version vX.Y.Z (consult labels on merged PRs since the last release — see "Version resolution" below).
+   - Branch off `dev`, run the bump, open a PR back to `dev`:
+
+     ```bash
+     git checkout dev && git pull
+     git checkout -b chore/release-vX.Y.Z
+
+     OLD=$(node -p "require('./package.json').version")
+     NEW=X.Y.Z
+
+     # 5 fields must move together — Version Sync CI verifies parity.
+     sed -i "s/\"version\": \"$OLD\"/\"version\": \"$NEW\"/" package.json .claude-plugin/marketplace.json
+     sed -i "s/version: \"$OLD\"/version: \"$NEW\"/" \
+       skills/unity-vrc-udon-sharp/SKILL.md \
+       skills/unity-vrc-world-sdk-3/SKILL.md \
+       .claude/skills/unity-vrc-skills-renovator/SKILL.md
+
+     git commit -am "chore(version): bump to vX.Y.Z"
+     git push -u origin chore/release-vX.Y.Z
+     gh pr create --base dev --label "release: maintenance" \
+       --title "chore(version): bump to vX.Y.Z" \
+       --body "Pre-release version bump for Step 2 of the release flow."
+     ```
+
+   - Wait for CI green (Version Sync CI verifies all 5 fields agree on `vX.Y.Z`). Merge the bump PR into `dev` (squash is fine here — single-purpose commit).
+
+2. **Create a release PR from `dev` to `main`**
    ```bash
    gh pr create --base main --head dev \
      --title "Release vX.Y.Z" \
      --body "Merge dev into main for release"
    ```
-   - Title should include the expected version (check the draft release for the resolved version)
-   - Wait for CI to pass and CodeRabbit approval
+   - Title must include the version that matches `package.json#version` on `dev` after Step 1.
+   - Wait for CI to pass. CodeRabbit approval is **not required for release PRs** (per repo convention — release PRs are mechanical merges of already-reviewed commits).
 
-2. **Merge the release PR**
-   - Merge (do NOT squash — preserve commit history)
-   - This triggers Release Drafter to update the draft release on `main`
+3. **Merge the release PR**
+   - Merge (do NOT squash — preserve commit history so Release Drafter sees each underlying PR commit).
+   - This triggers Release Drafter to update the draft release on `main`.
 
-3. **Publish the GitHub Release draft**
+4. **Publish the GitHub Release draft**
    ```bash
    # List draft releases
    gh release list --exclude-drafts=false
 
-   # Review and publish the draft (edit title/notes if needed)
+   # Always rewrite the auto-generated notes before publishing:
+   #   - Remove the "Release vX.Y.Z (#N)" self-reference line
+   #   - Replace bare PR titles with user-facing prose
+   #   - Add a reporter acknowledgement section if any bundled PR closed an
+   #     externally-reported Issue (mirror the reporter's language: Japanese
+   #     reporter → Japanese acknowledgement, English reporter → English)
+   gh release edit vX.Y.Z --notes "$(cat <<'NOTES'
+   ## What's New in vX.Y.Z
+   ...
+   NOTES
+   )"
+
+   # Publish (this triggers publish.yml → npm publish)
    gh release edit vX.Y.Z --draft=false
    ```
-   - The `published` event triggers `publish.yml`
-   - `publish.yml` reads the tag, sets `npm version`, and runs `npm publish --provenance`
-   - Uses the `npm-publish` environment (requires `NPM_TOKEN` secret)
+   - The `published` event triggers `publish.yml`.
+   - `publish.yml` reads the tag, runs `npm version "$VERSION" --allow-same-version` (no-op if Step 1 was done correctly), syncs to SKILL.md / marketplace.json again as a safety net, and runs `npm publish --provenance`.
+   - Uses the `npm-publish` environment (requires `NPM_TOKEN` secret).
 
-### Version resolution (automatic)
+### Version resolution (label-driven)
 
-Release Drafter resolves the version bump from PR labels:
+When deciding the target version in Step 1, count the labels on PRs merged into `dev` since the last release:
 
 | Label | Bump |
 |-------|------|
@@ -140,14 +178,14 @@ Release Drafter resolves the version bump from PR labels:
 | `release: docs` | patch |
 | `release: maintenance` | patch |
 
-If no label matches, defaults to **patch**.
+The highest bump wins. If no label matches, default to **patch**. Release Drafter independently resolves the same labels for the draft body, so as long as the manual bump in Step 1 matches Release Drafter's resolution, the draft and `package.json` will agree.
 
 ### What NOT to do
 
-- Do NOT manually bump `package.json` version (publish.yml handles it)
-- Do NOT create tags manually (Release Drafter creates them)
-- Do NOT push directly to `main` (branch protection blocks it)
-- Do NOT merge feature branches directly to `main` (always go through `dev`)
+- Do NOT skip Step 1 (the manual version bump). `publish.yml`'s runner-side mutation does **not** commit back, so a missed bump leaves the git tree frozen. The Version Sync CI check trivially passes when all 5 fields agree on the wrong value — this drifted for 5 release cycles before being caught (PR #169).
+- Do NOT create tags manually (Release Drafter creates them when the release is published).
+- Do NOT push directly to `main` (branch protection blocks it; use the release PR flow).
+- Do NOT merge feature branches directly to `main` (always go through `dev`).
 
 ## Editing Skills
 


### PR DESCRIPTION
## Summary

Codifies the **Option C** decision from the discussion that surfaced PR #169's root cause:

> *"package.json のバージョン表記、ずっと合ってなくない？"*

The actual primary mechanism for keeping `package.json#version` and the SKILL.md / marketplace.json metadata up to date was supposed to be `publish.yml`'s runner-side `npm version` step — but those edits never get committed back. Result: the git tree drifted at `1.2.1` for 5 release cycles (v1.6.0, v1.7.1, v1.8.0, v1.8.1, ...) and the Version Sync CI check trivially passed because all 5 mismatched fields agreed at the wrong value. PR #169 catches the values up to `1.8.1`; this PR is the **process fix** that prevents recurrence.

## What changed

### `CLAUDE.md` — Release Guide section

- **New Step 1**: bump 5 version fields on `dev` via a separate `chore(version): bump to vX.Y.Z` PR **before** opening the release PR. Includes a copy-pasteable sed snippet that touches all 5 files in lockstep (so Version Sync CI catches partial bumps).
- **Existing Steps 1-3 renumbered to 2-4**; existing wording mostly preserved.
- **Notes updated** in "What NOT to do":
  - Removed the misleading *"Do NOT manually bump `package.json` version"* line — that was the root cause.
  - Added a reference to PR #169 as the historical incident.
- **Step 4 (publish)** now mentions the reporter-language acknowledgement guidance (mirrors the rule already saved in `feedback_issues_in_english.md`).

### `.github/PULL_REQUEST_TEMPLATE/release.md` (new)

A named PR template selectable via `?template=release.md`. Includes:
- A pre-flight checklist with the 5 version fields enumerated, so a maintainer (or AI agent) can mechanically verify Step 1 was done before opening the release PR.
- Standard sections (Summary / What changed / Reporter acknowledgement / Merge instructions / Post-merge / Test plan / Release impact) shaped by the v1.8.1 release notes I rewrote earlier today.

The default behavior of GitHub PR creation is unchanged (no `PULL_REQUEST_TEMPLATE.md` at the root, so the default empty body still applies). The release template is opt-in via URL or `gh pr create --body-file`.

## Why Option C (and not A or B)

From the discussion:

- **A** (automate `publish.yml` to commit version bump back to `main`) was rejected because the necessary `contents: write` permission combined with `enforce_admins: true` branch protection would require a PAT or GitHub App token — an extra secret to manage for marginal benefit.
- **B** (pure manual bump in release PR) was rejected as too easy to forget; the "always bumps in dev first" rule wouldn't be load-bearing enough to prevent recurrence.
- **C** (this PR — manual bump on dev codified by `CLAUDE.md` + a release PR template that mechanically prompts for verification) gives the durability of A without the secrets-management overhead, and the safety of B with an automation guardrail.

## Reviewer notes

- **`publish.yml` is intentionally untouched.** Its runner-side `npm version` and SKILL.md / marketplace.json sed pass remain as a safety net for "I forgot to bump on dev but tagged anyway" — the npm tarball will still ship the correct version, the only thing that suffers is the git tree (which is already the case and now explicitly the responsibility of the release PR opener to keep current).
- **Version Sync CI is now load-bearing for the first time.** Previously it verified all 5 fields agreed (which they did, at `1.2.1`); after this PR it actually catches partial bumps where someone updated `package.json` but not `marketplace.json` or one of the `SKILL.md` files.
- **No code changes**, only docs + a new template file. CI risk is minimal (Markdown Links and EditorConfig only).

## Stacked-PR ordering

This PR depends on PR #169 having merged so future bumps build on the now-correct `1.8.1` baseline. Order: merge #169 first, then this PR (or vice versa — they don't textually conflict, just semantically).

## Test plan

- [ ] CI green (Symlinks / Hooks / Markdown / npm Pack / Installer Tests / EditorConfig / Version Sync)
- [ ] Merge order: PR #169 first (catch-up), then this PR (process)
- [ ] Next release uses Step 1: maintainer (or AI) bumps version on dev via `chore(version): bump to vX.Y.Z` PR before the release PR
- [ ] Future-state validation: after the next release publishes, confirm git tree's `package.json#version == npm view ... version`

## Release impact

`release: docs` → patch bump per Release Drafter. No user-facing change.