### PR TITLE
Release v1.8.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "1.2.1"
+    "version": "1.8.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "1.8.1"
+    "version": "1.8.2"
   },
   "plugins": [
     {

--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -27,8 +27,19 @@ Any change to these paths requires a documentation sync check:
 ## What NOT to Update
 
 - `CHANGELOG.md` — managed by Release Drafter, not manual edits
-- `package.json` version — managed by publish workflow
-- `SKILL.md` version fields — managed by publish workflow
+
+## What to Update Together (Release Flow)
+
+These fields must be bumped together on `dev` via a `chore(version): bump to vX.Y.Z` PR
+**before** opening the release PR. See CLAUDE.md "Release Guide" Step 1 for the exact procedure.
+`publish.yml` does mutate them in the CI runner as a safety net, but those edits are not
+committed back, so the source-of-truth must be kept current by hand:
+
+- `package.json` → `.version`
+- `.claude-plugin/marketplace.json` → `.metadata.version`
+- `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
+- `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
+- `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`
 
 ## Checklist (run mentally before committing)
 

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.8.1"
+    version: "1.8.2"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.2.1"
+    version: "1.8.1"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,61 @@
+# Release PR Template
+
+> Open a release PR with this template by appending `?template=release.md` to the new-PR URL,
+> or by editing the body after creation. See `CLAUDE.md` "Release Guide" for the full flow.
+
+## Pre-flight checklist (Step 1 must be done BEFORE this PR is opened)
+
+- [ ] **Version bumped on `dev`** via a separate `chore(version): bump to vX.Y.Z` PR, already merged.
+  Verify with `node -p "require('./package.json').version"` on `dev` — it must equal the target version.
+- [ ] All 5 version fields are in sync (Version Sync CI checks this; verify locally too):
+  - `package.json` → `.version`
+  - `.claude-plugin/marketplace.json` → `.metadata.version`
+  - `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
+  - `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
+  - `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`
+
+## Summary
+
+Release vX.Y.Z — short one-line punchline.
+
+**N PRs since vPREVIOUS:**
+
+- #NNN — `<type>`: `one-sentence summary`
+- ...
+
+**Version bump driver**: `release: <highest-label>` → `<bump-type>`.
+
+## What changed
+
+### `Skill or Area` (#NNN)
+
+
+- ...
+
+## Reporter acknowledgement (if applicable)
+
+If any of the bundled PRs closed an externally-reported Issue, list reporters here. The release notes
+themselves should also include a thank-you (in the reporter's language).
+
+## Merge instructions
+
+**DO NOT SQUASH** — use a plain merge commit so Release Drafter sees each underlying PR.
+
+## Post-merge
+
+1. Release Drafter creates/updates a draft release on `main`.
+2. Rewrite the draft notes (`gh release edit vX.Y.Z --notes "$(cat <<'NOTES' ... NOTES)"`):
+   - Remove the auto-generated "Release vX.Y.Z (#N)" self-reference line.
+   - Convert bare PR titles to user-facing prose.
+   - Add reporter thank-you if applicable, in the reporter's language.
+3. `gh release edit vX.Y.Z --draft=false` to publish — triggers `publish.yml` → `npm publish`.
+
+## Test plan
+
+- [ ] CI green (Symlinks / Hooks / Markdown / npm Pack / Installer Tests / EditorConfig / Version Sync)
+- [ ] Release Drafter draft body reflects the merged PRs
+- [ ] After publish: `npm view agent-skills-vrc-udon version` returns vX.Y.Z
+
+## Release impact
+
+`release: <label>` → `<bump-type>` bump per Release Drafter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,42 +95,95 @@ node bin/install.mjs --help
 ### Overview
 
 ```
-dev ──release PR──> main ──Release Drafter draft──> publish ──> npm
+dev ──version-bump PR──> dev ──release PR──> main ──Release Drafter draft──> publish ──> npm
 ```
 
-Version numbers and changelogs are **fully automated** by Release Drafter.
-Do NOT manually edit `package.json` version — `publish.yml` sets it from the release tag.
+Changelogs are automated by Release Drafter. **Version numbers must be bumped manually on `dev` before opening the release PR** (see Step 1 below). `publish.yml` does run `npm version "$VERSION" --no-git-tag-version` in the CI runner as a safety net, but those edits are not committed back, so the git tree's source-of-truth must be kept current by hand.
 
 ### Step-by-step
 
-1. **Create a release PR from `dev` to `main`**
+1. **Bump version fields on `dev`**
+   - Decide the target version vX.Y.Z (consult labels on merged PRs since the last release — see "Version resolution" below).
+   - Branch off `dev`, run the bump, open a PR back to `dev`:
+
+     ```bash
+     set -e
+     git checkout dev && git pull
+     git checkout -b chore/release-vX.Y.Z
+
+     # OLD: read from local package.json. If your local is stale, prefer:
+     #   OLD=$(npm view agent-skills-vrc-udon version)
+     OLD=$(node -p "require('./package.json').version")
+     NEW=X.Y.Z
+
+     # 5 fields must move together — Version Sync CI verifies parity.
+     # The SKILL.md sed is anchored to the 4-space-indented frontmatter line
+     # so body-text occurrences (e.g. SDK version mentions) are not rewritten.
+     sed -i "s/\"version\": \"$OLD\"/\"version\": \"$NEW\"/" package.json .claude-plugin/marketplace.json
+     sed -i "s/^    version: \"$OLD\"$/    version: \"$NEW\"/" \
+       skills/unity-vrc-udon-sharp/SKILL.md \
+       skills/unity-vrc-world-sdk-3/SKILL.md \
+       .claude/skills/unity-vrc-skills-renovator/SKILL.md
+
+     # Sanity check before commit — only the 5 expected fields should diff.
+     git diff --stat
+
+     git commit -am "chore(version): bump to vX.Y.Z"
+     git push -u origin chore/release-vX.Y.Z
+     gh pr create --base dev --label "release: maintenance" \
+       --title "chore(version): bump to vX.Y.Z" \
+       --body "Pre-release version bump for Step 2 of the release flow."
+     ```
+
+   - Wait for **all** CI jobs green — specifically Version Sync, which verifies all 5 fields agree on `vX.Y.Z`. (Branch protection currently enforces only `Symlink Integrity / Hook Scripts / npm Pack Test` as required contexts; do not merge if Version Sync is red even though GitHub allows it.) Merge the bump PR into `dev` (squash is fine here — single-purpose commit). CodeRabbit review is optional on this PR — it's mechanical and Version Sync is the substantive check.
+
+2. **Create a release PR from `dev` to `main`**
+
    ```bash
    gh pr create --base main --head dev \
      --title "Release vX.Y.Z" \
      --body "Merge dev into main for release"
    ```
-   - Title should include the expected version (check the draft release for the resolved version)
-   - Wait for CI to pass and CodeRabbit approval
 
-2. **Merge the release PR**
-   - Merge (do NOT squash — preserve commit history)
-   - This triggers Release Drafter to update the draft release on `main`
+   - Title must include the version that matches `package.json#version` on `dev` after Step 1.
+   - Wait for CI to pass. CodeRabbit approval is **not required for release PRs** (per repo convention — release PRs are mechanical merges of already-reviewed commits).
 
-3. **Publish the GitHub Release draft**
+3. **Merge the release PR**
+   - Merge (do NOT squash — preserve commit history so Release Drafter sees each underlying PR commit).
+   - This triggers Release Drafter to update the draft release on `main`.
+
+4. **Publish the GitHub Release draft**
+
    ```bash
    # List draft releases
    gh release list --exclude-drafts=false
 
-   # Review and publish the draft (edit title/notes if needed)
+   # Always rewrite the auto-generated notes before publishing:
+   #   - Remove the "Release vX.Y.Z (#N)" self-reference line
+   #   - Replace bare PR titles with user-facing prose
+   #   - Add a reporter acknowledgement section if any bundled PR closed an
+   #     externally-reported Issue. Mirror the reporter's language for the
+   #     release-notes acknowledgement (Japanese reporter → Japanese; English
+   #     reporter → English). Issue/PR titles and bodies remain English-first
+   #     per repo convention; the reporter-language rule applies only to
+   #     user-facing release notes.
+   gh release edit vX.Y.Z --notes "$(cat <<'NOTES'
+   ## What's New in vX.Y.Z
+   ...
+   NOTES
+   )"
+
+   # Publish (this triggers publish.yml → npm publish)
    gh release edit vX.Y.Z --draft=false
    ```
-   - The `published` event triggers `publish.yml`
-   - `publish.yml` reads the tag, sets `npm version`, and runs `npm publish --provenance`
-   - Uses the `npm-publish` environment (requires `NPM_TOKEN` secret)
 
-### Version resolution (automatic)
+   - The `published` event triggers `publish.yml`.
+   - `publish.yml` reads the tag, runs `npm version "$VERSION" --allow-same-version` (no-op if Step 1 was done correctly), syncs to SKILL.md / marketplace.json again as a safety net, and runs `npm publish --provenance`.
+   - Uses the `npm-publish` environment (requires `NPM_TOKEN` secret).
 
-Release Drafter resolves the version bump from PR labels:
+### Version resolution (label-driven)
+
+When deciding the target version in Step 1, count the labels on PRs merged into `dev` since the last release:
 
 | Label | Bump |
 |-------|------|
@@ -140,14 +193,14 @@ Release Drafter resolves the version bump from PR labels:
 | `release: docs` | patch |
 | `release: maintenance` | patch |
 
-If no label matches, defaults to **patch**.
+The highest bump wins. If no label matches, default to **patch**. Release Drafter independently resolves the same labels for the draft body, so as long as the manual bump in Step 1 matches Release Drafter's resolution, the draft and `package.json` will agree.
 
 ### What NOT to do
 
-- Do NOT manually bump `package.json` version (publish.yml handles it)
-- Do NOT create tags manually (Release Drafter creates them)
-- Do NOT push directly to `main` (branch protection blocks it)
-- Do NOT merge feature branches directly to `main` (always go through `dev`)
+- Do NOT skip Step 1 (the manual version bump). `publish.yml`'s runner-side mutation does **not** commit back, so a missed bump leaves the git tree frozen. The Version Sync CI check trivially passes when all 5 fields agree on the wrong value — this drifted for 5 release cycles before being caught (PR #169).
+- Do NOT create tags manually (Release Drafter creates them when the release is published).
+- Do NOT push directly to `main` (branch protection blocks it; use the release PR flow).
+- Do NOT merge feature branches directly to `main` (always go through `dev`).
 
 ## Editing Skills
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.2.1",
+  "version": "1.8.1",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.8.1"
+    version: "1.8.2"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.2.1"
+    version: "1.8.1"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -31,7 +31,7 @@ Every rule in this skill exists because UdonSharp's default behavior is to **fai
 Four architectural decisions that must be made before choosing sync modes or writing any synced variable. Changing them mid-implementation typically requires a full rewrite:
 
 - **Who owns this state?** One owner writes; all others read. If two players can both write (e.g., a shared toggle), you need an ownership transfer protocol — writes without ownership are silently discarded.
-- **When does ownership transfer?** On grab? Interact? Game event? `OnPlayerLeft`? Ownership transfer is asynchronous — do not write synced variables immediately after `SetOwner()`; write inside `OnOwnershipTransferred`.
+- **When does ownership transfer?** On grab? Interact? Game event? `OnPlayerLeft`? `Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` is `true` synchronously after the call, and writing `[UdonSynced]` fields plus `RequestSerialization()` immediately afterwards is safe under an `IsOwner` guard. Concurrent `SetOwner` calls from multiple clients are resolved by network arrival order — there is no client-side arbitration, so accept that the loser's write is overwritten.
 - **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Persistent state requires `[UdonSynced]` variables; the owner calls `RequestSerialization()` on join events to push current state to newcomers.
 - **What if the owner leaves mid-session?** Without explicit `OnPlayerLeft` handling, the object's synced state can never change again. Decide upfront: auto-transfer to master, reset to a known default, or the next interacting player claims ownership.
 
@@ -60,7 +60,7 @@ These constraints cause either **compile-time failures** or **silent runtime fai
 | 9 | Use LINQ (`.Where`, `.Select`, etc.) or lambda expressions | Compile error — not supported by Udon compiler | Manual `for` loops with named methods |
 | 10 | Use `Button.onClick.AddListener()` | Not available in Udon — no runtime delegate support | Configure `SendCustomEvent` via Inspector OnClick |
 | 11 | Mix Continuous and Manual sync concerns on one behaviour | Wastes bandwidth (discrete values in Continuous) or loses control (redundant `RequestSerialization` in Continuous) | Separate behaviours: Continuous for position/rotation, Manual for discrete state |
-| 12 | Write synced variables before `OnOwnershipTransferred` confirms ownership | `SetOwner` is async — writes before confirmation are silently discarded | Store intent locally, write + serialize in `OnOwnershipTransferred` callback |
+| 12 | Write to `[UdonSynced]` fields without an `IsOwner` guard | Non-owner writes are purely local and silently reverted on the next deserialization from the actual owner | `Networking.SetOwner` first if needed (locally immediate), then write under `IsOwner` and call `RequestSerialization()` |
 | 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compiles but silently ignored at runtime — the attribute has no effect and methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
 | 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
@@ -98,8 +98,8 @@ Late joiners don't see current state?
   ├── State set only on event (e.g., player trigger)?  → Also set in Start() + RequestSerialization() on owner
   └── Using SendCustomNetworkEvent for persistent state? → Use [UdonSynced] variables instead
 
-OnOwnershipTransferred never fires after SetOwner()?
-  └── SetOwner() is async — write synced vars inside OnOwnershipTransferred callback, not immediately after
+OnOwnershipTransferred not firing on a remote client?
+  └── On the caller, the callback fires synchronously inside SetOwner — confirm the calling client called Networking.SetOwner(LocalPlayer, gameObject), and that remote clients resolve the same gameObject reference (scene path or prefab GUID)
 ```
 
 ## Reference Loading Guide

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -1006,7 +1006,9 @@ public class SyncedUrlList : UdonSharpBehaviour
 | `[UdonSynced] string` for metadata | JSON-encoded array of `[timestamp, type, sender]` entries |
 | `VRCJson.TrySerializeToJson` / `TryDeserializeFromJson` | Serialization of structured metadata into a single synced string |
 | `OnDeserialization` | Handles incoming sync data on non-owner clients |
-| Pending-operation + `OnOwnershipTransferred` | Defers synced writes until ownership is confirmed, avoiding SetOwner race conditions |
+| Pending-operation + `OnOwnershipTransferred` | Carries multi-step deferred operation parameters (Add vs Remove) from the request site to the callback. |
+
+> *Note: `Networking.SetOwner` is locally immediate (post-2021.2.2), so this pattern is not required for ownership timing — it survives because it cleanly carries the operation context from the request site into the callback. See [networking-antipatterns.md §1](networking-antipatterns.md#1-ownership-race-condition) for the immediate-after-SetOwner alternative when no parameter passing is needed.*
 
 **Bandwidth and Performance Considerations:**
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -428,12 +428,13 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 
 ### Ownership Request Arbitration
 
-`OnOwnershipRequest` allows the current owner to accept or reject ownership transfers. This is called **only on the current owner's client**.
+`OnOwnershipRequest` allows the current owner to accept or reject ownership transfers. The callback runs locally on **both the requester and the current owner**, so the logic must return the same result on both sides to avoid desync.
 
 ```csharp
 /// <summary>
-/// Called on the current owner's client when another player requests ownership.
-/// Return true to accept, false to reject the transfer.
+/// Called on both the requester's and the current owner's clients
+/// when another player requests ownership. Return true to accept,
+/// false to reject the transfer. The result MUST agree on both sides.
 /// </summary>
 public override bool OnOwnershipRequest(
     VRCPlayerApi requestingPlayer,

--- a/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
@@ -10,17 +10,18 @@ Common mistakes in UdonSharp networking that cause silent failures, data loss, o
 
 ### 1. Ownership Race Condition
 
-**Problem**: Two clients call `Networking.SetOwner` simultaneously for the same object. There is no built-in conflict resolution — the last-processed `SetOwner` wins, which is non-deterministic. Whichever client "loses" the race will have its synced variable writes silently discarded because `RequestSerialization()` is called before ownership is confirmed.
+**Problem**: `Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` returns `true` synchronously after the call returns, and `OnOwnershipTransferred` fires synchronously inside the `SetOwner` stack on that client. When two clients call `SetOwner` for the same object at the same moment, **both succeed locally** and may write `[UdonSynced]` variables; VRChat's network resolves the durable owner by network arrival order, and the loser's write is overwritten when the winner's serialization arrives. There is no client-side arbitration. Treat "loser overwrite" as a property of the network, not a bug to engineer around with callback gating.
 
 **Wrong:**
 
 ```csharp
-// Client A and Client B both execute this at the same time
+// Mutating [UdonSynced] without an IsOwner guard — when SetOwner has not
+// been called for the local client (e.g., owner is someone else), the
+// write is purely local and is silently reverted on the next deserialization.
 public void TryCapture()
 {
-    Networking.SetOwner(Networking.LocalPlayer, gameObject);
-    capturedBy = Networking.LocalPlayer.playerId; // May be overwritten by Client B
-    RequestSerialization();                        // May be dropped — not owner yet
+    capturedBy = Networking.LocalPlayer.playerId; // No IsOwner guard — may be a non-owner write
+    RequestSerialization();                        // No-op when called by a non-owner
 }
 ```
 
@@ -31,28 +32,39 @@ public void TryCapture()
 public class CapturePoint : UdonSharpBehaviour
 {
     [UdonSynced] private int capturedBy = -1;
-    private int _pendingCaptureId = -1;
 
     public void TryCapture()
     {
-        // Store intent, then request ownership
-        _pendingCaptureId = Networking.LocalPlayer.playerId;
-        Networking.SetOwner(Networking.LocalPlayer, gameObject);
-        // Do NOT write synced variables here — ownership is not confirmed yet
-    }
+        // SetOwner is locally immediate. After it returns, IsOwner is true
+        // for this client. Two clients racing to capture will both write
+        // locally and serialize; the network resolves the durable owner by
+        // arrival order, and the loser's write is overwritten when the
+        // winner's serialization arrives. This is acceptable for capture-
+        // point semantics.
+        if (!Networking.IsOwner(gameObject))
+        {
+            Networking.SetOwner(Networking.LocalPlayer, gameObject);
+        }
 
-    public override void OnOwnershipTransferred(VRCPlayerApi player)
-    {
-        if (!player.isLocal) return;
-
-        // Only write + serialize after confirmed ownership
-        capturedBy = _pendingCaptureId;
+        capturedBy = Networking.LocalPlayer.playerId;
         RequestSerialization();
     }
+
+    public override void OnDeserialization()
+    {
+        // Update visuals from synced state (runs on non-owner clients).
+        UpdateVisualsFromCapturedBy();
+    }
+
+    private void UpdateVisualsFromCapturedBy() { /* ... */ }
 }
 ```
 
-**Explanation**: `Networking.SetOwner` is asynchronous. The previous owner must acknowledge the transfer before `OnOwnershipTransferred` fires on the new owner. Writing synced variables before that callback means the write may come from a non-owner and will be silently ignored by VRChat. Use `OnOwnershipTransferred` as the commit point.
+**Explanation**: `Networking.SetOwner` is **locally immediate**. After the call returns, `Networking.IsOwner(gameObject)` is `true` and `OnOwnershipTransferred` has already fired synchronously inside the `SetOwner` stack on the calling client. Writing `[UdonSynced]` fields and calling `RequestSerialization()` immediately afterwards is safe under an `IsOwner` guard. Concurrent calls from multiple clients are *not* arbitrated client-side — VRChat's network resolves the durable owner by arrival order, and the loser's local write is overwritten when the winner's serialization arrives. See the [Transfer Events Diagram](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram) on creators.vrchat.com.
+
+**When `OnOwnershipRequest` fits.** If the *current owner* needs to reject ownership transfers during a critical action (turn-based logic, mid-transaction state), use `OnOwnershipRequest`. That is a different problem class — owner-side protection — not arbitration among concurrent requesters. See [networking.md §"Ownership Arbitration with OnOwnershipRequest"](networking.md#ownership-arbitration-with-onownershiprequest).
+
+> *Footnote: Pre-2021.2.2 SDKs were asynchronous; this skill targets SDK 3.7.1+ where the locally-immediate behavior is in effect.*
 
 ---
 
@@ -277,19 +289,11 @@ public class GameFlag : UdonSharpBehaviour
     {
         if (!Networking.IsOwner(gameObject))
         {
-            // Become owner first, then write in OnOwnershipTransferred
+            // Locally immediate; we own the object after this returns.
             Networking.SetOwner(Networking.LocalPlayer, gameObject);
-            return;
         }
 
-        SetCaptured(true);
-    }
-
-    public override void OnOwnershipTransferred(VRCPlayerApi player)
-    {
-        if (!player.isLocal) return;
-
-        // Ownership confirmed — safe to write and serialize
+        // SetOwner is locally immediate — safe to write under IsOwner.
         SetCaptured(true);
     }
 
@@ -308,7 +312,7 @@ public class GameFlag : UdonSharpBehaviour
 }
 ```
 
-**Explanation**: In UdonSharp, only the current owner's `RequestSerialization()` calls are transmitted. Non-owner writes to `[UdonSynced]` variables are purely local and will be overwritten by the next deserialization from the actual owner. Always guard synced writes with `Networking.IsOwner(gameObject)` and use the `SetOwner` + `OnOwnershipTransferred` pattern when ownership transfer is needed.
+**Explanation**: In UdonSharp, only the current owner's `RequestSerialization()` calls are transmitted. Non-owner writes to `[UdonSynced]` variables are purely local and will be overwritten by the next deserialization from the actual owner — that is the silent failure to guard against. Always guard synced writes with `Networking.IsOwner(gameObject)`; if you are not the owner, call `Networking.SetOwner` first — it is locally immediate, so once it returns `IsOwner` is `true` and you may write and serialize on the same frame.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -457,54 +457,47 @@ Debug.Log($"Owner: {owner.displayName}");
 ### Ownership Transfer
 
 ```csharp
-// Request ownership for local player
+// Request ownership for the local player.
+// Locally immediate — IsOwner(gameObject) returns true after this call.
 Networking.SetOwner(Networking.LocalPlayer, gameObject);
-
-// Note: Ownership transfer is not instant!
-// The previous owner must acknowledge the transfer
 ```
 
-**Important timing issue**: After `SetOwner`, the new owner cannot immediately modify synced variables. It must wait for the previous owner's acknowledgment:
+**Set owner if needed and update synced state in one call:**
 
 ```csharp
-// WRONG - May fail due to timing
-Networking.SetOwner(Networking.LocalPlayer, gameObject);
-syncedValue = 10; // Might not sync!
-RequestSerialization();
-
-// CORRECT - Wait for ownership confirmation
 public void RequestOwnershipAndUpdate(int newValue)
 {
-    pendingValue = newValue;
-    Networking.SetOwner(Networking.LocalPlayer, gameObject);
-    // Value will be set in OnOwnershipTransferred
+    if (!Networking.IsOwner(gameObject))
+    {
+        Networking.SetOwner(Networking.LocalPlayer, gameObject);
+    }
+
+    syncedValue = newValue;
+    RequestSerialization();
 }
 
+// OnOwnershipTransferred remains useful for inheritance scenarios
+// (e.g., the previous owner left and you became owner without a
+// SetOwner call of your own). For SetOwner-initiated transfers, the
+// callback fires synchronously inside SetOwner — usually you do not
+// need to write code in it for the calling-side path.
 public override void OnOwnershipTransferred(VRCPlayerApi player)
 {
     if (player.isLocal)
     {
-        syncedValue = pendingValue;
+        // Re-broadcast state so non-owner clients converge.
         RequestSerialization();
     }
 }
 ```
 
-### Ownership Transfer Timing Diagram
+### Ownership Transfer Timing Semantics
 
-```text
-Player A (current owner) | Player B (requesting)
--------------------------|------------------------
-                        | SetOwner(B, obj)
-                        | [Cannot sync yet!]
-Receives request         |
-Acknowledges transfer   |
-                        | OnOwnershipTransferred(B)
-                        | [Now safe to sync]
-                        | RequestSerialization()
-```
+- **On the calling client:** `Networking.SetOwner` takes effect immediately. `Networking.IsOwner(gameObject)` returns `true` synchronously after the call. `OnOwnershipTransferred` fires synchronously within the `SetOwner` stack on the calling client.
+- **On remote clients:** the new ownership becomes visible after VRChat propagates the change. Each remote client's `OnOwnershipTransferred` fires when the propagation arrives.
+- **No client-side arbitration:** when two clients call `SetOwner` simultaneously, both succeed locally and may write synced variables; VRChat resolves the durable owner by network arrival order. The loser's write is overwritten when the winner's serialization arrives. This is by design — see [networking-antipatterns.md §1](networking-antipatterns.md#1-ownership-race-condition) for the recommended `IsOwner`-guarded pattern, and [§"Ownership Arbitration with OnOwnershipRequest"](#ownership-arbitration-with-onownershiprequest) below for owner-side protection during critical actions.
 
-**Race condition warning**: If multiple players call `SetOwner` simultaneously, the last one processed wins. There is no built-in conflict resolution.
+> *Footnote: Pre-2021.2.2 SDKs treated `SetOwner` as asynchronous on the calling client; current SDKs (3.7.1+, this skill's coverage range) are locally immediate. Source: [Ownership Transfer Events](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram).*
 
 ### Owner Leave and Ownership Cascade
 
@@ -642,8 +635,8 @@ public void IncrementScore()
 {
     if (!Networking.IsOwner(gameObject))
     {
+        // SetOwner is locally immediate — IsOwner is true after this returns.
         Networking.SetOwner(Networking.LocalPlayer, gameObject);
-        return; // Wait for OnOwnershipTransferred
     }
 
     score += 10;
@@ -1123,7 +1116,7 @@ The **owner-centric** pattern reduces both risks: a specific `GameObject` has ex
 owner at all times, so `Networking.IsOwner(gameObject)` typically returns the same result
 across all clients. Note that during ownership transfers (e.g., the current owner leaves),
 there is a brief transient window where clients may briefly disagree on who the owner is
-until the network round-trip completes. The `OnOwnershipTransferred` callback is the correct
+until VRChat propagates the new ownership to other clients. The `OnOwnershipTransferred` callback is the correct
 place to handle this case — re-initialize owner-only state and call `RequestSerialization()`
 so all clients converge to the new owner's authoritative state.
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -571,7 +571,9 @@ public override bool OnOwnershipRequest(
 | Turn-based game during active turn | Reject (`false`) until turn ends |
 | Free-for-all interaction | Accept (`true`) |
 
-> **Important**: `OnOwnershipRequest` runs locally on **both the requester and the current owner**. The logic must be consistent on both sides to avoid desync. If the owner has disconnected, the callback is not invoked — VRChat auto-assigns directly.
+> **Important**: `OnOwnershipRequest` runs locally on **both the requester and the current owner** (per the official [Network Components page](https://creators.vrchat.com/worlds/udon/networking/network-components/): "This logic runs locally on both the requester and the owner"). The logic must return the same result on both sides to avoid desync. If the current owner has disconnected, the callback is not invoked — VRChat auto-assigns directly.
+>
+> The two parameters are `VRCPlayerApi requestingPlayer` (the player calling `SetOwner`) and `VRCPlayerApi requestedOwner` (the player being assigned ownership — typically the same as `requestingPlayer` for self-promotion, but can differ when one client transfers ownership to another).
 
 ## Synced Variables
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1184,8 +1184,10 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | One-off world init (fires once at world launch) | Acceptable | Preferred |
 | Ongoing game logic (timers, spawning, scoring) | No — fragile | Yes |
 | Responding to player join/leave events | No — may double-fire | Yes |
-| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Yes — runs on current owner |
+| Approving ownership transfers (`OnOwnershipRequest`) | No — wrong API | Neither[^owner-req] |
 | Checking if a specific player is the master | `player.isMaster` on `VRCPlayerApi` | N/A |
+
+[^owner-req]: The callback fires on both the requester and the current owner; logic must agree on both clients to avoid desync. See [Ownership Arbitration with OnOwnershipRequest](#ownership-arbitration-with-onownershiprequest) above.
 
 > **Reference**: VRChat networking documentation — https://creators.vrchat.com/worlds/udon/networking/
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-ui.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-ui.md
@@ -1586,7 +1586,11 @@ public class AppManager : UdonSharpBehaviour
     private bool _isTransitioning = false;
     private int _previousAppIndex = -1;
 
-    // Pending open state (used when ownership transfer is in progress)
+    // Pending open state — carries the requested operation from OpenApp/CloseCurrentApp
+    // into OnOwnershipTransferred so the callback knows which app to open.
+    // Note: Networking.SetOwner is locally immediate (post-2021.2.2), so a request that
+    // already owns the object can execute synchronously; this field exists for the
+    // ownership-transfer code path only.
     // -2 = no pending operation, -1 = pending close, >= 0 = pending open index
     private int _pendingOpenIndex = -2;
 

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -217,9 +217,8 @@ Run through this checklist before publishing any world.
 
 ### Ownership and Sync
 
-- [ ] All `[UdonSynced]` modifications are preceded by `Networking.IsOwner()` checks
+- [ ] All `[UdonSynced]` writes are guarded by `Networking.IsOwner(gameObject)`; if not owner, call `Networking.SetOwner` first (locally immediate), then write and `RequestSerialization()` (Manual sync)
 - [ ] All Manual-sync behaviours call `RequestSerialization()` after modifying synced fields
-- [ ] Ownership transfer (`Networking.SetOwner()`) is confirmed via `OnOwnershipTransferred` before writing synced state
 - [ ] No ownership fights: two scripts do not compete for ownership of the same object
 
 ### Late Joiner Correctness

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -403,41 +403,33 @@ MyProperty = 10;
 **Symptoms:**
 - Unexpected ownership changes
 - State desynchronization
-- "Flickering" between states
+- Loser's local write is overwritten when the concurrent winner's serialization arrives
 
 **Solution:**
+
+`Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` returns `true` synchronously after the call. There is no need to defer the action to `OnOwnershipTransferred`. Concurrent callers each succeed locally; the network resolves the durable owner by arrival order, and the loser's write is overwritten on the next deserialization. Guard writes with `IsOwner` and accept that property of the network.
+
 ```csharp
-// Use ownership request pattern
 public override void Interact()
 {
-    if (Networking.IsOwner(gameObject))
+    if (!Networking.IsOwner(gameObject))
     {
-        // Already owner, proceed
-        DoAction();
-    }
-    else
-    {
-        // Request ownership, wait for transfer
-        _pendingAction = true;
+        // SetOwner is locally immediate; IsOwner is true after this returns.
         Networking.SetOwner(Networking.LocalPlayer, gameObject);
     }
-}
 
-public override void OnOwnershipTransferred(VRCPlayerApi player)
-{
-    if (player.isLocal && _pendingAction)
-    {
-        _pendingAction = false;
-        DoAction();
-    }
+    DoAction();
 }
 
 private void DoAction()
 {
-    // Modify synced variables here
+    // IsOwner is true on this frame after SetOwner; safe to write
+    // synced variables here.
     RequestSerialization();
 }
 ```
+
+> For owner-side protection during critical actions (e.g., reject ownership requests mid-transaction), use `OnOwnershipRequest` — see [networking.md §"Ownership Arbitration with OnOwnershipRequest"](networking.md#ownership-arbitration-with-onownershiprequest).
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.8.1"
+    version: "1.8.2"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.2.1"
+    version: "1.8.1"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 


### PR DESCRIPTION
Merge dev into main for v1.8.2 release.

Includes:
- #172 — Correct ownership transfer model post-2021.2.2 (fixes #171, reporter @Guribo)
- #175 — Align ownership-transfer follow-ups (fixes #173 + #174)
- #177 — Correct Migration Decision Table row for OnOwnershipRequest (fixes #176)
- #178 — chore(version): bump 5 fields to v1.8.2

CodeRabbit review optional per release PR convention.