### PR TITLE
docs(skills/udon-sharp): correct ownership transfer model post-2021.2.2 (#171)

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -31,7 +31,7 @@ Every rule in this skill exists because UdonSharp's default behavior is to **fai
 Four architectural decisions that must be made before choosing sync modes or writing any synced variable. Changing them mid-implementation typically requires a full rewrite:
 
 - **Who owns this state?** One owner writes; all others read. If two players can both write (e.g., a shared toggle), you need an ownership transfer protocol — writes without ownership are silently discarded.
-- **When does ownership transfer?** On grab? Interact? Game event? `OnPlayerLeft`? Ownership transfer is asynchronous — do not write synced variables immediately after `SetOwner()`; write inside `OnOwnershipTransferred`.
+- **When does ownership transfer?** On grab? Interact? Game event? `OnPlayerLeft`? `Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` is `true` synchronously after the call, and writing `[UdonSynced]` fields plus `RequestSerialization()` immediately afterwards is safe under an `IsOwner` guard. Concurrent `SetOwner` calls from multiple clients are resolved by network arrival order — there is no client-side arbitration, so accept that the loser's write is overwritten.
 - **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Persistent state requires `[UdonSynced]` variables; the owner calls `RequestSerialization()` on join events to push current state to newcomers.
 - **What if the owner leaves mid-session?** Without explicit `OnPlayerLeft` handling, the object's synced state can never change again. Decide upfront: auto-transfer to master, reset to a known default, or the next interacting player claims ownership.
 
@@ -60,7 +60,7 @@ These constraints cause either **compile-time failures** or **silent runtime fai
 | 9 | Use LINQ (`.Where`, `.Select`, etc.) or lambda expressions | Compile error — not supported by Udon compiler | Manual `for` loops with named methods |
 | 10 | Use `Button.onClick.AddListener()` | Not available in Udon — no runtime delegate support | Configure `SendCustomEvent` via Inspector OnClick |
 | 11 | Mix Continuous and Manual sync concerns on one behaviour | Wastes bandwidth (discrete values in Continuous) or loses control (redundant `RequestSerialization` in Continuous) | Separate behaviours: Continuous for position/rotation, Manual for discrete state |
-| 12 | Write synced variables before `OnOwnershipTransferred` confirms ownership | `SetOwner` is async — writes before confirmation are silently discarded | Store intent locally, write + serialize in `OnOwnershipTransferred` callback |
+| 12 | Write to `[UdonSynced]` fields without an `IsOwner` guard | Non-owner writes are purely local and silently reverted on the next deserialization from the actual owner | `Networking.SetOwner` first if needed (locally immediate), then write under `IsOwner` and call `RequestSerialization()` |
 | 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compiles but silently ignored at runtime — the attribute has no effect and methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
 | 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
@@ -98,8 +98,8 @@ Late joiners don't see current state?
   ├── State set only on event (e.g., player trigger)?  → Also set in Start() + RequestSerialization() on owner
   └── Using SendCustomNetworkEvent for persistent state? → Use [UdonSynced] variables instead
 
-OnOwnershipTransferred never fires after SetOwner()?
-  └── SetOwner() is async — write synced vars inside OnOwnershipTransferred callback, not immediately after
+OnOwnershipTransferred not firing on a remote client?
+  └── On the caller, the callback fires synchronously inside SetOwner — confirm the calling client called Networking.SetOwner(LocalPlayer, gameObject), and that remote clients resolve the same gameObject reference (scene path or prefab GUID)
 ```
 
 ## Reference Loading Guide

--- a/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
@@ -10,17 +10,18 @@ Common mistakes in UdonSharp networking that cause silent failures, data loss, o
 
 ### 1. Ownership Race Condition
 
-**Problem**: Two clients call `Networking.SetOwner` simultaneously for the same object. There is no built-in conflict resolution — the last-processed `SetOwner` wins, which is non-deterministic. Whichever client "loses" the race will have its synced variable writes silently discarded because `RequestSerialization()` is called before ownership is confirmed.
+**Problem**: `Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` returns `true` synchronously after the call returns, and `OnOwnershipTransferred` fires synchronously inside the `SetOwner` stack on that client. When two clients call `SetOwner` for the same object at the same moment, **both succeed locally** and may write `[UdonSynced]` variables; VRChat's network resolves the durable owner by network arrival order, and the loser's write is overwritten when the winner's serialization arrives. There is no client-side arbitration. Treat "loser overwrite" as a property of the network, not a bug to engineer around with callback gating.
 
 **Wrong:**
 
 ```csharp
-// Client A and Client B both execute this at the same time
+// Mutating [UdonSynced] without an IsOwner guard — when SetOwner has not
+// been called for the local client (e.g., owner is someone else), the
+// write is purely local and is silently reverted on the next deserialization.
 public void TryCapture()
 {
-    Networking.SetOwner(Networking.LocalPlayer, gameObject);
-    capturedBy = Networking.LocalPlayer.playerId; // May be overwritten by Client B
-    RequestSerialization();                        // May be dropped — not owner yet
+    capturedBy = Networking.LocalPlayer.playerId; // No IsOwner guard — may be a non-owner write
+    RequestSerialization();                        // No-op when called by a non-owner
 }
 ```
 
@@ -31,28 +32,39 @@ public void TryCapture()
 public class CapturePoint : UdonSharpBehaviour
 {
     [UdonSynced] private int capturedBy = -1;
-    private int _pendingCaptureId = -1;
 
     public void TryCapture()
     {
-        // Store intent, then request ownership
-        _pendingCaptureId = Networking.LocalPlayer.playerId;
-        Networking.SetOwner(Networking.LocalPlayer, gameObject);
-        // Do NOT write synced variables here — ownership is not confirmed yet
-    }
+        // SetOwner is locally immediate. After it returns, IsOwner is true
+        // for this client. Two clients racing to capture will both write
+        // locally and serialize; the network resolves the durable owner by
+        // arrival order, and the loser's write is overwritten when the
+        // winner's serialization arrives. This is acceptable for capture-
+        // point semantics.
+        if (!Networking.IsOwner(gameObject))
+        {
+            Networking.SetOwner(Networking.LocalPlayer, gameObject);
+        }
 
-    public override void OnOwnershipTransferred(VRCPlayerApi player)
-    {
-        if (!player.isLocal) return;
-
-        // Only write + serialize after confirmed ownership
-        capturedBy = _pendingCaptureId;
+        capturedBy = Networking.LocalPlayer.playerId;
         RequestSerialization();
     }
+
+    public override void OnDeserialization()
+    {
+        // Update visuals from synced state (runs on non-owner clients).
+        UpdateVisualsFromCapturedBy();
+    }
+
+    private void UpdateVisualsFromCapturedBy() { /* ... */ }
 }
 ```
 
-**Explanation**: `Networking.SetOwner` is asynchronous. The previous owner must acknowledge the transfer before `OnOwnershipTransferred` fires on the new owner. Writing synced variables before that callback means the write may come from a non-owner and will be silently ignored by VRChat. Use `OnOwnershipTransferred` as the commit point.
+**Explanation**: `Networking.SetOwner` is **locally immediate**. After the call returns, `Networking.IsOwner(gameObject)` is `true` and `OnOwnershipTransferred` has already fired synchronously inside the `SetOwner` stack on the calling client. Writing `[UdonSynced]` fields and calling `RequestSerialization()` immediately afterwards is safe under an `IsOwner` guard. Concurrent calls from multiple clients are *not* arbitrated client-side — VRChat's network resolves the durable owner by arrival order, and the loser's local write is overwritten when the winner's serialization arrives. See the [Transfer Events Diagram](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram) on creators.vrchat.com.
+
+**When `OnOwnershipRequest` fits.** If the *current owner* needs to reject ownership transfers during a critical action (turn-based logic, mid-transaction state), use `OnOwnershipRequest`. That is a different problem class — owner-side protection — not arbitration among concurrent requesters. See [networking.md §"Ownership Arbitration with OnOwnershipRequest"](networking.md#ownership-arbitration-with-onownershiprequest).
+
+> *Footnote: Pre-2021.2.2 SDKs were asynchronous; this skill targets SDK 3.7.1+ where the locally-immediate behavior is in effect.*
 
 ---
 
@@ -277,19 +289,11 @@ public class GameFlag : UdonSharpBehaviour
     {
         if (!Networking.IsOwner(gameObject))
         {
-            // Become owner first, then write in OnOwnershipTransferred
+            // Locally immediate; we own the object after this returns.
             Networking.SetOwner(Networking.LocalPlayer, gameObject);
-            return;
         }
 
-        SetCaptured(true);
-    }
-
-    public override void OnOwnershipTransferred(VRCPlayerApi player)
-    {
-        if (!player.isLocal) return;
-
-        // Ownership confirmed — safe to write and serialize
+        // SetOwner is locally immediate — safe to write under IsOwner.
         SetCaptured(true);
     }
 
@@ -308,7 +312,7 @@ public class GameFlag : UdonSharpBehaviour
 }
 ```
 
-**Explanation**: In UdonSharp, only the current owner's `RequestSerialization()` calls are transmitted. Non-owner writes to `[UdonSynced]` variables are purely local and will be overwritten by the next deserialization from the actual owner. Always guard synced writes with `Networking.IsOwner(gameObject)` and use the `SetOwner` + `OnOwnershipTransferred` pattern when ownership transfer is needed.
+**Explanation**: In UdonSharp, only the current owner's `RequestSerialization()` calls are transmitted. Non-owner writes to `[UdonSynced]` variables are purely local and will be overwritten by the next deserialization from the actual owner — that is the silent failure to guard against. Always guard synced writes with `Networking.IsOwner(gameObject)`; if you are not the owner, call `Networking.SetOwner` first — it is locally immediate, so once it returns `IsOwner` is `true` and you may write and serialize on the same frame.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -457,54 +457,47 @@ Debug.Log($"Owner: {owner.displayName}");
 ### Ownership Transfer
 
 ```csharp
-// Request ownership for local player
+// Request ownership for the local player.
+// Locally immediate — IsOwner(gameObject) returns true after this call.
 Networking.SetOwner(Networking.LocalPlayer, gameObject);
-
-// Note: Ownership transfer is not instant!
-// The previous owner must acknowledge the transfer
 ```
 
-**Important timing issue**: After `SetOwner`, the new owner cannot immediately modify synced variables. It must wait for the previous owner's acknowledgment:
+**Set owner if needed and update synced state in one call:**
 
 ```csharp
-// WRONG - May fail due to timing
-Networking.SetOwner(Networking.LocalPlayer, gameObject);
-syncedValue = 10; // Might not sync!
-RequestSerialization();
-
-// CORRECT - Wait for ownership confirmation
 public void RequestOwnershipAndUpdate(int newValue)
 {
-    pendingValue = newValue;
-    Networking.SetOwner(Networking.LocalPlayer, gameObject);
-    // Value will be set in OnOwnershipTransferred
+    if (!Networking.IsOwner(gameObject))
+    {
+        Networking.SetOwner(Networking.LocalPlayer, gameObject);
+    }
+
+    syncedValue = newValue;
+    RequestSerialization();
 }
 
+// OnOwnershipTransferred remains useful for inheritance scenarios
+// (e.g., the previous owner left and you became owner without a
+// SetOwner call of your own). For SetOwner-initiated transfers, the
+// callback fires synchronously inside SetOwner — usually you do not
+// need to write code in it for the calling-side path.
 public override void OnOwnershipTransferred(VRCPlayerApi player)
 {
     if (player.isLocal)
     {
-        syncedValue = pendingValue;
+        // Re-broadcast state so non-owner clients converge.
         RequestSerialization();
     }
 }
 ```
 
-### Ownership Transfer Timing Diagram
+### Ownership Transfer Timing Semantics
 
-```text
-Player A (current owner) | Player B (requesting)
--------------------------|------------------------
-                        | SetOwner(B, obj)
-                        | [Cannot sync yet!]
-Receives request         |
-Acknowledges transfer   |
-                        | OnOwnershipTransferred(B)
-                        | [Now safe to sync]
-                        | RequestSerialization()
-```
+- **On the calling client:** `Networking.SetOwner` takes effect immediately. `Networking.IsOwner(gameObject)` returns `true` synchronously after the call. `OnOwnershipTransferred` fires synchronously within the `SetOwner` stack on the calling client.
+- **On remote clients:** the new ownership becomes visible after VRChat propagates the change. Each remote client's `OnOwnershipTransferred` fires when the propagation arrives.
+- **No client-side arbitration:** when two clients call `SetOwner` simultaneously, both succeed locally and may write synced variables; VRChat resolves the durable owner by network arrival order. The loser's write is overwritten when the winner's serialization arrives. This is by design — see [networking-antipatterns.md §1](networking-antipatterns.md#1-ownership-race-condition) for the recommended `IsOwner`-guarded pattern, and [§"Ownership Arbitration with OnOwnershipRequest"](#ownership-arbitration-with-onownershiprequest) below for owner-side protection during critical actions.
 
-**Race condition warning**: If multiple players call `SetOwner` simultaneously, the last one processed wins. There is no built-in conflict resolution.
+> *Footnote: Pre-2021.2.2 SDKs treated `SetOwner` as asynchronous on the calling client; current SDKs (3.7.1+, this skill's coverage range) are locally immediate. Source: [Ownership Transfer Events](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram).*
 
 ### Owner Leave and Ownership Cascade
 
@@ -642,8 +635,8 @@ public void IncrementScore()
 {
     if (!Networking.IsOwner(gameObject))
     {
+        // SetOwner is locally immediate — IsOwner is true after this returns.
         Networking.SetOwner(Networking.LocalPlayer, gameObject);
-        return; // Wait for OnOwnershipTransferred
     }
 
     score += 10;
@@ -1123,7 +1116,7 @@ The **owner-centric** pattern reduces both risks: a specific `GameObject` has ex
 owner at all times, so `Networking.IsOwner(gameObject)` typically returns the same result
 across all clients. Note that during ownership transfers (e.g., the current owner leaves),
 there is a brief transient window where clients may briefly disagree on who the owner is
-until the network round-trip completes. The `OnOwnershipTransferred` callback is the correct
+until VRChat propagates the new ownership to other clients. The `OnOwnershipTransferred` callback is the correct
 place to handle this case — re-initialize owner-only state and call `RequestSerialization()`
 so all clients converge to the new owner's authoritative state.
 

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -217,9 +217,8 @@ Run through this checklist before publishing any world.
 
 ### Ownership and Sync
 
-- [ ] All `[UdonSynced]` modifications are preceded by `Networking.IsOwner()` checks
+- [ ] All `[UdonSynced]` writes are guarded by `Networking.IsOwner(gameObject)`; if not owner, call `Networking.SetOwner` first (locally immediate), then write and `RequestSerialization()` (Manual sync)
 - [ ] All Manual-sync behaviours call `RequestSerialization()` after modifying synced fields
-- [ ] All synced writes are guarded by `Networking.IsOwner(gameObject)` (call `Networking.SetOwner` first if needed; it is locally immediate)
 - [ ] No ownership fights: two scripts do not compete for ownership of the same object
 
 ### Late Joiner Correctness

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -219,7 +219,7 @@ Run through this checklist before publishing any world.
 
 - [ ] All `[UdonSynced]` modifications are preceded by `Networking.IsOwner()` checks
 - [ ] All Manual-sync behaviours call `RequestSerialization()` after modifying synced fields
-- [ ] Ownership transfer (`Networking.SetOwner()`) is confirmed via `OnOwnershipTransferred` before writing synced state
+- [ ] All synced writes are guarded by `Networking.IsOwner(gameObject)` (call `Networking.SetOwner` first if needed; it is locally immediate)
 - [ ] No ownership fights: two scripts do not compete for ownership of the same object
 
 ### Late Joiner Correctness

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -403,41 +403,33 @@ MyProperty = 10;
 **Symptoms:**
 - Unexpected ownership changes
 - State desynchronization
-- "Flickering" between states
+- Loser's local write is overwritten when the concurrent winner's serialization arrives
 
 **Solution:**
+
+`Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` returns `true` synchronously after the call. There is no need to defer the action to `OnOwnershipTransferred`. Concurrent callers each succeed locally; the network resolves the durable owner by arrival order, and the loser's write is overwritten on the next deserialization. Guard writes with `IsOwner` and accept that property of the network.
+
 ```csharp
-// Use ownership request pattern
 public override void Interact()
 {
-    if (Networking.IsOwner(gameObject))
+    if (!Networking.IsOwner(gameObject))
     {
-        // Already owner, proceed
-        DoAction();
-    }
-    else
-    {
-        // Request ownership, wait for transfer
-        _pendingAction = true;
+        // SetOwner is locally immediate; IsOwner is true after this returns.
         Networking.SetOwner(Networking.LocalPlayer, gameObject);
     }
-}
 
-public override void OnOwnershipTransferred(VRCPlayerApi player)
-{
-    if (player.isLocal && _pendingAction)
-    {
-        _pendingAction = false;
-        DoAction();
-    }
+    DoAction();
 }
 
 private void DoAction()
 {
-    // Modify synced variables here
+    // IsOwner is true on this frame after SetOwner; safe to write
+    // synced variables here.
     RequestSerialization();
 }
 ```
+
+> For owner-side protection during critical actions (e.g., reject ownership requests mid-transaction), use `OnOwnershipRequest` — see [networking.md §"Ownership Arbitration with OnOwnershipRequest"](networking.md#ownership-arbitration-with-onownershiprequest).
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #171 (reported by @Guribo, SDK 3.10.3) flagged that `networking-antipatterns.md` §1 "Ownership Race Condition" describes pre-2021.2.2 SetOwner behavior (asynchronous; synced writes after SetOwner silently discarded). VRChat fixed that ~5 years ago — the current behavior is locally immediate. Verifying against the official [Ownership Transfer Events](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram) documentation and Guribo's empirical SDK 3.10.3 test confirms the bug.

Beyond the §1 site Guribo flagged, the same misconception was repeated in 4 more places across the udon-sharp skill, and the §1 "Correct" example used `OnOwnershipTransferred` as a commit point — a pattern that does **not** actually solve the multi-client race (both clients' callbacks fire synchronously, and the network arbitrates by last arrival), so the example needed structural redesign, not just rewording.

## Mechanism correction (before / after)

**Before** (incorrect — pre-2021.2.2 model):
- `Networking.SetOwner` is asynchronous on the calling client.
- The previous owner must acknowledge before `OnOwnershipTransferred` fires on the new owner.
- Therefore: defer all synced writes to the `OnOwnershipTransferred` callback after `SetOwner`.

**After** (correct, post-2021.2.2):
- `Networking.SetOwner` is **locally immediate** on the calling client. After it returns, `Networking.IsOwner(gameObject)` is `true` and `OnOwnershipTransferred` has already fired synchronously inside the `SetOwner` stack on the calling client.
- Writing `[UdonSynced]` fields and calling `RequestSerialization()` immediately after `SetOwner` is safe under an `IsOwner` guard.
- Concurrent `SetOwner` calls from multiple clients are resolved by network arrival order — there is no client-side arbitration. Treat "loser overwrite" as a property of the network, not a bug to engineer around with callback gating.
- For owner-side protection during critical actions, use `OnOwnershipRequest` (already documented in `networking.md`).

Citation: [VRChat 2021.2.2 release notes](https://docs.vrchat.com/docs/vrchat-202122) — *"Networking.SetOwner now works immediately - you can update variables immediately after changing ownership and the changes will apply properly."*

## Affected files (5 files, 7 edit sites, 2 commits)

**Commit 1** — semantic pivot:
- `skills/unity-vrc-udon-sharp/references/networking-antipatterns.md` (§1 full rewrite, §5 Correct simplification)
- `skills/unity-vrc-udon-sharp/references/networking.md` (Ownership Transfer section + timing diagram replacement + IncrementScore fix + owner-leave phrasing)
- `skills/unity-vrc-udon-sharp/references/troubleshooting.md` (Ownership Transfer Race Conditions Solution rewrite)
- `skills/unity-vrc-udon-sharp/SKILL.md` (architectural-decisions bullet, NEVER row 12, sync-debugging tip)

**Commit 2** — cross-reference alignment:
- `skills/unity-vrc-udon-sharp/references/testing.md` (pre-publish checklist line)

No version bump — that lands separately as a `chore(version)` PR per repo release policy. Release Drafter label is `release: docs` (this is a documentation correction, not a runtime defect).

## What was deliberately left alone

- `references/patterns-core.md` L281/L607/L615/L734 already use the correct immediate-after-SetOwner pattern — no change needed.
- `OnOwnershipRequest` documentation in `networking.md` L548-581 is accurate.
- The legitimate post-inheritance use case for `OnOwnershipTransferred` (re-broadcasting state when you inherited ownership without your own SetOwner call) is preserved.
- Tier 3 sites (`constraints.md` SyncedUrlList example, `patterns-ui.md` CloseCurrentApp) use the defer-via-pending-flag pattern — functionally correct post-2021.2.2 but with stale rationale labels. Tracked in follow-up Issue #173.

## Reporter acknowledgement

Thanks to @Guribo for the precise repro test (SDK 3.10.3) and for linking the official creators.vrchat.com transfer-events diagram. The verification of his report also surfaced a deeper issue with the existing "Correct" example (the `OnOwnershipTransferred`-as-commit-point pattern was itself incorrect for multi-client races), which is fixed in the same PR.

## Test plan

- [ ] CI passes: Symlink Integrity, Hook Scripts, npm Pack Test
- [ ] CI passes: Markdown Links (no broken references in or to the rewritten sections)
- [ ] CI passes: EditorConfig
- [x] Local: `npm test` — 5/5 tests passing
- [x] Local: `npm pack --dry-run` — 70 files, 285 kB tarball
- [x] Local: `node bin/install.mjs --list` runs cleanly
- [x] Local: `npx markdown-link-check` on all 5 modified files — exit 0
- [ ] In-page anchor `#1-ownership-race-condition` still resolves (slug preserved by keeping heading text)
- [ ] CodeRabbit approval received before merge

Closes #171

## Follow-up Issues

Two follow-up Issues were filed during the verification of #171 to capture out-of-scope work that should not be lost:

- #173 — Tier 3 rationale-label refresh on `constraints.md` SyncedUrlList and `patterns-ui.md` CloseCurrentApp examples (functionally correct, but obsolete rationale labels).
- #174 — Verify accuracy of the `OnOwnershipRequest` "runs locally on both sides" claim in `networking.md` L580 (adjacent to but out-of-scope of #171).
