### PR TITLE
fix(skills/udon-sharp): correct OnPersistenceUsageUpdated signature (#217)

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -415,11 +415,11 @@ public class StorageMonitor : UdonSharpBehaviour
         SendCustomEventDelayedSeconds(nameof(RequestRefresh), RefreshInterval);
     }
 
-    // Called by VRChat when fresh storage usage data is available for a player
-    public override void OnPersistenceUsageUpdated(VRCPlayerApi player)
+    // Called by VRChat when fresh storage usage data is available.
+    // Always fires on the local player's UdonBehaviours.
+    public override void OnPersistenceUsageUpdated()
     {
-        if (!player.isLocal) return;
-        ShowUsage(player);
+        ShowUsage(Networking.LocalPlayer);
     }
 
     // Periodic refresh event

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -266,11 +266,11 @@ player.RequestStorageUsageUpdate();             // request a fresh value from se
 The `OnPersistenceUsageUpdated` event fires when updated usage data arrives:
 
 ```csharp
-public override void OnPersistenceUsageUpdated(VRCPlayerApi player)
+// Always fires on the local player's UdonBehaviours.
+public override void OnPersistenceUsageUpdated()
 {
-    if (!player.isLocal) return;
-    int used  = player.GetPlayerDataStorageUsage();
-    int limit = player.GetPlayerDataStorageLimit();
+    int used  = Networking.LocalPlayer.GetPlayerDataStorageUsage();
+    int limit = Networking.LocalPlayer.GetPlayerDataStorageLimit();
     Debug.Log($"Storage: {used}/{limit} bytes");
 }
 ```


### PR DESCRIPTION
## Summary

Fix `OnPersistenceUsageUpdated` method signature in `persistence.md` and `sdk-migration.md`.

- **Before**: `void OnPersistenceUsageUpdated(VRCPlayerApi player)` (incorrect)
- **After**: `void OnPersistenceUsageUpdated()` (matches SDK source)

The event fires on the local player's UdonBehaviours — code examples now use `Networking.LocalPlayer` instead of a method parameter.

Closes #217

### Verification

- SDK source (`UdonSharpBehaviour.cs:OnPersistenceUsageUpdated`): `public virtual void OnPersistenceUsageUpdated() {}`
- `events.md` already has the correct parameterless signature (added in PR #216)
- Discovered during PR #216 CodeRabbit review

## Test plan

- [ ] `grep -rn "OnPersistenceUsageUpdated(VRCPlayerApi" skills/` returns 0 hits
- [ ] Markdown Links CI passes
- [ ] EditorConfig passes