### PR TITLE
chore(repo): add unity-project-for-sdk-search convention for local SDK API verification (Refs #192)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ node_modules/
 *.tgz
 .npm/
 plans/
+
+# Local Unity project for SDK API verification (see unity-project-for-sdk-search/README.md).
+# The directory itself is gitignored so the SDK never gets bundled into the npm tarball;
+# only its README.md is tracked so the convention is discoverable on clone.
+unity-project-for-sdk-search/*
+!unity-project-for-sdk-search/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,14 @@ The highest bump wins. If no label matches, default to **patch**. Release Drafte
 - Do NOT push directly to `main` (branch protection blocks it; use the release PR flow).
 - Do NOT merge feature branches directly to `main` (always go through `dev`).
 
+## SDK Verification
+
+Public VRChat creator docs and the `vrchat-community/UdonSharp` API page sometimes lag behind the actual SDK binary. When triaging a knowledge-request Issue that hinges on whether a specific API exists, the authoritative source is the SDK DLL itself.
+
+This repo uses a gitignored local workspace pattern at `unity-project-for-sdk-search/` for that verification. The directory is intentionally not packed into the npm tarball — only its `README.md` is tracked so the convention is discoverable on clone. See [`unity-project-for-sdk-search/README.md`](unity-project-for-sdk-search/README.md) for one-time setup steps, the canonical `strings | grep` command, and the Udon wrapper symbol legend.
+
+Use this verification path before documenting any API that you cannot confirm against the official public docs.
+
 ## Editing Skills
 
 When modifying skill content in `skills/`:

--- a/unity-project-for-sdk-search/README.md
+++ b/unity-project-for-sdk-search/README.md
@@ -1,0 +1,93 @@
+# SDK Verification Workspace
+
+This directory is a **gitignored** workspace for verifying VRChat SDK APIs against the actual shipped SDK binary. Drop a Unity project with the VRChat World SDK installed here, then `grep` the SDK DLLs to confirm whether a specific API exists.
+
+Only this `README.md` is tracked. Anything else placed under `unity-project-for-sdk-search/` is gitignored — see the repo root `.gitignore` for the rule.
+
+## Why this exists
+
+Public VRChat documentation lags behind the shipped SDK. While triaging knowledge-request Issues we have repeatedly hit cases where:
+
+- `creators.vrchat.com/worlds/udon/networking/network-components/` omits a method that exists in the SDK,
+- `vrchat-community/UdonSharp` API page (the canonical `udonsharp.docs.vrchat.com/vrchat-api/`) does not yet list newly added methods,
+- third-party tutorials echo the stale public docs.
+
+The authoritative source is the SDK DLL itself. This directory makes that source one `grep` away.
+
+**Reference precedent**: Issue #190 (VRCObjectPool ownership patterns) — the maintainer reported a `Shuffle()` method that every public source omitted; verification required SDK DLL inspection, which confirmed the method exists.
+
+## Setup
+
+1. Open Unity Hub. Create a new Unity project here, for example:
+
+   ```
+   unity-project-for-sdk-search/sdk-search-project/
+   ```
+
+2. Install the VRChat World SDK via VPM (VRChat Creator Companion).
+
+3. The SDK lands at:
+
+   ```
+   unity-project-for-sdk-search/sdk-search-project/Packages/com.vrchat.worlds/
+   ```
+
+4. Optional: install UdonSharp via VPM (already a dependency of Worlds SDK).
+
+## Verification commands
+
+The two most useful DLLs are under `Packages/com.vrchat.worlds/Runtime/`. The Udon wrapper DLL is the highest-signal source because it lists every API that Udon (and therefore UdonSharp) can call.
+
+```bash
+# Set this once per shell session — adjust the project subdirectory name if you used a different one.
+SDK="unity-project-for-sdk-search/sdk-search-project/Packages/com.vrchat.worlds"
+
+# 1. Does method `X` exist on `VRCSomeComponent`? Inspect the Udon wrapper symbols.
+strings -a "$SDK/Runtime/Udon/External/VRC.Udon.VRCWrapperModules.dll" \
+  | grep -E "VRCSomeComponent|__X__"
+
+# 2. Or scan the main SDK assembly for the raw method name.
+strings -a "$SDK/Runtime/VRCSDK/Plugins/VRCSDK3.dll" | grep X
+
+# 3. Open SDK source files where present (some integrations ship as .cs).
+grep -rn "VRCSomeComponent" "$SDK/" --include="*.cs"
+```
+
+## Udon wrapper symbol legend
+
+Symbols inside `VRC.Udon.VRCWrapperModules.dll` follow this format:
+
+```
+# Method with no arguments
+__<MethodName>__<ReturnType>
+
+# Method with arguments — ArgTypes come BEFORE ReturnType
+__<MethodName>__<ArgType1>[_<ArgType2>...]__<ReturnType>
+```
+
+The ordering matters: **arg types precede the return type**, separated by `__`. Multiple arg types within the args segment are joined by a single `_`.
+
+> This format is **observed empirically** in SDK 3.10.3's `VRC.Udon.VRCWrapperModules.dll`. It is not a documented public contract — VRChat could change Udon's symbol naming in a future SDK release. If a grep against a newer SDK starts returning surprising results, re-derive the format from a known method (e.g. `__TryToSpawn__UnityEngineGameObject` for `GameObject TryToSpawn()`) and update this legend.
+
+Examples (taken from `ExternVRCSDK3ComponentsVRCObjectPool` block, SDK 3.10.3):
+
+| Symbol | Decoded signature |
+|---|---|
+| `__TryToSpawn__UnityEngineGameObject` | `GameObject TryToSpawn()` — no args, return = GameObject |
+| `__Shuffle__SystemVoid` | `void Shuffle()` — no args, return = void |
+| `__Return__UnityEngineGameObject__SystemVoid` | `void Return(GameObject)` — one arg = GameObject, return = void |
+
+Hypothetical multi-arg form: `__Foo__SystemInt32_UnityEngineTransform__SystemVoid` would decode to `void Foo(int, Transform)`.
+
+Note that other shorter tokens (e.g. a plain `Return` string with no `__` framing) sometimes also appear in the DLL — those are unrelated symbols (property names, enum values, etc.) and are not the method wrapper. The `__<Method>__...` form is the only authoritative signal that Udon can dispatch to that method.
+
+## What NOT to do
+
+- Do not commit the SDK or any Unity-generated files. The `.gitignore` rule blocks them automatically; do not bypass with `git add -f`.
+- Do not redistribute the SDK contents. VRChat's SDK license is non-redistribution.
+- Do not symlink this directory into another location that gets packed into npm. The `npm Pack Test` CI catches this, but avoid the round-trip.
+- Do not assume "Shuffle exists in the wrapper DLL" means the method is publicly supported. It only means Udon can call it. Confirm runtime behavior (owner-only? network-synced?) by additional means (Unity Editor IntelliSense, SDK release notes, hands-on test) before documenting it in the skill.
+
+## Updating SDK versions
+
+When VRChat ships a new SDK release, update the local project via VPM (Creator Companion → "Update" on the World SDK package). No repo change is required — re-run the same `grep` commands against the new DLL.


### PR DESCRIPTION
## Summary

Adds a gitignored local workspace pattern at `unity-project-for-sdk-search/` for verifying VRChat SDK APIs against the shipped SDK binary. Only the directory's `README.md` is tracked (single re-include exception); everything else is gitignored.

Closes #192.

## Why this exists

Public VRChat docs lag behind the shipped SDK. While triaging Issue #190 (VRCObjectPool ownership patterns), the maintainer reported a method that every public source omitted but the SDK 3.10.3 DLL contains. Verifying it required downloading the VPM tarball each time. This convention makes the SDK binary one `grep` away for every future knowledge-request Issue.

## What changed (3 files, +107/-0)

| File | Change | Lines |
|---|---|---|
| `.gitignore` | New rule: `unity-project-for-sdk-search/*` + `!unity-project-for-sdk-search/README.md` exception | +6 |
| `unity-project-for-sdk-search/README.md` | NEW. Setup procedure (Unity Hub + VPM), verification commands, Udon wrapper symbol legend with empirically-derived format, license non-redistribution warning | +93 |
| `CLAUDE.md` | NEW `## SDK Verification` section between Release Guide and Editing Skills, pointing at the README | +8 |

## Verification

### gitignore rule (gate)

```bash
# Should be ignored (any path under workspace)
git check-ignore -v unity-project-for-sdk-search/sdk-search-project/Packages/com.vrchat.worlds/Runtime/VRCSDK3.dll
# → .gitignore:13:unity-project-for-sdk-search/*  (PASS)

# Should NOT be ignored (re-include exception)
git check-ignore -v unity-project-for-sdk-search/README.md
# → .gitignore:14:!unity-project-for-sdk-search/README.md  (PASS — exception rule fires)
```

### npm pack isolation (gate)

```bash
npm pack --dry-run | grep -i "unity-project"
# → empty (PASS — dir excluded from tarball)
```

Total tarball: 285.6 kB / 1.0 MB unpacked / 69 files (unchanged from pre-PR baseline + 0 new entries).

### Empirical SDK DLL verification (the use case this enables)

Demonstrated against SDK 3.10.3 via VPM tarball:

```text
$ strings -a com.vrchat.worlds/Runtime/Udon/External/VRC.Udon.VRCWrapperModules.dll \
    | grep -E "^__(TryToSpawn|Shuffle|Return)__"
__TryToSpawn__UnityEngineGameObject
__Shuffle__SystemVoid
__Return__UnityEngineGameObject__SystemVoid
```

The README documents this empirical format with three concrete examples and notes it is observed-not-contracted (could change in future SDK releases).

## Review priorities for CodeRabbit / reviewer

1. **gitignore rule shape** — does `unity-project-for-sdk-search/*` + `!README.md` correctly survive `git add -A`?
2. **License warning** — README "What NOT to do" block names `git add -f` by name as a forbidden bypass; assess if wording is strong enough.
3. **CLAUDE.md placement** — between Release Guide and Editing Skills, reasonable?
4. **Udon wrapper format claim** — empirical caveat included, but symbol legend itself is asserted as fact. Acceptable for a contributor-internal doc?

## Out of scope

- Shipping a Unity project (per-contributor concern).
- Automating SDK version selection (manual via VPM).
- Documenting non-Worlds SDK paths (Avatars / Base SDK have different DLL locations).

## Follow-up

Issue #190 implementation will use this workspace for live verification of the VRCObjectPool method surface and any future skill-API changes that depend on SDK truth.