### PR TITLE
feat(skills/udon-sharp): VRCObjectPool Shuffle() + Interact-driven Cost Tier patterns (Refs #190)

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -230,7 +230,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | `web-loading.md` | String/Image downloading, VRCJson, Trusted URLs | VRCStringDownloader, VRCImageDownloader, VRCJson, DataDictionary, VRCUrl |
 | `image-loading-vram.md` | Advanced VRAM management for image loading: Destroy vs Dispose, double-buffer fade, stock mode, mipmap bias | VRAM, texture memory, memory leak, Destroy, Dispose, double buffer, fade, mipmap, TextureInfo |
 | `web-loading-advanced.md` | Advanced data loading: Base64 texture embedding via StringDownloader, cross-platform compression, URL double-key indexing, LRU decode cache | Base64, LoadRawTextureData, StringDownloader texture, DXT1, ETC_RGB4, UNITY_ANDROID, LRU cache, packed resources, binary format |
-| `api.md` | VRCPlayerApi, Networking, enums reference | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity, Drone, VRCDroneApi |
+| `api.md` | VRCPlayerApi, Networking, enums reference, VRCObjectPool methods + Interact-driven ownership patterns | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity, Drone, VRCDroneApi, VRCObjectPool, TryToSpawn, Return, Shuffle, pool owner, Interact pool, pool forwarded spawn, pool ownership transfer |
 | `events.md` | All Udon events (including OnPlayerRestored, OnContactEnter) | OnPlayerJoined, OnPlayerLeft, OnPlayerTriggerEnter, OnOwnershipTransferred |
 | `editor-scripting.md` | Editor scripting, proxy system, and UdonSharpProgramAsset auto-generation | UdonSharpEditor, UdonSharpBehaviourProxy, SerializedObject, UdonSharpProgramAsset, auto-generate, AssetPostprocessor, .asset missing |
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -468,7 +468,7 @@ public class PoolManager : UdonSharpBehaviour
 
 ### Usage Pattern: Interact-Driven (User-Triggered)
 
-The Master-Managed pattern above is owner-driven: spawning happens inside `OnPlayerJoined`, which is only called on the pool owner's client. When the trigger is `Interact()`, any client fires the event regardless of pool ownership. Writing `pool.TryToSpawn()` directly inside `Interact()` works on the pool owner's client but silently no-ops for everyone else. There are two correct resolutions, presented as a cost tier below.
+The Master-Managed pattern above protects its pool calls with an `IsOwner` guard inside `OnPlayerJoined`. `OnPlayerJoined` runs on every client when a new player joins; the guard ensures only the pool owner's client actually executes `TryToSpawn()` / `Return()` — non-owner clients early-return safely without hitting a silent no-op at the pool method itself. When the trigger is `Interact()`, the handler body runs only on the interacting player's local client. Writing `pool.TryToSpawn()` directly there works only when the interacting player happens to own the pool — for everyone else the call reaches the pool method and silently no-ops with no exception. There are two correct resolutions, presented as a cost tier below.
 
 | Tier | Approach | Cost | When |
 |---|---|---|---|
@@ -477,6 +477,8 @@ The Master-Managed pattern above is owner-driven: spawning happens inside `OnPla
 
 #### Tier 1 — Forward to owner (recommended)
 
+> **Setup precondition**: Attach `PoolInteractForwarded` to the **same GameObject as the `VRCObjectPool`** it references. `NetworkEventTarget.Owner` resolves to the owner of the *sending UdonBehaviour's* GameObject (per [creators.vrchat.com networking events](https://creators.vrchat.com/worlds/udon/networking/events/)), not to `objectPool.gameObject`. Co-location ensures the event is delivered to the pool owner. If you need the interactor and the pool on separate GameObjects, see Tier 2 instead.
+
 ```csharp
 using UdonSharp;
 using UnityEngine;
@@ -484,18 +486,25 @@ using VRC.SDK3.Components;
 using VRC.SDKBase;
 using VRC.Udon.Common.Interfaces;
 
+// Attach this script to the SAME GameObject as the VRCObjectPool it references.
 public class PoolInteractForwarded : UdonSharpBehaviour
 {
     public VRCObjectPool objectPool;
 
     public override void Interact()
     {
-        // Ask the current pool owner to do the work; no ownership change.
+        // NetworkEventTarget.Owner targets the owner of THIS UdonBehaviour's
+        // GameObject. Since this script is co-located with objectPool, the
+        // event is delivered to the pool owner — no ownership change needed.
         SendCustomNetworkEvent(NetworkEventTarget.Owner, nameof(OwnerSpawn));
     }
 
     public void OwnerSpawn()
     {
+        // Defensive: if ownership transferred between the event send and arrival,
+        // the new owner will still see this fire on the old owner's client; the
+        // guard makes the call a safe no-op rather than silently spawning on
+        // a stale owner.
         if (!Networking.IsOwner(objectPool.gameObject)) return;
         objectPool.Shuffle();
         GameObject spawned = objectPool.TryToSpawn();
@@ -504,7 +513,7 @@ public class PoolInteractForwarded : UdonSharpBehaviour
 }
 ```
 
-`OwnerSpawn` runs only on the player that currently owns `objectPool.gameObject`. The `IsOwner` guard is defensive against a race where ownership transfers between the `SendCustomNetworkEvent` call and the handler arriving on the previous owner's client.
+`OwnerSpawn` runs on the client that owns this script's GameObject (which, per the co-location precondition above, is the pool owner). The `IsOwner` guard is defensive against a race where ownership transfers between the `SendCustomNetworkEvent` call and the handler arriving on the previous owner's client.
 
 #### Tier 2 — Take ownership first (acceptable)
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -337,22 +337,34 @@ Object pooling for network-aware objects. The pool manages and synchronizes the 
 
 ### Methods
 
+| Method | Signature | Owner-only | Network-synchronized |
+|---|---|---|---|
+| `TryToSpawn()` | `GameObject TryToSpawn()` | Yes | Yes |
+| `Return(obj)` | `void Return(GameObject obj)` | Yes | Yes |
+| `Shuffle()` | `void Shuffle()` | Yes | Yes |
+
+`TryToSpawn()` and `Return()` are publicly documented on creators.vrchat.com; `Shuffle()` is observed in the SDK 3.10.3 Udon wrapper symbols (`__Shuffle__SystemVoid` in `VRC.Udon.VRCWrapperModules.dll`) but absent from public API docs at the time of writing — its owner-only / synced behavior follows the same runtime contract as the other two methods. All three methods silently no-op when called by a non-owner at runtime; for patterns that require any client to trigger pool operations, see [Usage Pattern: Interact-Driven (User-Triggered)](#usage-pattern-interact-driven-user-triggered).
+
 ```csharp
 public VRCObjectPool pool;
 
-// Activate an unused object (pool owner only). Returns null if all objects are in use.
+// Activate an unused object; returns null if all objects are in use.
 GameObject spawned = pool.TryToSpawn();
 
-// Return an object to the pool (pool owner only). Deactivates the object.
-pool.Return(GameObject obj);
+// Return an object to the pool (deactivates it).
+pool.Return(spawned);
+
+// Shuffle the internal order of available objects.
+pool.Shuffle();
 ```
 
 ### Ownership Behavior
 
-The VRCObjectPool itself is a networked object; only its **owner** can call `TryToSpawn()` and `Return()`.
+The VRCObjectPool itself is a networked object; only its **owner** can call `TryToSpawn()`, `Return()`, or `Shuffle()`. Non-owner calls silently no-op at runtime (see Methods table above). To support callers from any client (e.g. `Interact()` handlers), see [Usage Pattern: Interact-Driven (User-Triggered)](#usage-pattern-interact-driven-user-triggered).
 
 - **`TryToSpawn()`** activates an available pooled object and returns it. The ownership of the activated object is **not** automatically transferred to any specific player — call `Networking.SetOwner()` explicitly after spawning if you need the spawned object to be owned by a particular player.
 - **`Return()`** deactivates the object and returns it to the pool. Only the pool owner can call this method.
+- **`Shuffle()`** randomizes the internal order of available pooled objects, synchronized across all clients. Only the pool owner can call this method.
 
 ### Network Synchronization
 
@@ -453,6 +465,74 @@ public class PoolManager : UdonSharpBehaviour
     }
 }
 ```
+
+### Usage Pattern: Interact-Driven (User-Triggered)
+
+The Master-Managed pattern above is owner-driven: spawning happens inside `OnPlayerJoined`, which is only called on the pool owner's client. When the trigger is `Interact()`, any client fires the event regardless of pool ownership. Writing `pool.TryToSpawn()` directly inside `Interact()` works on the pool owner's client but silently no-ops for everyone else. There are two correct resolutions, presented as a cost tier below.
+
+| Tier | Approach | Cost | When |
+|---|---|---|---|
+| 1 | Forward to current pool owner via `SendCustomNetworkEvent(NetworkEventTarget.Owner, …)`; do spawn inside the owner-side handler | One network event, no ownership change | Default. Preserves whatever ownership scheme the pool already uses (master-managed, last-interactor, etc.). |
+| 2 | Take ownership locally with `Networking.SetOwner(LocalPlayer, pool.gameObject)`, then call `TryToSpawn()` / `Shuffle()` directly | One ownership transfer per Interact, no separate event | When the interaction semantically implies "this player now owns the next spawn" (e.g. each player owns their own ammo pool). |
+
+#### Tier 1 — Forward to owner (recommended)
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Components;
+using VRC.SDKBase;
+using VRC.Udon.Common.Interfaces;
+
+public class PoolInteractForwarded : UdonSharpBehaviour
+{
+    public VRCObjectPool objectPool;
+
+    public override void Interact()
+    {
+        // Ask the current pool owner to do the work; no ownership change.
+        SendCustomNetworkEvent(NetworkEventTarget.Owner, nameof(OwnerSpawn));
+    }
+
+    public void OwnerSpawn()
+    {
+        if (!Networking.IsOwner(objectPool.gameObject)) return;
+        objectPool.Shuffle();
+        GameObject spawned = objectPool.TryToSpawn();
+        // ... assign ownership of `spawned` if needed
+    }
+}
+```
+
+`OwnerSpawn` runs only on the player that currently owns `objectPool.gameObject`. The `IsOwner` guard is defensive against a race where ownership transfers between the `SendCustomNetworkEvent` call and the handler arriving on the previous owner's client.
+
+#### Tier 2 — Take ownership first (acceptable)
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Components;
+using VRC.SDKBase;
+
+public class PoolInteractTakeOwnership : UdonSharpBehaviour
+{
+    public VRCObjectPool objectPool;
+
+    public override void Interact()
+    {
+        Networking.SetOwner(Networking.LocalPlayer, objectPool.gameObject);
+        objectPool.Shuffle();
+        GameObject spawned = objectPool.TryToSpawn();
+        // ... assign ownership of `spawned` if needed
+    }
+}
+```
+
+`Networking.SetOwner` is locally immediate post-SDK 2021.2.2, so it is safe to call pool methods on the next line under an `IsOwner` invariant. See [networking.md](networking.md) for the full ownership model.
+
+#### Choosing between Tier 1 and Tier 2
+
+Use Tier 1 by default. Use Tier 2 when the interaction conceptually transfers ownership of the pool to the interacting player — for example, per-player ammo pools or individual draw-card decks. Mixing both patterns in one world is fine when each pool's role is different; Tier framing applies per-pool, not globally.
 
 ### VRCObjectPool vs VRCInstantiate
 


### PR DESCRIPTION
## Summary

Closes #190. Documents `VRCObjectPool.Shuffle()` in the skill for the first time and adds Interact-driven Cost Tier patterns (Tier 1 forward-to-owner / Tier 2 take-ownership-first) to `api.md`.

## Context

- Reporter: @niaka3dayo (maintainer's own Issue — code samples provided verbatim in the Issue body).
- **`Shuffle()` is absent from every public VRChat / UdonSharp source** (creator-docs, vrchat-community/UdonSharp API page, third-party tutorials) but verified present in SDK 3.10.3 via direct DLL inspection — the `__Shuffle__SystemVoid` Udon wrapper symbol in `VRC.Udon.VRCWrapperModules.dll`.
- **This PR is the first dogfood of PR #193's `unity-project-for-sdk-search/` convention**. The provenance sentence in the new Methods table paragraph cites the DLL symbol directly so future readers can re-derive the source themselves.
- Tier framing follows the established Cost Tier reframing precedent (#181/#182/#189 → PRs #183/#191). Both Tier 1 (forwarded) and Tier 2 (ownership-take) are correct API uses with different runtime costs — not NEVER rules.

## What changed (2 files, +85/-5)

| File | Change | Lines |
|---|---|---|
| `references/api.md` | Methods code block → Methods table with 3 rows (incl. **Shuffle**); Ownership Behavior bullets updated for coherence; new H3 `### Usage Pattern: Interact-Driven (User-Triggered)` between Master-Managed Pool and `VRCObjectPool vs VRCInstantiate` | +84/-4 |
| `SKILL.md` | api.md row's Search Hints extended with VRCObjectPool / Interact-driven keywords | +1/-1 |

`CHEATSHEET.md` was reviewed by a separate Lane and returned "no insertion warranted" — pool only appears as a pointer-table row there with no code sample to augment. Discoverability is covered by the api.md anchor + SKILL.md search hints.

## Tier framing (load-bearing)

The new section's "Choosing between Tier 1 and Tier 2" sub-section reads:

> Use Tier 1 by default. Use Tier 2 when the interaction conceptually transfers ownership of the pool to the interacting player — for example, per-player ammo pools or individual draw-card decks. Mixing both patterns in one world is fine when each pool's role is different; Tier framing applies per-pool, not globally.

Tier 2 is presented as a **positive use case for per-player ownership semantics**, not as a fallback. No phrasing like "fallback", "second-class", "must always prefer Tier 1" appears in the new content.

## 4-Route discoverability audit

### Route A — grep

```text
$ rg -c "Interact-Driven|PoolInteractForwarded|PoolInteractTakeOwnership|usage-pattern-interact-driven-user-triggered|Interact pool" skills/unity-vrc-udon-sharp/
skills/unity-vrc-udon-sharp/references/api.md:5
skills/unity-vrc-udon-sharp/SKILL.md:1
```

6 hits across 2 files. PASS.

### Route B — cross-reference

The Methods table paragraph links to `#usage-pattern-interact-driven-user-triggered`. Destination heading exists at `api.md:469` (`### Usage Pattern: Interact-Driven (User-Triggered)`). PASS.

### Route C — direct read

`## VRCObjectPool` section structure after edits (relative to section start):

```
### Properties
### Methods                                  ← table with TryToSpawn / Return / Shuffle
### Ownership Behavior                       ← updated to include Shuffle bullet
### Network Synchronization
### Pooled Object Contract
### Usage Pattern: Master-Managed Pool       ← existing, untouched
### Usage Pattern: Interact-Driven (User-Triggered)   ← new (this PR)
### VRCObjectPool vs VRCInstantiate
```

PASS.

### Route D — semantic context

SKILL.md search hints on the `api.md` row now include `VRCObjectPool, TryToSpawn, Return, Shuffle, pool owner, Interact pool, pool forwarded spawn, pool ownership transfer`. PASS.

## Boundary audit

```text
$ git diff -U0 -- skills/ | grep -E "^\+" | grep -iE "禁止|never use TryToSpawn|must not use|forbidden"
(no output — pass)
```

## Provenance sentence (verifiable)

```text
$ grep -n "__Shuffle__SystemVoid" skills/unity-vrc-udon-sharp/references/api.md
```

returns the Methods-table paragraph citing the DLL symbol directly. A future reader can re-derive the claim via:

```bash
strings -a unity-project-for-sdk-search/TestProject/Packages/com.vrchat.worlds/Runtime/Udon/External/VRC.Udon.VRCWrapperModules.dll \
  | grep "__Shuffle__SystemVoid"
```

## Reporter code fidelity

Both code blocks (`PoolInteractForwarded`, `PoolInteractTakeOwnership`) are reproduced from Issue #190 with only `using` import cleanup. The `IsOwner` defensive guard in Tier 1's `OwnerSpawn` is preserved as Reporter wrote it.

## Out of scope (no follow-up needed)

- Hands-on multi-client test of `Shuffle()` owner-only / synced behavior — accepted on maintainer authority for this PR; if a contributor produces a hands-on test that contradicts the claim, file a correction Issue.
- `CHEATSHEET.md` pool sample insertion (correctly skipped per Lane B decision).

## Verification

- [x] Reporter code reproduced verbatim (`PoolInteractForwarded` Tier 1 / `PoolInteractTakeOwnership` Tier 2)
- [x] Methods table includes Shuffle() with correct signature
- [x] Provenance sentence cites `__Shuffle__SystemVoid` and SDK 3.10.3
- [x] Tier 2 framed positively, not as fallback
- [x] 4-route discoverability audit all GREEN
- [x] Boundary audit: 0 prescriptive hits in diff
- [x] No new NEVER row added
- [x] Ownership Behavior section coherent with Methods table
- [ ] CI green (in-flight on this PR)
- [ ] CodeRabbit review pass / skip