### PR TITLE
docs(skills/udon-sharp): document Capsule contact shape

### DIFF
--- a/skills/unity-vrc-udon-sharp/assets/templates/ContactReceiver.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/ContactReceiver.cs
@@ -10,8 +10,9 @@ using VRC.Udon;
 ///
 /// Setup:
 /// 1. Add "VRC Contact Receiver" component to this GameObject.
-/// 2. Configure Radius, Allow Self, Allow Others, and Content Types on it.
-/// 3. Assign the public fields below in the Inspector.
+/// 2. Set Shape Type to Sphere or Capsule. Capsule also requires Height (Y-axis).
+/// 3. Configure Radius, Allow Self, Allow Others, and Content Types on it.
+/// 4. Assign the public fields below in the Inspector.
 ///
 /// See references/dynamics.md "Contacts" for full API documentation.
 /// </summary>

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -955,7 +955,7 @@ VRCContactSender sender = GetComponent<VRCContactSender>();
 float radius = sender.radius;             // Collision radius (both shapes; max 3 m)
 float height = sender.height;             // Capsule height along Y, half-spheres included (max 6 m)
 ContactBase.ShapeType shapeType = sender.shapeType; // Sphere or Capsule
-string contentType = sender.contentType;
+string contentType = sender.contentType;  // Contact tag string (e.g. "Finger", "Hand", or custom)
 ```
 
 Shape and dimension properties are read/write from Udon. `height` is only meaningful when `shapeType` is `ContactBase.ShapeType.Capsule`.

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -937,7 +937,12 @@ receiver.UpdateContentTypes(allowedTypes);
 // Properties
 bool allowSelf = receiver.allowSelf;     // Allow contacts from same avatar
 bool allowOthers = receiver.allowOthers; // Allow contacts from other avatars
+float radius = receiver.radius;          // Collision radius (both shapes; max 3 m)
+float height = receiver.height;          // Capsule height along Y, half-spheres included (max 6 m)
+ContactBase.ShapeType shapeType = receiver.shapeType; // Sphere or Capsule
 ```
+
+Shape and dimension properties are read/write from Udon. `height` is only meaningful when `shapeType` is `ContactBase.ShapeType.Capsule`.
 
 ### VRCContactSender
 
@@ -947,9 +952,13 @@ Sends contact events to receivers.
 VRCContactSender sender = GetComponent<VRCContactSender>();
 
 // Properties
-float radius = sender.radius;
+float radius = sender.radius;             // Collision radius (both shapes; max 3 m)
+float height = sender.height;             // Capsule height along Y, half-spheres included (max 6 m)
+ContactBase.ShapeType shapeType = sender.shapeType; // Sphere or Capsule
 string contentType = sender.contentType;
 ```
+
+Shape and dimension properties are read/write from Udon. `height` is only meaningful when `shapeType` is `ContactBase.ShapeType.Capsule`.
 
 ### VRCPhysBone
 

--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -32,7 +32,7 @@ Contacts provide a collision detection system between **Senders** and **Receiver
 3. Configure `Radius` (and `Height` for Capsule)
 4. Set `Content Type` (identifies what kind of contact this is)
 
-```
+```text
 VRC Contact Sender (Sphere)
 ├── Shape Type: Sphere
 ├── Radius: 0.02 (finger-sized; max 3 m)
@@ -60,7 +60,7 @@ VRC Contact Sender (Capsule)
 4. Configure allowed content types
 5. Implement contact events in Udon
 
-```
+```text
 VRC Contact Receiver (Sphere)
 ├── Shape Type: Sphere
 ├── Radius: 0.05 (max 3 m)

--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -28,29 +28,53 @@ Contacts provide a collision detection system between **Senders** and **Receiver
 #### Contact Sender
 
 1. Add `VRC Contact Sender` component to a GameObject
-2. Configure `Radius` (collision size)
-3. Set `Content Type` (identifies what kind of contact this is)
+2. Choose `Shape Type`: `Sphere` or `Capsule`
+3. Configure `Radius` (and `Height` for Capsule)
+4. Set `Content Type` (identifies what kind of contact this is)
 
 ```
-VRC Contact Sender
-├── Radius: 0.02 (finger-sized)
-├── Content Type: "Finger"
-└── Shape: Sphere
+VRC Contact Sender (Sphere)
+├── Shape Type: Sphere
+├── Radius: 0.02 (finger-sized; max 3 m)
+└── Content Type: "Finger"
+
+VRC Contact Sender (Capsule)
+├── Shape Type: Capsule
+├── Radius: 0.05 (max 3 m)
+├── Height: 0.3 (Y-axis, half-spheres included; max 6 m)
+└── Content Type: "Custom"
 ```
+
+**Shape comparison:**
+
+| Shape | Fields | Typical use |
+|-------|--------|-------------|
+| `Sphere` | `Radius` | Point contacts (fingers, small projectiles) |
+| `Capsule` | `Radius` + `Height` | Elongated contacts (arms, props, area triggers) |
 
 #### Contact Receiver
 
 1. Add `VRC Contact Receiver` component to a GameObject
 2. Add UdonBehaviour to the **same** GameObject
-3. Configure allowed content types
-4. Implement contact events in Udon
+3. Choose `Shape Type` and configure its dimensions
+4. Configure allowed content types
+5. Implement contact events in Udon
 
 ```
-VRC Contact Receiver
-├── Radius: 0.05
+VRC Contact Receiver (Sphere)
+├── Shape Type: Sphere
+├── Radius: 0.05 (max 3 m)
 ├── Allow Self: true (contacts from same avatar)
 ├── Allow Others: true (contacts from other avatars)
 └── Content Types: ["Finger", "Hand"]
+
+VRC Contact Receiver (Capsule)
+├── Shape Type: Capsule
+├── Radius: 0.05 (max 3 m)
+├── Height: 0.5 (Y-axis, half-spheres included; max 6 m)
+├── Allow Self: true
+├── Allow Others: true
+└── Content Types: ["Hand"]
 ```
 
 ### Contact Events


### PR DESCRIPTION
## Summary

Document the Capsule contact shape which exists in SDK 3.10.0+ but was missing from the skill documentation. Only `Shape: Sphere` was previously documented.

Closes #205

## Changes

- **dynamics.md**: Expanded Contacts Setup section with Sphere/Capsule shape variants, shape comparison table, and max dimension limits (Radius 3m, Height 6m)
- **api.md**: Added `radius`, `height`, `shapeType` properties to VRCContactSender and VRCContactReceiver sections (DLL-verified read/write from Udon)
- **ContactReceiver.cs**: Updated setup instructions to include Shape Type selection

## Evidence

- DLL verification (`VRC.Udon.VRCWrapperModules.dll`): `__get_shapeType__VRCDynamicsContactBaseShapeType`, `__set_shapeType__VRCDynamicsContactBaseShapeType`, `__get_height__SystemSingle`, `__set_height__SystemSingle` confirmed
- Official docs cross-referenced: https://creators.vrchat.com/common-components/contacts/
- VRChat Developer Update (May 21, 2026) confirms Capsule as pre-existing shape

## Test Plan

- [ ] `npm pack --dry-run` passes
- [ ] CI checks pass (Symlink Integrity, Hook Scripts, EditorConfig, npm Pack Test, Markdown Links)
- [ ] No broken markdown formatting in tree diagrams
- [ ] No SDK version range changes (remains 3.10.3)