### PR TITLE
docs(skills/udon-sharp): correct Migration Decision Table row for OnOwnershipRequest (#176)

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1184,7 +1184,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | One-off world init (fires once at world launch) | Acceptable | Preferred |
 | Ongoing game logic (timers, spawning, scoring) | No — fragile | Yes |
 | Responding to player join/leave events | No — may double-fire | Yes |
-| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Yes — runs on current owner |
+| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Neither — the callback fires on both the requester and the current owner; logic must agree on both clients to avoid desync. See [Ownership Arbitration with OnOwnershipRequest](#ownership-arbitration-with-onownershiprequest) above. |
 | Checking if a specific player is the master | `player.isMaster` on `VRCPlayerApi` | N/A |
 
 > **Reference**: VRChat networking documentation — https://creators.vrchat.com/worlds/udon/networking/

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1184,8 +1184,10 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | One-off world init (fires once at world launch) | Acceptable | Preferred |
 | Ongoing game logic (timers, spawning, scoring) | No — fragile | Yes |
 | Responding to player join/leave events | No — may double-fire | Yes |
-| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Neither — the callback fires on both the requester and the current owner; logic must agree on both clients to avoid desync. See [Ownership Arbitration with OnOwnershipRequest](#ownership-arbitration-with-onownershiprequest) above. |
+| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Neither[^owner-req] |
 | Checking if a specific player is the master | `player.isMaster` on `VRCPlayerApi` | N/A |
+
+[^owner-req]: The callback fires on both the requester and the current owner; logic must agree on both clients to avoid desync. See [Ownership Arbitration with OnOwnershipRequest](#ownership-arbitration-with-onownershiprequest) above.
 
 > **Reference**: VRChat networking documentation — https://creators.vrchat.com/worlds/udon/networking/
 


### PR DESCRIPTION
## Summary

The IsMaster vs IsOwner Migration Decision Table at \`networking.md\` L1187 described the \`OnOwnershipRequest\` row as **\"Yes — runs on current owner\"**. That phrasing implies \`IsOwner\` is the right gate to use inside the callback, but the callback fires on **both** the requester and the current owner (per the official Network Components page and \`networking.md\` L574).

On the requester's client, \`IsOwner == false\` at \`OnOwnershipRequest\` fire-time — they aren't the owner yet — so any \`IsOwner\`-gated branch inside the callback silently takes the other path on the requester. The result is precisely the \"disagreements in logic between the two will cause a desync\" failure mode that L574 warns against.

This was the pre-existing LOW finding from PR #175's reviewer pass, filed as Issue #176.

## Change

Single-row edit in the Migration Decision Table:

```diff
-| Approving ownership transfers (\`OnOwnershipRequest\`) | No — wrong API | Yes — runs on current owner |
+| Approving ownership transfers (\`OnOwnershipRequest\`) | No — wrong API | Neither — the callback fires on both the requester and the current owner; logic must agree on both clients to avoid desync. See [Ownership Arbitration with OnOwnershipRequest](#ownership-arbitration-with-onownershiprequest) above. |
```

Why **\"Neither\"** rather than **\"Yes — but logic must agree on both clients\"**: \`IsOwner\` inside \`OnOwnershipRequest\` is genuinely the wrong tool — it returns different values on the two clients (\`false\` on requester, \`true\` on current owner) and there is no version of \"use \`IsOwner\` correctly\" that gives the right answer. \"Neither\" steers readers away from the trap entirely; the cross-link carries the full guidance.

## Verification

- [x] \`npm test\` — 5/5 pass
- [x] \`npx markdown-link-check\` on networking.md — exit 0
- [x] In-table cross-link \`#ownership-arbitration-with-onownershiprequest\` resolves to the existing section at L541
- [x] No version bump (per release policy)

## Closes

Closes #176