### PR TITLE
chore(version): bump to v2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "1.9.0"
+    "version": "2.0.0"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.9.0"
+    version: "2.0.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.9.0"
+    version: "2.0.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "1.9.0"
+    version: "2.0.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 


### PR DESCRIPTION
Pre-release version bump for Step 2 of the v2.0.0 release flow.

Bumps the canonical 5 version fields from `1.9.0` to `2.0.0`:
- `package.json` → `.version`
- `.claude-plugin/marketplace.json` → `.metadata.version`
- `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
- `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
- `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`

Verified by Version Sync CI before merge.

**Version resolution**: PR #188 (`release: breaking`) is the highest-bump driver since the last release (v1.9.0). Per CLAUDE.md "Version resolution (label-driven)" highest bump wins → major → v2.0.0.

After this lands on `dev`, Step 2 opens the release PR (`dev` → `main`).