### PR TITLE
docs(skills/udon-sharp): qualify Core Principle 5 to align with Event Dispatch Cost Tiers

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -41,7 +41,7 @@ Four architectural decisions that must be made before choosing sync modes or wri
 2. **Ownership Before Mutation** — Only the owner of an object can modify its synced variables. Always `SetOwner` → modify → `RequestSerialization`.
 3. **Late Joiner Correctness** — State must be correct for players who join after events have occurred. Design for re-serialization, not just live updates.
 4. **Sync Minimization** — Every synced variable costs bandwidth (see data budget in `udonsharp-sync-selection.md`). Derive what you can locally; sync only the source of truth.
-5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()`.
+5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()` **for state-change reactions; for hot-path or periodic work, see [Event Dispatch & Cross-Behaviour Call Cost Tiers](references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers)**.
 
 ## Common Mistakes (NEVER List)
 


### PR DESCRIPTION
## Summary

Single-line edit to `skills/unity-vrc-udon-sharp/SKILL.md:44` appending a qualifier to Core Principle 5 to distinguish state-change reactions from hot-path / periodic work, with an anchor link to the Event Dispatch & Cross-Behaviour Call Cost Tiers section.

Resolves the apparent conflict between Principle 5 (*"Event-Driven, Not Polling"*) and the Cost Tiers section added in #191 (`references/patterns-performance.md:1066`), which notes that `SendCustomEvent` and cross-behaviour calls are costly in hot paths.

## Change

```diff
-5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()`.
+5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()` **for state-change reactions; for hot-path or periodic work, see [Event Dispatch & Cross-Behaviour Call Cost Tiers](references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers)**.
```

## Verification

- [x] Anchor target `references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers` resolves to the existing heading (`patterns-performance.md:1066`). Anchor uses GitHub's double-hyphen rule for ` & ` headings.
- [x] `grep` confirmed no duplicate of the "Event-Driven, Not Polling" wording elsewhere in `skills/` or `templates/`.
- [x] `git diff --check` clean (no trailing whitespace / conflict markers).
- [x] Frontmatter version untouched, so this PR does **not** trigger the 5-file version-bump sync.
- [ ] Lychee / markdown-link-check (CI side) passes.

## Release notes

- Release Drafter label: `release: docs` (patch bump).
- Reporter (@KatanoShingo) raised this in a post-merge comment on #189. Credit in Japanese in the release notes per the reporter-language rule (`feedback_release_notes_cleanup.md`).

## Acceptance criteria (from #200)

- [x] `SKILL.md:44` qualifier added with anchor link
- [ ] Anchor link renders correctly on the GitHub diff view (verify before merge)
- [x] No regressions to skill-judge score expected (1-line clarification, no structural changes)
- [ ] Reporter credited in release notes (Japanese) — to be confirmed at release time

Closes #200