### PR TITLE
chore(version): bump to v1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "1.8.2"
+    "version": "1.9.0"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.8.2"
+    version: "1.9.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.8.2"
+    version: "1.9.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.8.2"
+    version: "1.9.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 


### PR DESCRIPTION
Pre-release version bump per [CLAUDE.md "Release Guide" Step 1](https://github.com/niaka3dayo/agent-skills-vrc-udon/blob/dev/CLAUDE.md). 5 fields move together; Version Sync CI verifies parity.

## Bundled changes for v1.9.0

This release bundles the deprecation of \`bin/install.mjs\` per #180 (PR #184, merged in \`d96314b\`).

- All install instructions point to the canonical \`npx skills add niaka3dayo/agent-skills-vrc-udon --yes\` command.
- The legacy \`npx agent-skills-vrc-udon\` entrypoint is now a deprecation shim (banner + exit 0); existing CI scripts continue to work.
- Full removal is reserved for v2.0.0 (tracked in #185).

## Fields bumped

- \`package.json#version\`: 1.8.2 → 1.9.0
- \`.claude-plugin/marketplace.json#metadata.version\`: 1.8.2 → 1.9.0
- \`skills/unity-vrc-udon-sharp/SKILL.md\` frontmatter \`version\`: 1.8.2 → 1.9.0
- \`skills/unity-vrc-world-sdk-3/SKILL.md\` frontmatter \`version\`: 1.8.2 → 1.9.0
- \`.claude/skills/unity-vrc-skills-renovator/SKILL.md\` frontmatter \`version\`: 1.8.2 → 1.9.0

## Test plan

- [ ] \`Version Sync\` CI green (the substantive check on this PR).
- [ ] \`Symlink Integrity\`, \`Hook Scripts\`, \`Markdown Links\`, \`npm Pack Test\` (with the new banner-grep step from #184), \`Installer Tests\`, \`EditorConfig\` all green.

CodeRabbit review optional on version-bump PRs (mechanical 5-line change).