### PR TITLE
docs(repo): runtime-semantics caveat for unity-project-for-sdk-search README (Refs #195)

### DIFF
--- a/unity-project-for-sdk-search/README.md
+++ b/unity-project-for-sdk-search/README.md
@@ -87,6 +87,7 @@ Note that other shorter tokens (e.g. a plain `Return` string with no `__` framin
 - Do not redistribute the SDK contents. VRChat's SDK license is non-redistribution.
 - Do not symlink this directory into another location that gets packed into npm. The `npm Pack Test` CI catches this, but avoid the round-trip.
 - Do not assume "Shuffle exists in the wrapper DLL" means the method is publicly supported. It only means Udon can call it. Confirm runtime behavior (owner-only? network-synced?) by additional means (Unity Editor IntelliSense, SDK release notes, hands-on test) before documenting it in the skill.
+- Do not infer **runtime semantics** (ownership rules, event scoping, sync timing, side effects, silent-failure modes) from method existence alone. `strings | grep` confirms whether a method is callable via Udon — it does NOT confirm whether the method is owner-only, what client receives a network event, what state syncs and when, or what happens when called in an invalid context. Runtime contracts must be verified against [creators.vrchat.com](https://creators.vrchat.com/) or hands-on **multi-client** testing in Unity. Precedent: PR #194 (Issue #190) shipped an initially-broken `NetworkEventTarget.Owner` example because the DLL confirmed method existence while the runtime target-resolution rule lived only in the public docs — caught pre-merge by independent reviewers (CodeRabbit + Codex Connector) citing creators.vrchat.com.
 
 ## Updating SDK versions
 


### PR DESCRIPTION
## Summary

Closes #195. Adds a single bullet to `unity-project-for-sdk-search/README.md` "What NOT to do" enumerating the categories of runtime semantics that **cannot** be inferred from `strings | grep` alone (ownership, event scoping, sync timing, side effects, silent-failure modes) and pointing readers at creators.vrchat.com / multi-client hands-on testing as the authoritative sources.

## Context

PR #194 (Issue #190) shipped an initially-broken Tier 1 example because the SDK DLL confirmed `Shuffle()` / `NetworkEventTarget.Owner` callability, but the **target-resolution runtime rule** lived only in the public docs. Two independent reviewers (CodeRabbit Major + Codex Connector P2) caught it pre-merge, citing creators.vrchat.com. The fix landed in commit `400a9ad` of PR #194.

This PR closes the implicit gap in the workspace's own documentation that allowed that bug to slip past the author's pre-PR self-review.

Generalised lesson is also captured in memory `feedback_static_existence_vs_runtime_semantics.md` (orchestrator-side).

## What changed (1 file, +1 line)

| File | Change | Lines |
|---|---|---|
| `unity-project-for-sdk-search/README.md` | One new bullet appended to "What NOT to do" section, with category enumeration + creators.vrchat.com link + PR #194 precedent citation | +1 / 0 |

The existing 4 bullets are unchanged. The new bullet is layered emphasis on a topic the previous 4th bullet covered loosely; the explicit category list + URL is the substantive addition.

## Verification

```text
$ grep -c "creators.vrchat.com" unity-project-for-sdk-search/README.md
2   # was 1, now 2 (1 existing + new bullet)

$ git diff --stat
 unity-project-for-sdk-search/README.md | 1 +
 1 file changed, 1 insertion(+)
```

Boundary audit: 0 prescriptive hits ("禁止" / "must not use" / "never use TryToSpawn") in the new content.

## Out of scope

- Restructuring the "What NOT to do" section or the README more broadly.
- Documenting which specific APIs have or lack runtime-contract docs in creators.vrchat.com (per-API, belongs in skill-specific docs).

## Verification checklist

- [x] One bullet added under existing "What NOT to do" section
- [x] No other content modified
- [x] Boundary audit clean
- [ ] CI green (in-flight)
- [ ] CodeRabbit review pass / skip