### PR TITLE
feat(installer): deprecate bin/install.mjs in favor of skills CLI (#180)

### DIFF
--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -14,7 +14,7 @@ Any change to these paths requires a documentation sync check:
 | `skills/*/references/*.md` | README.md Skills section (reference count/list) |
 | `skills/*/assets/templates/*.cs` | README.md Skills section (template count) |
 | `templates/*.md` | README.md Install/Structure section |
-| `bin/install.mjs` | README.md Install section, CLAUDE.md Testing section |
+| `bin/install.mjs` | README.md Install section (Method 3 deprecation callout, all 5 language variants), CLAUDE.md Testing section (banner verification command) |
 
 ## What to Check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,21 +92,16 @@ jobs:
             fi
           done
 
-      - name: Test installer help
-        run: node bin/install.mjs --help
-
-      - name: Test installer version
+      - name: Smoke-test deprecation shim (Issue #180)
         run: |
-          VERSION=$(node bin/install.mjs --version)
+          OUT=$(node bin/install.mjs)
+          echo "$OUT"
+          echo "$OUT" | grep -q 'npx skills add niaka3dayo/agent-skills-vrc-udon' \
+            || { echo "ERROR: deprecation banner missing canonical command"; exit 1; }
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$VERSION" != "$PKG_VERSION" ]; then
-            echo "ERROR: Version mismatch: $VERSION != $PKG_VERSION"
-            exit 1
-          fi
-          echo "OK: Version $VERSION"
-
-      - name: Test installer list
-        run: node bin/install.mjs --list
+          echo "$OUT" | grep -q "v$PKG_VERSION" \
+            || { echo "ERROR: deprecation banner missing version v$PKG_VERSION"; exit 1; }
+          echo "OK: deprecation banner present"
 
   installer-tests:
     name: Installer Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Both `dev` and `main` are protected:
 
 | File | Purpose |
 |------|---------|
-| `bin/install.mjs` | npx installer (copies skills + templates to user project) |
+| `bin/install.mjs` | v1.9.0+ deprecation shim — prints a migration banner and exits 0. Slated for removal in v2.0.0 (#180) |
 | `package.json` | npm metadata, `files` array controls what gets published |
 | `skills/*/SKILL.md` | Skill definitions with YAML frontmatter |
 | `skills/*/rules/*.md` | Constraint rules for AI code generation |
@@ -66,9 +66,8 @@ Both `dev` and `main` are protected:
 # Verify npm pack includes correct files
 npm pack --dry-run
 
-# Test installer
-node bin/install.mjs --list
-node bin/install.mjs --help
+# Smoke-test the deprecation shim (v1.9.0+)
+node bin/install.mjs | grep -q 'npx skills add niaka3dayo/agent-skills-vrc-udon'
 ```
 
 ## CI Checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If the only reason "this is bad" is "the community dislikes it" or "it's ethical
 - **Outdated information**: SDK updates that make existing rules inaccurate
 - **Missing patterns**: Common UdonSharp patterns not covered by the skills
 - **Broken hooks**: Validation hooks that produce false positives/negatives
-- **Installer issues**: Problems with `npx agent-skills-vrc-udon`
+- **Install issues**: Problems with `npx skills add niaka3dayo/agent-skills-vrc-udon` or `claude plugin add niaka3dayo/agent-skills-vrc-udon`. (The legacy `npx agent-skills-vrc-udon` command is a deprecation shim as of v1.9.0; see [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180).)
 
 ## How to Report
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -75,17 +75,9 @@ npx skills add niaka3dayo/agent-skills-vrc-udon
 claude plugin add niaka3dayo/agent-skills-vrc-udon
 ```
 
-### 方法 3: npx 直接インストール
+### 方法 3: npx 直接インストール（v1.9.0 以降は非推奨）
 
-```bash
-npx agent-skills-vrc-udon
-```
-
-オプション:
-```bash
-npx agent-skills-vrc-udon --force    # 既存ファイルを上書き
-npx agent-skills-vrc-udon --list     # インストール対象ファイルをプレビュー（ドライラン）
-```
+> **非推奨です。** `npx agent-skills-vrc-udon` はファイルをコピーしなくなり、移行先を案内するメッセージを表示して終了します。代わりに上記の方法 1（`npx skills add ...`）をご利用ください。v2.0.0 でこのコマンドは完全に削除されます。経緯と移行手順は [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180) をご覧ください。
 
 ### 方法 4: git clone
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -75,18 +75,9 @@ npx skills add niaka3dayo/agent-skills-vrc-udon
 claude plugin add niaka3dayo/agent-skills-vrc-udon
 ```
 
-### 방법 3: npx 직접 설치
+### 방법 3: npx 직접 설치 (v1.9.0부터 사용 중단)
 
-```bash
-npx agent-skills-vrc-udon
-```
-
-옵션:
-
-```bash
-npx agent-skills-vrc-udon --force    # 기존 파일 덮어쓰기
-npx agent-skills-vrc-udon --list     # 설치될 파일 미리보기 (드라이런)
-```
+> **사용 중단되었습니다.** `npx agent-skills-vrc-udon`은 더 이상 파일을 복사하지 않으며, 마이그레이션 안내 메시지를 출력하고 종료합니다. 위의 방법 1(`npx skills add ...`)을 사용해 주세요. v2.0.0에서 이 명령은 완전히 제거될 예정입니다. 배경 및 마이그레이션 안내는 [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180)을 참고하세요.
 
 ### 방법 4: git clone
 

--- a/README.md
+++ b/README.md
@@ -75,17 +75,9 @@ This uses the [skills.sh](https://skills.sh) ecosystem to install skills into yo
 claude plugin add niaka3dayo/agent-skills-vrc-udon
 ```
 
-### Method 3: npx direct install
+### Method 3: npx direct install (deprecated, v1.9.0+)
 
-```bash
-npx agent-skills-vrc-udon
-```
-
-Options:
-```bash
-npx agent-skills-vrc-udon --force    # Overwrite existing files
-npx agent-skills-vrc-udon --list     # Preview files to install (dry run)
-```
+> **Deprecated.** The `npx agent-skills-vrc-udon` command no longer copies files; it prints a banner and exits. Use Method 1 (`npx skills add ...`) above. Full removal is scheduled for v2.0.0. See [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180) for the rationale and migration notes.
 
 ### Method 4: git clone
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,18 +75,9 @@ npx skills add niaka3dayo/agent-skills-vrc-udon
 claude plugin add niaka3dayo/agent-skills-vrc-udon
 ```
 
-### 方式三：npx 直接安装
+### 方式三：npx 直接安装（v1.9.0 起已弃用）
 
-```bash
-npx agent-skills-vrc-udon
-```
-
-选项：
-
-```bash
-npx agent-skills-vrc-udon --force    # 覆盖已有文件
-npx agent-skills-vrc-udon --list     # 预览待安装文件（模拟运行）
-```
+> **已弃用。** `npx agent-skills-vrc-udon` 不再复制任何文件，仅输出迁移提示后退出。请改用上方的方式一（`npx skills add ...`）。完全移除计划在 v2.0.0。背景说明和迁移指引请参见 [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180)。
 
 ### 方式四：git clone
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -75,18 +75,9 @@ npx skills add niaka3dayo/agent-skills-vrc-udon
 claude plugin add niaka3dayo/agent-skills-vrc-udon
 ```
 
-### 方法 3：npx 直接安裝
+### 方法 3：npx 直接安裝（自 v1.9.0 起棄用）
 
-```bash
-npx agent-skills-vrc-udon
-```
-
-選項：
-
-```bash
-npx agent-skills-vrc-udon --force    # 覆寫現有檔案
-npx agent-skills-vrc-udon --list     # 預覽待安裝檔案（模擬執行）
-```
+> **已棄用。** `npx agent-skills-vrc-udon` 不再複製任何檔案，僅輸出遷移提示後結束。請改用上方的方法 1（`npx skills add ...`）。v2.0.0 將完全移除此指令。背景說明與遷移步驟請參閱 [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180)。
 
 ### 方法 4：git clone
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 This repository is a **knowledge base** (Markdown files, C# templates, shell scripts). It does not contain application code that processes user data.
 
-The only executable component is the **NPX installer** (`bin/install.mjs`), which copies files to the user's project directory.
+The only executable component is a small **deprecation shim** (`bin/install.mjs`), which prints a migration banner and exits without writing any files. This shim is scheduled for removal in v2.0.0 (see [Issue #180](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180)).
 
 ## Reporting
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -1,351 +1,50 @@
 #!/usr/bin/env node
 
 /**
- * agent-skills-vrc-udon installer
+ * agent-skills-vrc-udon — deprecation shim (v1.9.0+).
  *
- * Usage:
- *   npx agent-skills-vrc-udon              Install skills to current directory
- *   npx agent-skills-vrc-udon --symlink    Install with symlinks for AI tools
- *   npx agent-skills-vrc-udon --list       List files that will be installed
- *   npx agent-skills-vrc-udon --uninstall  Remove installed files
- *   npx agent-skills-vrc-udon --help       Show help
- *   npx agent-skills-vrc-udon --version    Show version
+ * As of v1.9.0, this entrypoint no longer installs files. It prints a
+ * deprecation banner pointing at the canonical install command and exits 0.
+ * Full removal (along with the package.json `bin` field, the bin/ directory,
+ * and this file) is scheduled for v2.0.0.
+ *
+ * Rationale and migration: https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180
  */
 
-import { existsSync, cpSync, mkdirSync, symlinkSync, readFileSync, writeFileSync, readdirSync, rmSync, statSync } from 'node:fs';
-import { resolve, dirname, join, relative } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PKG_ROOT = resolve(__dirname, '..');
-const TARGET = process.cwd();
-
-const noColor = process.env.NO_COLOR !== undefined;
-const bold = (s) => noColor ? s : `\x1b[1m${s}\x1b[0m`;
-const green = (s) => noColor ? s : `\x1b[32m${s}\x1b[0m`;
-const yellow = (s) => noColor ? s : `\x1b[33m${s}\x1b[0m`;
-const cyan = (s) => noColor ? s : `\x1b[36m${s}\x1b[0m`;
-const dim = (s) => noColor ? s : `\x1b[2m${s}\x1b[0m`;
-const red = (s) => noColor ? s : `\x1b[31m${s}\x1b[0m`;
-
 const pkg = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8'));
 
-const HELP = `
-${bold('agent-skills-vrc-udon')} v${pkg.version}
+const noColor = process.env.NO_COLOR !== undefined;
+const bold = (s) => (noColor ? s : `\x1b[1m${s}\x1b[0m`);
+const yellow = (s) => (noColor ? s : `\x1b[33m${s}\x1b[0m`);
+const cyan = (s) => (noColor ? s : `\x1b[36m${s}\x1b[0m`);
+const dim = (s) => (noColor ? s : `\x1b[2m${s}\x1b[0m`);
 
-  AI Agent Skills for VRChat UdonSharp development.
-  Installs skills, rules, and validation hooks for AI coding agents.
+const CANONICAL = 'npx skills add niaka3dayo/agent-skills-vrc-udon --yes';
+const ISSUE_URL = 'https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180';
 
-${bold('Usage:')}
-  npx agent-skills-vrc-udon [options]
-
-${bold('Options:')}
-  --symlink    Create symlinks for AI tool directories (.claude/, .agents/, etc.)
-  --force      Overwrite existing files
-  --list       List files that will be installed (dry run)
-  --uninstall  Remove all files installed by this package
-  --help       Show this help message
-  --version    Show version
-
-${bold('Examples:')}
-  ${dim('# Install to current project')}
-  npx agent-skills-vrc-udon
-
-  ${dim('# Install with AI tool symlinks')}
-  npx agent-skills-vrc-udon --symlink
-
-  ${dim('# Force overwrite existing files')}
-  npx agent-skills-vrc-udon --force
-
-  ${dim('# Remove installed files')}
-  npx agent-skills-vrc-udon --uninstall
-`;
-
-const args = process.argv.slice(2);
-
-if (args.includes('--help') || args.includes('-h')) {
-  console.log(HELP);
-  process.exit(0);
-}
-
-if (args.includes('--version') || args.includes('-v')) {
-  console.log(pkg.version);
-  process.exit(0);
-}
-
-const useSymlinks = args.includes('--symlink');
-const force = args.includes('--force');
-const listOnly = args.includes('--list');
-const uninstall = args.includes('--uninstall');
-
-const AGENT_DOCS_SRC = join(PKG_ROOT, 'skills');
-const DEST_DIR = join(TARGET, '.agent-skills');
-const AGENT_DOCS_DEST = join(DEST_DIR, 'skills');
-const VERSION_FILE = join(DEST_DIR, '.version');
-
-const TEMPLATES_DIR = join(PKG_ROOT, 'templates');
-const CONFIG_FILES = ['CLAUDE.md', 'AGENTS.md', 'GEMINI.md'];
-const AI_TOOL_DIRS = ['.claude', '.agents', '.codex', '.gemini'];
-
-/** Count files recursively */
-function countFiles(dir) {
-  let count = 0;
-  if (!existsSync(dir)) return count;
-  const entries = readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      count += countFiles(join(dir, entry.name));
-    } else {
-      count++;
-    }
-  }
-  return count;
-}
-
-/** List files recursively */
-function listFiles(dir, base) {
-  const files = [];
-  if (!existsSync(dir)) return files;
-  const entries = readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...listFiles(fullPath, base));
-    } else {
-      files.push(relative(base, fullPath));
-    }
-  }
-  return files;
-}
-
-/** Check if a directory is empty */
-function isDirEmpty(dir) {
-  if (!existsSync(dir)) return true;
-  const entries = readdirSync(dir);
-  return entries.length === 0;
-}
-
-/** Read installed version from .agent-skills/.version, or null if not present */
-function readInstalledVersion() {
-  if (!existsSync(VERSION_FILE)) return null;
-  try {
-    return readFileSync(VERSION_FILE, 'utf8').trim();
-  } catch {
-    return null;
-  }
-}
-
-/** Write current package version to .agent-skills/.version */
-function writeVersionFile() {
-  writeFileSync(VERSION_FILE, pkg.version, 'utf8');
-}
-
-// --uninstall: remove all installed files
-if (uninstall) {
-  console.log('');
-  console.log(bold('agent-skills-vrc-udon') + ` v${pkg.version}`);
-  console.log(dim('Uninstalling VRChat UdonSharp skills...\n'));
-
-  if (!existsSync(DEST_DIR)) {
-    console.log(yellow('  Nothing to uninstall.') + ` ${dim('.agent-skills/ does not exist.')}`);
-    console.log('');
-    process.exit(0);
-  }
-
-  let removed = 0;
-
-  // Remove skills/ subdirectory
-  if (existsSync(AGENT_DOCS_DEST)) {
-    const count = countFiles(AGENT_DOCS_DEST);
-    rmSync(AGENT_DOCS_DEST, { recursive: true, force: true });
-    removed += count;
-    console.log(red('  REMOVE') + ` .agent-skills/skills/ ${dim(`(${count} files)`)}`);
-  }
-
-  // Remove config reference files
-  for (const cf of CONFIG_FILES) {
-    const dest = join(DEST_DIR, cf);
-    if (existsSync(dest)) {
-      rmSync(dest, { force: true });
-      removed++;
-      console.log(red('  REMOVE') + ` .agent-skills/${cf}`);
-    }
-  }
-
-  // Remove version file
-  if (existsSync(VERSION_FILE)) {
-    rmSync(VERSION_FILE, { force: true });
-    console.log(red('  REMOVE') + ` .agent-skills/.version`);
-  }
-
-  // Remove .agent-skills/ itself if now empty
-  if (isDirEmpty(DEST_DIR)) {
-    rmSync(DEST_DIR, { recursive: true, force: true });
-    console.log(red('  REMOVE') + ` .agent-skills/ ${dim('(directory empty, removed)')}`);
-  } else {
-    console.log(yellow('  KEEP') + ` .agent-skills/ ${dim('(directory not empty, keeping)')}`);
-  }
-
-  console.log('');
-  console.log(bold('Done!'));
-  console.log(`  ${red(`${removed} files removed`)}`);
-  console.log('');
-  process.exit(0);
-}
-
-// --list: dry run
-if (listOnly) {
-  console.log(bold('\nFiles to install:\n'));
-
-  const files = listFiles(AGENT_DOCS_SRC, PKG_ROOT);
-  for (const f of files) {
-    console.log(`  ${dim('.agent-skills/')}${f}`);
-  }
-
-  console.log('');
-  for (const cf of CONFIG_FILES) {
-    const src = join(TEMPLATES_DIR, cf);
-    if (!existsSync(src)) continue;
-    console.log(`  ${dim('.agent-skills/')}${cf} ${dim('(reference)')}`);
-  }
-
-  if (useSymlinks) {
-    console.log('');
-    for (const dir of AI_TOOL_DIRS) {
-      console.log(`  ${dir}/skills/ ${dim('-> .agent-skills/skills/')}`);
-      console.log(`  ${dir}/rules/  ${dim('-> .agent-skills/skills/unity-vrc-udon-sharp/rules/')}`);
-    }
-  }
-
-  const totalFiles = files.length + CONFIG_FILES.length;
-  console.log(`\n  ${bold(`${totalFiles} files`)} will be installed.\n`);
-  process.exit(0);
-}
-
-// Main install
 console.log('');
 console.log(bold('agent-skills-vrc-udon') + ` v${pkg.version}`);
-
-// Version detection: show upgrade/already-up-to-date message
-const installedVersion = readInstalledVersion();
-// Treat any version mismatch (upgrade or downgrade) as a request to refresh
-// installed content, so .version never drifts ahead of the actual files.
-// Without this, an upgrade re-run without --force would print
-// "Upgrading from..." but keep the old skills/ on disk while bumping .version,
-// permanently masking new rules from existing users (Issue #164).
-const isUpgrade = installedVersion !== null && installedVersion !== pkg.version;
-const shouldOverwrite = force || isUpgrade;
-if (installedVersion !== null) {
-  if (installedVersion === pkg.version) {
-    console.log(dim(`Already up to date (v${pkg.version}).`));
-  } else {
-    console.log(cyan(`Upgrading from v${installedVersion} to v${pkg.version}...`));
-  }
-} else {
-  console.log(dim('Installing VRChat UdonSharp skills for AI agents...'));
-}
+console.log('');
+console.log(yellow('  DEPRECATED') + dim(': the npx installer no longer copies files.'));
+console.log('');
+console.log('  Starting with v1.9.0 this command is a no-op shim. It will be');
+console.log('  removed entirely in v2.0.0. Please switch to the canonical');
+console.log('  install path:');
+console.log('');
+console.log('    ' + cyan(CANONICAL));
+console.log('');
+console.log('  Alternative (Claude Code users):');
+console.log('');
+console.log('    ' + cyan('claude plugin add niaka3dayo/agent-skills-vrc-udon'));
+console.log('');
+console.log(dim(`  Background and migration notes: ${ISSUE_URL}`));
 console.log('');
 
-let copied = 0;
-let skipped = 0;
-
-// 1. Copy skills/
-if (existsSync(AGENT_DOCS_DEST) && !shouldOverwrite) {
-  console.log(yellow('  SKIP') + ` .agent-skills/skills/ ${dim('(already exists, use --force to overwrite)')}`);
-  skipped += countFiles(AGENT_DOCS_SRC);
-} else {
-  mkdirSync(AGENT_DOCS_DEST, { recursive: true });
-  cpSync(AGENT_DOCS_SRC, AGENT_DOCS_DEST, { recursive: true, force: true });
-  const count = countFiles(AGENT_DOCS_SRC);
-  copied += count;
-  console.log(green('  COPY') + ` skills/ -> .agent-skills/skills/ ${dim(`(${count} files)`)}`);
-}
-
-// 2. Copy config reference files
-for (const cf of CONFIG_FILES) {
-  const src = join(TEMPLATES_DIR, cf);
-  const dest = join(DEST_DIR, cf);
-
-  if (!existsSync(src)) continue;
-
-  if (existsSync(dest) && !shouldOverwrite) {
-    console.log(yellow('  SKIP') + ` .agent-skills/${cf} ${dim('(already exists)')}`);
-    skipped++;
-  } else {
-    mkdirSync(dirname(dest), { recursive: true });
-    cpSync(src, dest);
-    copied++;
-    console.log(green('  COPY') + ` ${cf} -> .agent-skills/${cf} ${dim('(reference)')}`);
-  }
-}
-
-// 3. Write version file
-writeVersionFile();
-
-// 4. Create symlinks if requested
-if (useSymlinks) {
-  console.log('');
-
-  const skillsTarget = join(DEST_DIR, 'skills');
-  const rulesTarget = join(DEST_DIR, 'skills', 'unity-vrc-udon-sharp', 'rules');
-
-  for (const dir of AI_TOOL_DIRS) {
-    const toolDir = join(TARGET, dir);
-    const skillsLink = join(toolDir, 'skills');
-    const rulesLink = join(toolDir, 'rules');
-
-    mkdirSync(toolDir, { recursive: true });
-
-    // skills symlink
-    if (existsSync(skillsLink) && !force) {
-      console.log(yellow('  SKIP') + ` ${dir}/skills/ ${dim('(already exists)')}`);
-    } else {
-      const relTarget = relative(toolDir, skillsTarget);
-      try {
-        symlinkSync(relTarget, skillsLink);
-        console.log(green('  LINK') + ` ${dir}/skills/ -> ${dim(relTarget)}`);
-      } catch {
-        console.log(yellow('  SKIP') + ` ${dir}/skills/ ${dim('(symlink creation failed)')}`);
-      }
-    }
-
-    // rules symlink
-    if (existsSync(rulesLink) && !force) {
-      console.log(yellow('  SKIP') + ` ${dir}/rules/ ${dim('(already exists)')}`);
-    } else {
-      const relTarget = relative(toolDir, rulesTarget);
-      try {
-        symlinkSync(relTarget, rulesLink);
-        console.log(green('  LINK') + ` ${dir}/rules/ -> ${dim(relTarget)}`);
-      } catch {
-        console.log(yellow('  SKIP') + ` ${dir}/rules/ ${dim('(symlink creation failed)')}`);
-      }
-    }
-  }
-}
-
-// Summary
-console.log('');
-console.log(bold('Done!'));
-console.log(`  ${green(`${copied} copied`)}, ${skipped > 0 ? yellow(`${skipped} skipped`) : `${skipped} skipped`}`);
-console.log('');
-
-// Next steps
-console.log(bold('Next steps:'));
-console.log('');
-console.log(`  ${cyan('1.')} AI tool config files are in ${bold('.agent-skills/')} as reference.`);
-console.log(`     Copy relevant sections to your project's CLAUDE.md / AGENTS.md / GEMINI.md.`);
-console.log('');
-
-if (!useSymlinks) {
-  console.log(`  ${cyan('2.')} To auto-link skills to AI tool directories, run:`);
-  console.log(`     ${dim('npx agent-skills-vrc-udon --symlink')}`);
-  console.log('');
-}
-
-console.log(`  ${cyan(useSymlinks ? '2.' : '3.')} For validation hooks, add to your AI tool settings:`);
-console.log(`     ${dim('PostToolUse: .agent-skills/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh')}`);
-console.log('');
-console.log(`  ${dim('Documentation: https://github.com/niaka3dayo/agent-skills-vrc-udon')}`);
-console.log('');
+process.exit(0);

--- a/tests/install.test.mjs
+++ b/tests/install.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,9 +12,8 @@ const REPO_ROOT = resolve(__dirname, '..');
 const INSTALLER = join(REPO_ROOT, 'bin/install.mjs');
 const PKG_VERSION = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version;
 
-/** A file that exists in the source skills/ tree; used as a sentinel to detect overwrite. */
-const SENTINEL_PATH = join('skills', 'unity-vrc-udon-sharp', 'SKILL.md');
-const STALE_MARKER = '__INSTALLER_TEST_STALE__\n';
+const CANONICAL_CMD = 'npx skills add niaka3dayo/agent-skills-vrc-udon';
+const ISSUE_URL = 'https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/180';
 
 function setupTempProject(t) {
   const dir = mkdtempSync(join(tmpdir(), 'agent-skills-test-'));
@@ -22,7 +21,7 @@ function setupTempProject(t) {
   return dir;
 }
 
-function runInstaller(cwd, args = []) {
+function runShim(cwd, args = []) {
   return execFileSync('node', [INSTALLER, ...args], {
     cwd,
     env: { ...process.env, NO_COLOR: '1' },
@@ -30,95 +29,49 @@ function runInstaller(cwd, args = []) {
   });
 }
 
-test('fresh install: copies skills and writes current package version', (t) => {
+test('no-args: prints deprecation banner, exits 0, writes nothing', (t) => {
   const dir = setupTempProject(t);
 
-  runInstaller(dir);
+  const out = runShim(dir);
 
-  assert.ok(
-    existsSync(join(dir, '.agent-skills', 'skills', 'unity-vrc-udon-sharp')),
-    'skills/ should be copied on fresh install',
-  );
-  assert.equal(
-    readFileSync(join(dir, '.agent-skills', '.version'), 'utf8').trim(),
-    PKG_VERSION,
-    '.version should match current package version',
-  );
+  assert.ok(out.includes(CANONICAL_CMD),
+    'banner must include the canonical skills CLI command');
+  assert.ok(out.includes(ISSUE_URL),
+    'banner must include the link to Issue #180');
+  assert.ok(out.includes(PKG_VERSION),
+    `banner must include the current package version (${PKG_VERSION})`);
+  assert.equal(existsSync(join(dir, '.agent-skills')), false,
+    'shim must NOT create .agent-skills/ on the user filesystem');
 });
 
-test('same-version re-run without --force: preserves existing files (current SKIP behavior)', (t) => {
+test('legacy flags are no-ops: each prints the same banner and exits 0', (t) => {
   const dir = setupTempProject(t);
 
-  runInstaller(dir);
-  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
-  writeFileSync(sentinel, STALE_MARKER, 'utf8');
+  const flags = [
+    ['--help'], ['-h'],
+    ['--version'], ['-v'],
+    ['--list'],
+    ['--symlink'],
+    ['--force'],
+    ['--uninstall'],
+    ['--unknown-flag'],
+    ['--symlink', '--force'],
+  ];
 
-  // .version already equals PKG_VERSION → not an upgrade → SKIP path is correct here
-  runInstaller(dir);
-
-  assert.equal(
-    readFileSync(sentinel, 'utf8'),
-    STALE_MARKER,
-    'same-version re-run should not overwrite (use --force for that)',
-  );
+  for (const argv of flags) {
+    const out = runShim(dir, argv);
+    assert.ok(out.includes(CANONICAL_CMD),
+      `flag ${JSON.stringify(argv)} should still print the canonical command`);
+    assert.equal(existsSync(join(dir, '.agent-skills')), false,
+      `flag ${JSON.stringify(argv)} must not create .agent-skills/`);
+  }
 });
 
-test('upgrade re-run without --force: overwrites stale skills (Issue #164)', (t) => {
+test('non-zero exit is never used (every invocation returns 0)', (t) => {
   const dir = setupTempProject(t);
 
-  runInstaller(dir);
-  // Simulate "user installed an older version" by downgrading .version
-  // and corrupting a sentinel file as if it were stale content.
-  writeFileSync(join(dir, '.agent-skills', '.version'), '0.0.0', 'utf8');
-  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
-  writeFileSync(sentinel, STALE_MARKER, 'utf8');
-
-  // Re-run without --force; installer should detect the version mismatch
-  // and overwrite stale skills/ content.
-  runInstaller(dir);
-
-  assert.notEqual(
-    readFileSync(sentinel, 'utf8'),
-    STALE_MARKER,
-    'Issue #164: skills/ was SKIPped during upgrade; content stayed stale',
-  );
-  assert.equal(
-    readFileSync(join(dir, '.agent-skills', '.version'), 'utf8').trim(),
-    PKG_VERSION,
-    '.version should be updated to current package version after upgrade',
-  );
-});
-
-test('upgrade re-run without --force: overwrites stale config reference files (Issue #164)', (t) => {
-  const dir = setupTempProject(t);
-
-  runInstaller(dir);
-  const claudeMd = join(dir, '.agent-skills', 'CLAUDE.md');
-  writeFileSync(claudeMd, STALE_MARKER, 'utf8');
-  writeFileSync(join(dir, '.agent-skills', '.version'), '0.0.0', 'utf8');
-
-  runInstaller(dir);
-
-  assert.notEqual(
-    readFileSync(claudeMd, 'utf8'),
-    STALE_MARKER,
-    'Issue #164: config files were SKIPped during upgrade; content stayed stale',
-  );
-});
-
-test('--force overwrites regardless of version state', (t) => {
-  const dir = setupTempProject(t);
-
-  runInstaller(dir);
-  const sentinel = join(dir, '.agent-skills', SENTINEL_PATH);
-  writeFileSync(sentinel, STALE_MARKER, 'utf8');
-
-  // .version still equals PKG_VERSION (no upgrade), but --force overrides
-  runInstaller(dir, ['--force']);
-
-  assert.notEqual(
-    readFileSync(sentinel, 'utf8'),
-    STALE_MARKER,
-    '--force must always overwrite, even on same-version re-run',
-  );
+  // execFileSync throws if exit code != 0; the absence of a throw is the assertion.
+  runShim(dir);
+  runShim(dir, ['--uninstall']);
+  runShim(dir, ['--definitely-not-a-flag']);
 });


### PR DESCRIPTION
Closes #180.

## Summary

- Replace `bin/install.mjs` with a ~50-line deprecation shim that prints a migration banner and exits 0. No files are copied to the user's project anymore.
- Banner points users at the canonical install command (`npx skills add niaka3dayo/agent-skills-vrc-udon --yes`) and the Claude Code plugin (`claude plugin add ...`), and links to #180 for context.
- All legacy flags (`--help`, `--version`, `--list`, `--symlink`, `--force`, `--uninstall`, plus unknown flags) are now no-ops that print the same banner. Existing CI scripts and shell pipelines that invoked the installer continue to exit 0.
- README × 5 (en, ja, zh-CN, zh-TW, ko) "Method 3" sections are demoted to a "Deprecated" callout that still documents the migration path; Methods 1, 2, and 4 are unchanged.
- Tests, CI npm-pack job, SECURITY.md, CONTRIBUTING.md, CLAUDE.md, and `.claude/rules/doc-sync.md` are updated to match.

## What ships in v1.9.0 (this PR) vs deferred to v2.0.0

| Change | v1.9.0 (this PR) | v2.0.0 (future PR) |
|---|---|---|
| `bin/install.mjs` body | replaced with shim | file deleted |
| `bin/` directory | kept | removed |
| `package.json` `"bin"` field | kept | removed |
| `package.json` `"files": ["bin/"]` | kept | removed |
| README Method 3 callout | "Deprecated" callout retained | section removed entirely |
| `tests/install.test.mjs` | rewritten for shim | file deleted |
| CI `installer-tests` job | kept | removed |
| SemVer bump | minor (1.8.2 → 1.9.0) | major (1.9.x → 2.0.0) |
| Required label | `release: feature` | `release: breaking` |

## Test plan

- [x] `npm test` passes locally (3 new tests covering banner, flag no-op, exit code).
- [x] `npm pack --dry-run` still lists `bin/install.mjs`, `skills/`, `templates/`, `LICENSE`, `README.md`.
- [x] `node bin/install.mjs` in a tmp dir prints the banner, exits 0, leaves no `.agent-skills/` behind.
- [x] `node bin/install.mjs --force --symlink --uninstall --version` (every legacy flag in one call) still exits 0 and prints the banner.
- [ ] CI green: Symlink Integrity, Hook Scripts, Markdown Links, npm Pack Test (with new banner-grep step), Installer Tests, EditorConfig, Version Sync.
- [ ] `/skill-judge` against `unity-vrc-udon-sharp` and `unity-vrc-world-sdk-3` shows no score regression.
- [ ] CodeRabbit review approved.

## Out of scope

Full removal of `bin/install.mjs`, the `bin/` directory, the `package.json` `bin` field, the `installer-tests` CI job, and the README "Deprecated" callouts is reserved for the v2.0.0 PR (a separate Issue should track that). Bundling removal here would cut the deprecation window to zero and convert this minor bump into a breaking one.