### PR TITLE
chore(skills): add language specifiers to bare code fences (MD040)

### DIFF
--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -55,7 +55,7 @@ public class MyScript : UdonSharpBehaviour { }
 
 ## Sync Strategy Decision Tree
 
-```
+```text
 Q1: Does data need to persist across sessions / per-player?
   Yes -> PlayerData (SDK 3.7.4+) or PlayerObject
   No  -> Q2

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -910,7 +910,7 @@ public class CameraMonitor : UdonSharpBehaviour
 
 ### Notes
 
-```
+```text
 - All properties are read-only from Udon. Camera settings cannot be set via this API.
 - OnVRCCameraSettingsChanged fires for both ScreenCamera and PhotoCamera changes;
   filter by comparing the parameter with VRCCameraSettings.ScreenCamera.

--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -213,7 +213,7 @@ PhysBones provide physics-based bone animation:
 2. Configure physics parameters
 3. Add UdonBehaviour for grab events (optional)
 
-```
+```text
 VRC Phys Bone
 ├── Root Transform: RopeStart
 ├── End Bone: (auto-detected or manual)
@@ -395,7 +395,7 @@ VRC Constraints replace Unity's built-in Constraints with a VRChat-optimized ver
 
 ### Constraints Setup
 
-```
+```text
 VRC Position Constraint
 ├── Sources: [Transform1 (weight 0.5), Transform2 (weight 0.5)]
 ├── Constraint Active: true

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -802,7 +802,7 @@ The Unity/VRChat per-frame execution order (steady state, every frame):
 
 When you are the first player to enter an instance:
 
-```
+```text
 _onEnable → _start
     ↓
 OnPlayerJoined(self)          ← fires for yourself
@@ -819,7 +819,7 @@ OnMasterChanged               ← master transferred from nobody to you
 
 When you join an existing instance:
 
-```
+```text
 _onEnable → _start
     ↓
 OnPlayerJoined(player A)      ← for each player already in the instance
@@ -849,7 +849,7 @@ In this specific edge case (most likely when the late joiner is the **first inst
 
 When a new player joins while you are already in the instance:
 
-```
+```text
 OnPlayerJoined(newPlayer)     ← fires only for the newly joined player
 ```
 

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -29,7 +29,7 @@ to a C# object, the GC can reclaim it. However, `Texture2D` is a **Unity engine 
 it has a small C# wrapper, but the actual pixel data lives in **unmanaged GPU memory** (VRAM).
 The GC sees only the tiny C# wrapper and cannot reclaim the GPU allocation.
 
-```
+```text
 C# heap (managed):                  GPU VRAM (unmanaged):
 ┌──────────────────────────┐        ┌───────────────────────────────┐
 │ Texture2D wrapper  (40 B)│──────> │ Pixel data  (width×height×bpp)│
@@ -195,7 +195,7 @@ The solution is a **double-buffer**: two Renderer slots (A and B) that alternate
 The new image loads into the "back" slot, a fade animation plays, and once the fade is
 complete the old texture is safe to destroy.
 
-```
+```text
 State 0 — Image X is displayed on Renderer A (front)
            Renderer B is idle (back)
 
@@ -419,7 +419,7 @@ public class DoubleBufferImageDisplay : UdonSharpBehaviour
 Download the next image each cycle. After the fade, destroy the old texture. VRAM holds
 at most two textures at once regardless of how many images are in the playlist.
 
-```
+```text
 Cycle 1: Download A  → display A  → VRAM: A
 Cycle 2: Download B  → fade A→B  → Destroy A  → VRAM: B
 Cycle 3: Download C  → fade B→C  → Destroy B  → VRAM: C
@@ -434,7 +434,7 @@ Cycle 3: Download C  → fade B→C  → Destroy B  → VRAM: C
 Download all images once, store the textures in a `Material[]` array. On repeat visits
 to the same image, use the cached texture — no download, instant transition.
 
-```
+```text
 Startup: Download A, B, C, D  → VRAM: A + B + C + D
 Runtime: Cycle through cached textures  → no further downloads
 ```
@@ -621,7 +621,7 @@ player is far from an image display, while keeping it sharp up close.
 A logarithmic curve gives a natural feel: the bias increases slowly near the object
 and accelerates as distance grows.
 
-```
+```text
 bias = log2(distance / sharpDistance)
 ```
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-performance.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-performance.md
@@ -884,7 +884,7 @@ All video-loading behaviours in the world hold a `[SerializeField]` reference to
 
 **Architecture:**
 
-```
+```text
 VideoPlayerA ──ScheduleLoad──▶ UrlLoadScheduler
 VideoPlayerB ──ScheduleLoad──▶  (shared singleton)
                                      │

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -344,7 +344,7 @@ The `interface` keyword is blocked in UdonSharp. When building modular systems �
 
 Define an **abstract base class** with abstract callback methods. Concrete handlers subclass it and override those methods. A **mediator** bridges the string-based `SendCustomEvent` call from the worker to the typed method on the callback reference.
 
-```
+```text
 Worker ──SendCustomEvent──▶ Mediator ──typed call──▶ AbstractBase ──override──▶ ConcreteHandler
 ```
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -171,7 +171,7 @@ The playback position is never synced directly. Instead, the owner records *when
 started the video (using server clock), and every client recomputes the current position
 independently:
 
-```
+```text
 currentPosition = syncStartTime
                 + (Networking.GetServerTimeInMilliseconds() - syncClockTime) / 1000f
                 * syncSpeed
@@ -304,7 +304,7 @@ public class PlaybackTimeSynchronizer : UdonSharpBehaviour
 
 ### Flow
 
-```
+```text
 OnDeserialization
   → URL in synced state?
       → PlayURL(syncUrl)
@@ -495,7 +495,7 @@ public class AVProTextureStabilizer : UdonSharpBehaviour
 
 ### Retry Logic
 
-```
+```text
 OnVideoError
   → permanent error?  → SetState(Error), notify user, stop
   → retriable error?

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -24,7 +24,7 @@ Common errors, causes, and solutions for VRChat UdonSharp development.
 ### "UdonSharp does not support X"
 
 **Symptoms:**
-```
+```text
 UdonSharpException: UdonSharp does not currently support [feature]
 ```
 
@@ -49,7 +49,7 @@ Use the alternatives documented. See `constraints.md` for the complete list.
 ### "The type or namespace 'X' could not be found"
 
 **Symptoms:**
-```
+```text
 CS0246: The type or namespace name 'List' could not be found
 ```
 
@@ -78,7 +78,7 @@ list.Add(new DataToken(42));
 ### "'UdonSharpBehaviour' does not contain a definition for 'X'"
 
 **Symptoms:**
-```
+```text
 CS1061: 'UdonSharpBehaviour' does not contain a definition for 'StartCoroutine'
 ```
 
@@ -100,7 +100,7 @@ CS1061: 'UdonSharpBehaviour' does not contain a definition for 'StartCoroutine'
 ### "Field 'X' is not serializable"
 
 **Symptoms:**
-```
+```text
 UdonSharp: Field 'X' is not serializable
 ```
 
@@ -138,7 +138,7 @@ public VRCPlayerApi GetTargetPlayer()
 ### "NullReferenceException"
 
 **Symptoms:**
-```
+```text
 NullReferenceException: Object reference not set to an instance of an object
 ```
 
@@ -190,7 +190,7 @@ public void DoSomethingWithPlayer()
 ### "SendCustomEvent: Method 'X' not found"
 
 **Symptoms:**
-```
+```text
 [UdonBehaviour] SendCustomEvent: Method 'MyMethod' not found
 ```
 
@@ -221,7 +221,7 @@ otherScript.SendCustomEvent("ProcessInput");
 ### "Heap ran out of memory"
 
 **Symptoms:**
-```
+```text
 Udon heap ran out of memory
 ```
 
@@ -271,7 +271,7 @@ for (int i = 0; i < 100; i++)
 ### "ArrayIndexOutOfRangeException"
 
 **Symptoms:**
-```
+```text
 IndexOutOfRangeException: Index was outside the bounds of the array
 ```
 
@@ -463,7 +463,7 @@ void Start()
 ### "Method 'X' is not network callable"
 
 **Symptoms:**
-```
+```text
 Method 'X' cannot be called as a network event
 ```
 
@@ -1616,13 +1616,13 @@ For errors not covered in this document, follow these investigation steps:
 
 ### Step 1: Search Official Docs (WebSearch)
 
-```
+```yaml
 WebSearch: "error message or keyword site:creators.vrchat.com"
 ```
 
 ### Step 2: Search VRChat Forums (WebSearch)
 
-```
+```yaml
 WebSearch:
   query: "error message site:ask.vrchat.com"
   allowed_domains: ["ask.vrchat.com"]
@@ -1632,7 +1632,7 @@ Look for solutions from community members who encountered the same issue.
 
 ### Step 3: Search Canny (Known Bugs)
 
-```
+```yaml
 WebSearch:
   query: "error message site:feedback.vrchat.com"
   allowed_domains: ["feedback.vrchat.com"]
@@ -1642,7 +1642,7 @@ Check whether VRChat officially recognizes the bug and if workarounds exist.
 
 ### Step 4: Search GitHub Issues
 
-```
+```yaml
 WebSearch:
   query: "error message site:github.com/vrchat-community/UdonSharp"
   allowed_domains: ["github.com"]

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -24,8 +24,11 @@ Common errors, causes, and solutions for VRChat UdonSharp development.
 ### "UdonSharp does not support X"
 
 **Symptoms:**
+
 ```text
+
 UdonSharpException: UdonSharp does not currently support [feature]
+
 ```
 
 **Common unsupported features:**
@@ -49,8 +52,11 @@ Use the alternatives documented. See `constraints.md` for the complete list.
 ### "The type or namespace 'X' could not be found"
 
 **Symptoms:**
+
 ```text
+
 CS0246: The type or namespace name 'List' could not be found
+
 ```
 
 **Causes:**
@@ -61,6 +67,7 @@ CS0246: The type or namespace name 'List' could not be found
 **Solution:**
 
 ```csharp
+
 // Wrong - List<T> not supported
 using System.Collections.Generic;
 List<int> numbers = new List<int>();
@@ -71,6 +78,7 @@ int[] numbers = new int[10];
 // Or use DataList for dynamic sizing
 DataList list = new DataList();
 list.Add(new DataToken(42));
+
 ```
 
 ---
@@ -78,8 +86,11 @@ list.Add(new DataToken(42));
 ### "'UdonSharpBehaviour' does not contain a definition for 'X'"
 
 **Symptoms:**
+
 ```text
+
 CS1061: 'UdonSharpBehaviour' does not contain a definition for 'StartCoroutine'
+
 ```
 
 **Cause:** Attempting to use MonoBehaviour methods not exposed to Udon.
@@ -100,8 +111,11 @@ CS1061: 'UdonSharpBehaviour' does not contain a definition for 'StartCoroutine'
 ### "Field 'X' is not serializable"
 
 **Symptoms:**
+
 ```text
+
 UdonSharp: Field 'X' is not serializable
+
 ```
 
 **Cause:** Attempting to sync an unsupported type.
@@ -118,7 +132,9 @@ UdonSharp: Field 'X' is not serializable
 - `VRCPlayerApi`
 
 **Solution:**
+
 ```csharp
+
 // Wrong - Cannot sync VRCPlayerApi
 [UdonSynced] private VRCPlayerApi targetPlayer;
 
@@ -129,6 +145,7 @@ public VRCPlayerApi GetTargetPlayer()
 {
     return VRCPlayerApi.GetPlayerById(targetPlayerId);
 }
+
 ```
 
 ---
@@ -138,8 +155,11 @@ public VRCPlayerApi GetTargetPlayer()
 ### "NullReferenceException"
 
 **Symptoms:**
+
 ```text
+
 NullReferenceException: Object reference not set to an instance of an object
+
 ```
 
 **Common causes:**
@@ -151,6 +171,7 @@ NullReferenceException: Object reference not set to an instance of an object
 **Solution:**
 
 ```csharp
+
 // Always validate Inspector references
 void Start()
 {
@@ -183,6 +204,7 @@ public void DoSomethingWithPlayer()
     }
     // Safe to use player
 }
+
 ```
 
 ---
@@ -190,8 +212,11 @@ public void DoSomethingWithPlayer()
 ### "SendCustomEvent: Method 'X' not found"
 
 **Symptoms:**
+
 ```text
+
 [UdonBehaviour] SendCustomEvent: Method 'MyMethod' not found
+
 ```
 
 **Causes:**
@@ -202,6 +227,7 @@ public void DoSomethingWithPlayer()
 **Solution:**
 
 ```csharp
+
 // Wrong - Method is private
 private void MyMethod() { }
 
@@ -214,6 +240,7 @@ public void MyMethod() { }
 // For passing data, use SetProgramVariable first
 otherScript.SetProgramVariable("inputValue", 42);
 otherScript.SendCustomEvent("ProcessInput");
+
 ```
 
 ---
@@ -221,8 +248,11 @@ otherScript.SendCustomEvent("ProcessInput");
 ### "Heap ran out of memory"
 
 **Symptoms:**
+
 ```text
+
 Udon heap ran out of memory
+
 ```
 
 **Causes:**
@@ -234,6 +264,7 @@ Udon heap ran out of memory
 **Solution:**
 
 ```csharp
+
 // Wrong - Creates new array every frame
 void Update()
 {
@@ -264,6 +295,7 @@ for (int i = 0; i < 100; i++)
 
 // Correct - Use char array or limit concatenation
 // For display purposes, just show final result
+
 ```
 
 ---
@@ -271,8 +303,11 @@ for (int i = 0; i < 100; i++)
 ### "ArrayIndexOutOfRangeException"
 
 **Symptoms:**
+
 ```text
+
 IndexOutOfRangeException: Index was outside the bounds of the array
+
 ```
 
 **Common causes:**
@@ -283,6 +318,7 @@ IndexOutOfRangeException: Index was outside the bounds of the array
 **Solution:**
 
 ```csharp
+
 // Always check array bounds
 public void ProcessArray(int[] data)
 {
@@ -303,6 +339,7 @@ public override void OnPlayerLeft(VRCPlayerApi player)
     // GetPlayers() count has already changed!
     // Cache count before iteration if needed
 }
+
 ```
 
 ---
@@ -318,24 +355,32 @@ public override void OnPlayerLeft(VRCPlayerApi player)
 **Checklist:**
 
 1. **Is the variable properly marked?**
+
 ```csharp
+
 // Correct
 [UdonSynced] private int myValue;
+
 ```
 
 2. **Is the type syncable?** (See syncable types above)
 
 3. **Did you call RequestSerialization()?**
+
 ```csharp
+
 public void ChangeValue()
 {
     myValue = 42;
     RequestSerialization(); // Required for Manual sync mode!
 }
+
 ```
 
 4. **Do you have ownership?**
+
 ```csharp
+
 public void ChangeValue()
 {
     if (!Networking.IsOwner(gameObject))
@@ -345,15 +390,19 @@ public void ChangeValue()
     myValue = 42;
     RequestSerialization();
 }
+
 ```
 
 5. **Check sync mode:**
+
 ```csharp
+
 // For infrequent changes (buttons, toggles)
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 
 // For continuous changes (position, rotation)
 [UdonBehaviourSyncMode(BehaviourSyncMode.Continuous)]
+
 ```
 
 ---
@@ -365,7 +414,9 @@ public void ChangeValue()
 **Checklist:**
 
 1. **Correct attribute syntax?**
+
 ```csharp
+
 // Correct - nameof() points to PROPERTY
 [UdonSynced, FieldChangeCallback(nameof(MyProperty))]
 private int _myValue;
@@ -379,15 +430,19 @@ public int MyProperty
         OnValueChanged();
     }
 }
+
 ```
 
 2. **Using property everywhere locally?**
+
 ```csharp
+
 // Wrong - Bypasses callback
 _myValue = 10;
 
 // Correct - Uses property
 MyProperty = 10;
+
 ```
 
 3. **Sync mode compatibility:**
@@ -410,6 +465,7 @@ MyProperty = 10;
 `Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` returns `true` synchronously after the call. There is no need to defer the action to `OnOwnershipTransferred`. Concurrent callers each succeed locally; the network resolves the durable owner by arrival order, and the loser's write is overwritten on the next deserialization. Guard writes with `IsOwner` and accept that property of the network.
 
 ```csharp
+
 public override void Interact()
 {
     if (!Networking.IsOwner(gameObject))
@@ -427,6 +483,7 @@ private void DoAction()
     // synced variables here.
     RequestSerialization();
 }
+
 ```
 
 > For owner-side protection during critical actions (e.g., reject ownership requests mid-transaction), use `OnOwnershipRequest` — see [networking.md §"Ownership Arbitration with OnOwnershipRequest"](networking.md#ownership-arbitration-with-onownershiprequest).
@@ -438,7 +495,9 @@ private void DoAction()
 **Problem:** Late joiners do not see the correct state.
 
 **Solution:**
+
 ```csharp
+
 public override void OnPlayerJoined(VRCPlayerApi player)
 {
     // Only owner needs to sync
@@ -454,6 +513,7 @@ void Start()
     // This runs after OnDeserialization for late joiners
     ApplyState();
 }
+
 ```
 
 ---
@@ -463,8 +523,11 @@ void Start()
 ### "Method 'X' is not network callable"
 
 **Symptoms:**
+
 ```text
+
 Method 'X' cannot be called as a network event
+
 ```
 
 **Causes:**
@@ -474,7 +537,9 @@ Method 'X' cannot be called as a network event
 4. Method has more than 8 parameters
 
 **Solution:**
+
 ```csharp
+
 // WRONG
 public void MyMethod(int value) { } // Missing attribute
 
@@ -483,6 +548,7 @@ private void MyMethod(int value) { } // Private
 // CORRECT
 [NetworkCallable]
 public void MyMethod(int value) { }
+
 ```
 
 ---
@@ -502,6 +568,7 @@ public void MyMethod(int value) { }
 3. Ensure all clients are on SDK 3.8.1+
 
 ```csharp
+
 // WRONG - VRCPlayerApi is not syncable
 [NetworkCallable]
 public void SetTarget(VRCPlayerApi player) { }
@@ -509,6 +576,7 @@ public void SetTarget(VRCPlayerApi player) { }
 // CORRECT - Use player ID instead
 [NetworkCallable]
 public void SetTarget(int playerId) { }
+
 ```
 
 ---
@@ -518,7 +586,9 @@ public void SetTarget(int playerId) { }
 **Symptoms:** Events are dropped and do not reach all clients
 
 **Solution:**
+
 ```csharp
+
 // Increase rate limit (max 100/sec)
 [NetworkCallable(100)]
 public void HighFrequencyEvent(float value) { }
@@ -533,6 +603,7 @@ public void SendIfReady(int value)
     lastSendTime = Time.time;
     SendCustomNetworkEvent(NetworkEventTarget.All, nameof(MyEvent), value);
 }
+
 ```
 
 ---
@@ -549,7 +620,9 @@ public void SendIfReady(int value)
 3. Wrong player reference
 
 **Solution:**
+
 ```csharp
+
 private bool dataReady = false;
 
 public override void OnPlayerRestored(VRCPlayerApi player)
@@ -573,6 +646,7 @@ public void SaveScore(int score)
     }
     PlayerData.SetInt(Networking.LocalPlayer, "score", score);
 }
+
 ```
 
 ---
@@ -587,7 +661,9 @@ public void SaveScore(int score)
 3. Key name too long (max 128 characters)
 
 **Solution:**
+
 ```csharp
+
 // WRONG - Trying to write to other player's data
 PlayerData.SetInt(otherPlayer, "score", 100); // Will fail silently
 
@@ -597,6 +673,7 @@ PlayerData.SetInt(Networking.LocalPlayer, "score", 100);
 // Debug storage usage
 string[] keys = PlayerData.GetKeys(Networking.LocalPlayer);
 Debug.Log($"Using {keys.Length} keys");
+
 ```
 
 ---
@@ -634,6 +711,7 @@ Debug.Log($"Using {keys.Length} keys");
 3. Check Allow Self/Allow Others settings (applies to avatar contacts only)
 
 ```csharp
+
 // Verify receiver is on this GameObject
 void Start()
 {
@@ -643,6 +721,7 @@ void Start()
         Debug.LogError("No VRCContactReceiver on this GameObject!");
     }
 }
+
 ```
 
 ---
@@ -657,7 +736,9 @@ void Start()
 3. No debounce logic
 
 **Solution:**
+
 ```csharp
+
 private float lastContactTime;
 private const float DEBOUNCE = 0.1f;
 
@@ -668,6 +749,7 @@ public override void OnContactEnter(ContactEnterInfo info)
 
     // Handle contact
 }
+
 ```
 
 ---
@@ -695,7 +777,9 @@ public override void OnContactEnter(ContactEnterInfo info)
 **Cause:** Contact is from a world object, not from an avatar
 
 **Solution:**
+
 ```csharp
+
 public override void OnContactEnter(ContactEnterInfo info)
 {
     if (info.isAvatar)
@@ -712,6 +796,7 @@ public override void OnContactEnter(ContactEnterInfo info)
         Debug.Log("Contact from world object");
     }
 }
+
 ```
 
 ---
@@ -741,6 +826,7 @@ For stations with `PlayerMobility = Immobilize`, the seated position is fixed. C
 > one script per station.
 
 ```csharp
+
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
@@ -809,6 +895,7 @@ public class StationZoneCheckStatic : UdonSharpBehaviour
         Debug.Log($"[StationZoneCheck] {player.displayName} exited zone (unseated)");
     }
 }
+
 ```
 
 ---
@@ -818,6 +905,7 @@ public class StationZoneCheckStatic : UdonSharpBehaviour
 For stations that can move (avatar stations, moving platforms), poll seated player positions periodically. This approach checks every 0.5 seconds instead of every frame to reduce overhead.
 
 ```csharp
+
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
@@ -941,6 +1029,7 @@ public class StationZoneCheckPolling : UdonSharpBehaviour
         Debug.Log($"[StationZonePoll] {player.displayName} exited zone");
     }
 }
+
 ```
 
 ---
@@ -956,6 +1045,7 @@ When neither static bounds check nor position polling is suitable — e.g., avat
 > from the proxy collider.
 
 ```csharp
+
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
@@ -1033,6 +1123,7 @@ public class PlayerFollowCollider : UdonSharpBehaviour
         followCollider.gameObject.SetActive(false);
     }
 }
+
 ```
 
 **Key considerations:**
@@ -1049,6 +1140,7 @@ public class PlayerFollowCollider : UdonSharpBehaviour
 `OnStationExited` may **not fire** when a seated player leaves the instance. Always pair station tracking with `OnPlayerLeft` cleanup to prevent stale data.
 
 ```csharp
+
 public override void OnPlayerLeft(VRCPlayerApi player)
 {
     if (!Utilities.IsValid(player)) return;
@@ -1060,6 +1152,7 @@ public override void OnPlayerLeft(VRCPlayerApi player)
         _isPlayerInZone = false;
     }
 }
+
 ```
 
 ---
@@ -1105,12 +1198,15 @@ public override void OnPlayerLeft(VRCPlayerApi player)
 **Cause:** UdonSharp uses a proxy system, and changes to the proxy are not auto-saved.
 
 **Solution:**
+
 ```csharp
+
 #if UNITY_EDITOR
 // In custom editor or after programmatic changes
 UdonSharpEditorUtility.CopyProxyToUdon(behaviour);
 EditorUtility.SetDirty(behaviour);
 #endif
+
 ```
 
 ---
@@ -1173,17 +1269,20 @@ This commonly happens when AI agents automate Unity setup (Unity MCP servers, cu
 Prefer the UdonSharp helper that wires `programSource` automatically:
 
 ```csharp
+
 #if UNITY_EDITOR && !COMPILER_UDONSHARP
 using UdonSharpEditor;
 
     // Creates UdonBehaviour AND sets programSource in one call
     MyScript script = gameObject.AddUdonSharpComponent<MyScript>();
 #endif
+
 ```
 
 If the `UdonBehaviour` was created without `AddUdonSharpComponent`, assign manually:
 
 ```csharp
+
 #if UNITY_EDITOR && !COMPILER_UDONSHARP
 using UnityEditor;
 
@@ -1195,6 +1294,7 @@ using UnityEditor;
     ub.programSource = programAsset;
     EditorUtility.SetDirty(ub);
 #endif
+
 ```
 
 Or, in the Inspector, drag the `.asset` from the Project window into the `Program Source` slot.
@@ -1212,7 +1312,9 @@ When automating UdonBehaviour creation, verify `programSource` is set as a post-
 **Checklist:**
 
 1. **Disable Update() when not needed:**
+
 ```csharp
+
 // Don't do this
 void Update()
 {
@@ -1235,16 +1337,22 @@ void Update()
 {
     // Only runs when enabled
 }
+
 ```
 
 2. **Reduce cross-script calls:**
+
 ```csharp
+
 // Cross-script calls have ~1.5x overhead
 // Use partial classes for large scripts instead
+
 ```
 
 3. **Cache component references:**
+
 ```csharp
+
 // Wrong - GetComponent every frame
 void Update()
 {
@@ -1263,6 +1371,7 @@ void Update()
 {
     _renderer.material.color = newColor;
 }
+
 ```
 
 4. **Use spatial partitioning:**
@@ -1280,7 +1389,9 @@ void Update()
 **Solution:**
 
 1. **Reduce sync frequency:**
+
 ```csharp
+
 // Don't sync every frame
 private float _lastSyncTime;
 private const float SYNC_INTERVAL = 0.1f; // 10 times per second
@@ -1293,25 +1404,32 @@ void Update()
         _lastSyncTime = Time.time;
     }
 }
+
 ```
 
 2. **Use smaller data types:**
+
 ```csharp
+
 // byte = 1 byte, int = 4 bytes
 [UdonSynced] private byte smallValue; // 0-255 range
 
 // short = 2 bytes
 [UdonSynced] private short mediumValue; // -32768 to 32767
+
 ```
 
 3. **Use Continuous sync mode for smoothly changing values:**
+
 ```csharp
+
 [UdonBehaviourSyncMode(BehaviourSyncMode.Continuous)]
 public class SmoothSync : UdonSharpBehaviour
 {
     [UdonSynced(UdonSyncMode.Smooth)] // Interpolated locally
     private Vector3 position;
 }
+
 ```
 
 ---
@@ -1321,7 +1439,9 @@ public class SmoothSync : UdonSharpBehaviour
 ### Start() Not Called on Inactive Objects
 
 **Problem:**
+
 ```csharp
+
 // Inactive GameObjects do not call Start()
 public class BrokenGimmick : UdonSharpBehaviour
 {
@@ -1338,6 +1458,7 @@ public class BrokenGimmick : UdonSharpBehaviour
         audioSource.Play(); // NullReferenceException!
     }
 }
+
 ```
 
 **Symptoms:**
@@ -1346,7 +1467,9 @@ public class BrokenGimmick : UdonSharpBehaviour
 - "Should work but doesn't" situation
 
 **Solution:**
+
 ```csharp
+
 // OnEnable + initialization flag pattern
 public class RobustGimmick : UdonSharpBehaviour
 {
@@ -1380,6 +1503,7 @@ public class RobustGimmick : UdonSharpBehaviour
         }
     }
 }
+
 ```
 
 **Situations where this occurs:**
@@ -1393,13 +1517,18 @@ public class RobustGimmick : UdonSharpBehaviour
 ### Field Initializers Not Working
 
 **Problem:**
+
 ```csharp
+
 // This doesn't work as expected
 public int maxHealth = 100; // Serialized value from Inspector wins
+
 ```
 
 **Solution:**
+
 ```csharp
+
 // Use Start() or explicit initialization
 private int _maxHealth;
 
@@ -1410,6 +1539,7 @@ void Start()
         _maxHealth = 100;
     }
 }
+
 ```
 
 ---
@@ -1417,24 +1547,33 @@ void Start()
 ### GetComponent Returns Proxy Instead of UdonSharpBehaviour
 
 **Problem:**
+
 ```csharp
+
 // Returns UdonBehaviour, not your type
 var myScript = other.GetComponent<MyScript>();
+
 ```
 
 **Solution (Runtime):**
+
 ```csharp
+
 // Cast works at runtime in VRChat
 var myScript = (MyScript)other.GetComponent(typeof(UdonBehaviour));
+
 ```
 
 **Solution (Editor):**
+
 ```csharp
+
 #if UNITY_EDITOR
 var myScript = other.GetUdonSharpComponent<MyScript>();
 #else
 var myScript = (MyScript)other.GetComponent(typeof(UdonBehaviour));
 #endif
+
 ```
 
 ---
@@ -1442,16 +1581,22 @@ var myScript = (MyScript)other.GetComponent(typeof(UdonBehaviour));
 ### Struct Modifications Not Persisting
 
 **Problem:**
+
 ```csharp
+
 transform.position.x = 5; // Doesn't work!
+
 ```
 
 **Solution:**
+
 ```csharp
+
 // Assign full struct
 Vector3 pos = transform.position;
 pos.x = 5;
 transform.position = pos;
+
 ```
 
 ---
@@ -1461,7 +1606,9 @@ transform.position = pos;
 **Problem:** No built-in way to cancel delayed events.
 
 **Solution:**
+
 ```csharp
+
 private bool _shouldExecute = true;
 
 public void ScheduleAction()
@@ -1480,6 +1627,7 @@ public void DelayedAction()
     if (!_shouldExecute) return;
     // Do action
 }
+
 ```
 
 ---
@@ -1489,7 +1637,9 @@ public void DelayedAction()
 **Problem:** Holding a `VRCPlayerApi` reference, but the player has left.
 
 **Solution:**
+
 ```csharp
+
 // Wrong - Storing reference
 private VRCPlayerApi _targetPlayer;
 
@@ -1513,6 +1663,7 @@ public VRCPlayerApi GetTarget()
     }
     return player;
 }
+
 ```
 
 ---
@@ -1522,6 +1673,7 @@ public VRCPlayerApi GetTarget()
 ### Logging Best Practices
 
 ```csharp
+
 // Use consistent format
 private void Log(string message)
 {
@@ -1538,11 +1690,13 @@ private void LogDebug(string message)
         Debug.Log($"[DEBUG:{gameObject.name}] {message}");
     }
 }
+
 ```
 
 ### State Visualization
 
 ```csharp
+
 // Show state in world using TextMeshPro
 public TextMeshProUGUI debugText;
 
@@ -1555,11 +1709,13 @@ void Update()
                         $"IsLocal: {Networking.IsOwner(gameObject)}";
     }
 }
+
 ```
 
 ### Network Debugging
 
 ```csharp
+
 public override void OnPreSerialization()
 {
     LogDebug($"Sending: value={_syncedValue}");
@@ -1574,6 +1730,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 {
     LogDebug($"Ownership -> {player.displayName}");
 }
+
 ```
 
 ---
@@ -1617,15 +1774,19 @@ For errors not covered in this document, follow these investigation steps:
 ### Step 1: Search Official Docs (WebSearch)
 
 ```yaml
+
 WebSearch: "error message or keyword site:creators.vrchat.com"
+
 ```
 
 ### Step 2: Search VRChat Forums (WebSearch)
 
 ```yaml
+
 WebSearch:
   query: "error message site:ask.vrchat.com"
   allowed_domains: ["ask.vrchat.com"]
+
 ```
 
 Look for solutions from community members who encountered the same issue.
@@ -1633,9 +1794,11 @@ Look for solutions from community members who encountered the same issue.
 ### Step 3: Search Canny (Known Bugs)
 
 ```yaml
+
 WebSearch:
   query: "error message site:feedback.vrchat.com"
   allowed_domains: ["feedback.vrchat.com"]
+
 ```
 
 Check whether VRChat officially recognizes the bug and if workarounds exist.
@@ -1643,9 +1806,11 @@ Check whether VRChat officially recognizes the bug and if workarounds exist.
 ### Step 4: Search GitHub Issues
 
 ```yaml
+
 WebSearch:
   query: "error message site:github.com/vrchat-community/UdonSharp"
   allowed_domains: ["github.com"]
+
 ```
 
 Check for UdonSharp-specific bugs and fix status.

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md
@@ -5,7 +5,7 @@ See `../references/sync-examples.md` for practical patterns and code examples.
 
 ## Decision Tree
 
-```
+```text
 Q1: Does it need to be visible to other players?
   No  -> No sync (no [UdonSynced], NoVariableSync)
   Yes -> Q2

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -22,7 +22,7 @@
 
 ### Checklist
 
-```
+```text
 □ VRCWorld prefab × 1
 □ Spawns configured
 □ Respawn Height set (below the floor)
@@ -44,7 +44,7 @@
 
 ### Spawn Order
 
-```
+```text
 Sequential: 0 → 1 → 2 → 0 → 1 (in order)
 Random:     Random selection
 Demo:       All players at Spawns[0]
@@ -66,7 +66,7 @@ Demo:       All players at Spawns[0]
 
 ### VRC_Pickup Setup
 
-```
+```text
 [GameObject]
 ├── Collider (IsTrigger recommended)
 ├── Rigidbody
@@ -87,7 +87,7 @@ OnPickupUseUp()      // Trigger released
 
 ### VRC_Station Setup
 
-```
+```text
 [GameObject]
 ├── Collider
 └── VRC_Station
@@ -190,7 +190,7 @@ Physics.Raycast(origin, dir, out hit, distance, playerMask);
 
 ### Optimization Checklist
 
-```
+```text
 □ Light baking complete
 □ Realtime lights ≤ 1
 □ Mirror default OFF
@@ -206,7 +206,7 @@ Physics.Raycast(origin, dir, out hit, distance, playerMask);
 
 ### Quick Setup
 
-```
+```text
 ✅ DO:
 ├── Lightmapper: Progressive GPU
 ├── Light Mode: Baked / Mixed
@@ -230,7 +230,7 @@ Physics.Raycast(origin, dir, out hit, distance, playerMask);
 
 ### Light Probes
 
-```
+```text
 Placement locations:
 ✅ Where players walk
 ✅ Light/dark boundaries
@@ -287,7 +287,7 @@ OnVideoReady()
 
 ### Pre-Upload Checklist
 
-```
+```text
 □ VRC_SceneDescriptor × 1
 □ Spawns configured
 □ Respawn Height appropriate
@@ -300,7 +300,7 @@ OnVideoReady()
 
 ### Upload Procedure
 
-```
+```text
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. Check & fix Validations
@@ -324,7 +324,7 @@ OnVideoReady()
 
 ### Content Warnings
 
-```
+```text
 □ Adult Language
 □ Blood/Gore
 □ Fear/Horror

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -127,7 +127,7 @@ If a world runs at 72 FPS on Quest with a single test client, it will typically 
 
 Exactly **one** is required in every VRChat world.
 
-```
+```text
 [VRCWorld Prefab]
 ├── VRC_SceneDescriptor (Required)
 ├── VRC_PipelineManager (Auto-added)
@@ -178,7 +178,7 @@ Exactly **one** is required in every VRChat world.
 
 ### Required Setup Checklist
 
-```
+```text
 □ Exactly one VRCWorld Prefab exists in the scene
 □ At least one Transform set in Spawns
 □ Respawn Height set to an appropriate value (well below the floor)
@@ -236,7 +236,7 @@ Exactly **one** is required in every VRChat world.
 
 ### Layer Setup Steps
 
-```
+```text
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. Click "Setup Layers for VRChat"
@@ -281,7 +281,7 @@ Exactly **one** is required in every VRChat world.
 
 If FPS is below target, follow this workflow — measure before guessing:
 
-```
+```text
 1. Measure
    ├── Unity Profiler: standard profiling in Play mode (primary; Deep Profile only for function-level deep dives — avoid on Quest, misleading results)
    ├── VRChat overlay: type "/perf" in-game
@@ -313,7 +313,7 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 ### Baked Lighting (Required)
 
-```
+```text
 ✅ Recommended settings:
 ├── Lightmapper: Progressive GPU
 ├── Lightmap Resolution: 10-20 texels/unit
@@ -361,7 +361,7 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 ### Upload Steps
 
-```
+```text
 1. Check Validation
    └── VRChat SDK > Build Panel > Validations
 
@@ -380,7 +380,7 @@ If FPS is below target, follow this workflow — measure before guessing:
 
 ### Pre-Upload Checklist
 
-```
+```text
 □ VRC_SceneDescriptor × 1
 □ Spawns configured
 □ Respawn Height appropriate

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -28,7 +28,7 @@ Complete guide for audio and video configuration.
 
 ### Audio System Architecture
 
-```
+```text
 [Audio Source]
 ├── Unity AudioSource (base functionality)
 └── VRC_SpatialAudioSource (extended functionality)
@@ -57,7 +57,7 @@ VRC_SpatialAudioSource is added alongside a Unity AudioSource.
 
 ### Distance Attenuation Model
 
-```
+```text
 Near = 2m, Far = 10m example:
 
 Distance(m): 0    2    4    6    8    10   12
@@ -70,7 +70,7 @@ Far = Attenuation end (0%)
 
 ### Volumetric Radius
 
-```
+```text
 Volumetric Radius = 0 (point source):
 - Calculated from listener-to-source distance
 - For small objects
@@ -85,7 +85,7 @@ Volumetric Radius > 0 (volumetric source):
 
 #### Ambient Sound (BGM)
 
-```
+```text
 AudioSource:
 ├── Spatial Blend: 0 (2D)
 ├── Loop: true
@@ -99,7 +99,7 @@ VRC_SpatialAudioSource:
 
 #### 3D Sound Effects (footsteps, doors)
 
-```
+```text
 AudioSource:
 ├── Spatial Blend: 1 (3D)
 ├── Loop: false
@@ -115,7 +115,7 @@ VRC_SpatialAudioSource:
 
 #### Wide Area Source (waterfall, crowd)
 
-```
+```text
 AudioSource:
 ├── Spatial Blend: 1 (3D)
 ├── Loop: true
@@ -210,7 +210,7 @@ The initial Steam Audio release is designed to **match ONSP behavior**. Advanced
 
 For the initial release, behavior is intentionally preserved:
 
-```
+```text
 Initial Steam Audio release:
 ├── Same Near/Far attenuation curves as ONSP
 ├── Same VRC_SpatialAudioSource property semantics
@@ -239,7 +239,7 @@ These APIs control per-player voice spatialization and remain the correct way to
 
 When Steam Audio becomes the default (no action required before then):
 
-```
+```text
 VRC_SpatialAudioSource components:
 □ Verify Near/Far values still achieve the intended effect
 □ Check Gain values — behavior is preserved but double-check critical audio
@@ -291,7 +291,7 @@ No world-side changes are required to test in the beta.
 
 ### Selection Guide
 
-```
+```text
 Use AVPro:
 ✅ Want to play YouTube/Twitch URLs
 ✅ Want to display live streams
@@ -309,7 +309,7 @@ Use Unity Video Player:
 
 ### AVPro Video Player
 
-```
+```text
 [Setup]
 1. Use the VRCAVProVideoPlayer Prefab included in the VRChat SDK
 2. Or add the VRC_AVProVideoPlayer component
@@ -331,7 +331,7 @@ Use Unity Video Player:
 
 ### Unity Video Player
 
-```
+```text
 [Setup]
 1. Use the VRCUnityVideoPlayer Prefab
 2. Or add the VRC_UnityVideoPlayer component
@@ -355,7 +355,7 @@ Use Unity Video Player:
 
 ### AVPro Video Player Setup
 
-```
+```text
 [AVPro Video Player Object]
 ├── VRC_AVProVideoPlayer
 │   ├── Auto Play: false (recommended)
@@ -372,7 +372,7 @@ Use Unity Video Player:
 
 ### Unity Video Player Setup
 
-```
+```text
 [Unity Video Player Object]
 ├── VRC_UnityVideoPlayer
 │   ├── Auto Play: false (recommended)
@@ -493,7 +493,7 @@ public class SyncedVideoPlayer : UdonSharpBehaviour
 
 ### Audio Optimization
 
-```
+```text
 Compression settings:
 
 BGM (long audio):
@@ -517,7 +517,7 @@ Ambient sounds (looping):
 
 ### Video Optimization
 
-```
+```text
 ⚠️ Limitations:
 
 Video players per world:
@@ -536,7 +536,7 @@ Resolution settings:
 
 ### Memory Considerations
 
-```
+```text
 Video player memory impact:
 
 RenderTexture size:
@@ -616,7 +616,7 @@ Debug.Log($"Video playing: {videoPlayer.IsPlaying}");
 
 ### VRC_SpatialAudioSource Defaults
 
-```
+```text
 Gain: 0 dB (World: +10 dB)
 Near: 0 m
 Far: 40 m

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -94,7 +94,7 @@ Allows players to grab objects.
 
 ### Required Setup
 
-```
+```text
 [Pickup GameObject]
 ├── Collider (Required)
 │   └── IsTrigger = true recommended
@@ -200,7 +200,7 @@ Creates a location where players can sit.
 
 ### Required Setup
 
-```
+```text
 [Station GameObject]
 ├── Collider (Required - for Interact)
 └── VRC_Station
@@ -261,7 +261,7 @@ public class StationController : UdonSharpBehaviour
 
 ### Avatar Station Rules
 
-```
+```text
 ⚠️ Additional restrictions for Stations on avatars:
 - Maximum 6 Stations
 - Station Descriptor (red box) must be enabled at upload time
@@ -341,7 +341,7 @@ Creates a mirror.
 
 ### Performance Warning
 
-```
+```text
 ⚠️ Significant performance impact:
 - Renders the entire scene an additional time
 - VR: Both eyes × 2 = 4x rendering
@@ -428,7 +428,7 @@ Creates a portal to another world.
 
 ### Setup
 
-```
+```text
 [Portal GameObject] ← Place at the root of the scene hierarchy
 ├── VRC_PortalMarker
 │   ├── World ID: wrld_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -438,7 +438,7 @@ Creates a portal to another world.
 
 ### Important Restrictions
 
-```
+```text
 ⚠️ Portals must be placed at the root of the scene hierarchy
    Instance information from preceding players is synced to other players
 
@@ -485,7 +485,7 @@ Configures 3D spatial audio. Automatically added to AudioSource.
 
 ### Avatar Restrictions
 
-```
+```text
 ⚠️ AudioSource on avatars:
 - Gain limit: 10 dB
 - Far limit: 40 m
@@ -501,7 +501,7 @@ Enables VRChat interaction with Unity UI (Canvas).
 
 ### Setup
 
-```
+```text
 [Canvas GameObject]
 ├── Canvas (Render Mode: World Space)
 ├── VRC_UIShape
@@ -532,7 +532,7 @@ Enables VRChat interaction with Unity UI (Canvas).
 
 ### TextMeshPro Recommendation
 
-```
+```text
 ✅ TextMeshPro:
 - High-quality text rendering
 - Better readability in VR
@@ -552,7 +552,7 @@ Displays avatars and allows switching.
 
 ### Setup
 
-```
+```text
 [Pedestal GameObject]
 ├── VRC_AvatarPedestal
 │   └── Avatar ID: avtr_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -567,7 +567,7 @@ Moves the player's camera along a defined spline path (SDK 3.9+). Typically used
 
 ### Setup
 
-```
+```text
 [Dolly Track Root]
 ├── VRC_CameraDolly
 │   ├── Path (SplineContainer or CinemachinePath reference)
@@ -644,7 +644,7 @@ public class DollyController : UdonSharpBehaviour
 
 ### Ownership and Network Notes
 
-```
+```text
 - VRC_CameraDolly only affects the local player's camera.
 - Play/Stop calls are local — no network sync is built in.
 - To sync a cinematic across all players, call Play() via
@@ -768,7 +768,7 @@ Unity standard components available in VRChat.
 
 ### Disabled on Quest/Android
 
-```
+```text
 ❌ Dynamic Bones
 ❌ Cloth (allowed in worlds, not on avatars)
 ❌ Physics on Avatar (Rigidbody, Collider, Joint)

--- a/skills/unity-vrc-world-sdk-3/references/layers.md
+++ b/skills/unity-vrc-world-sdk-3/references/layers.md
@@ -61,7 +61,7 @@ VRChat uses Unity's layer system to organize GameObjects, control collisions, an
 
 ### Commonly Used Custom Layers
 
-```
+```text
 Layer 22: "Intangible" - Decorations with no collision
 Layer 23: "LocalOnly" - Local-only objects
 Layer 24: "TriggerZone" - Trigger zones only
@@ -74,7 +74,7 @@ Layer 25: "Projectiles" - Projectiles
 
 ### Default (Layer 0)
 
-```
+```text
 Purpose:
 - General objects
 - Objects that don't need special handling
@@ -86,7 +86,7 @@ Notes:
 
 ### Environment (Layer 11)
 
-```
+```text
 Purpose:
 - Walls, floors, ceilings
 - Walkable terrain
@@ -99,7 +99,7 @@ Characteristics:
 
 ### Pickup (Layer 13)
 
-```
+```text
 Purpose:
 - Objects with VRC_Pickup
 
@@ -111,7 +111,7 @@ Characteristics:
 
 ### PickupNoEnvironment (Layer 14)
 
-```
+```text
 Purpose:
 - Pickups that pass through environment
 - Objects that can be handed through walls
@@ -123,7 +123,7 @@ Characteristics:
 
 ### Walkthrough (Layer 17)
 
-```
+```text
 Purpose:
 - Walk-through objects
 - Visual barriers
@@ -136,7 +136,7 @@ Characteristics:
 
 ### MirrorReflection (Layer 18)
 
-```
+```text
 Purpose:
 - Objects to display in mirrors
 - Mirror-only layer
@@ -152,13 +152,13 @@ Notes:
 
 ### Checking the Current Matrix
 
-```
+```text
 Edit > Project Settings > Physics > Layer Collision Matrix
 ```
 
 ### VRChat Default Collision Matrix
 
-```
+```text
 Important collision pairs:
 
 ✅ Collide:
@@ -237,7 +237,7 @@ void Start()
 
 ### Recommendations
 
-```
+```text
 ✅ Choose the appropriate layer:
 - Floors, walls → Environment
 - Grabbable items → Pickup
@@ -250,7 +250,7 @@ void Start()
 
 ### Prohibited Actions
 
-```
+```text
 ❌ Avoid:
 - Renaming VRChat reserved layers
 - Using Player/PlayerLocal layers (VRChat exclusive)
@@ -287,7 +287,7 @@ Debug.Log($"Layers {layerA} and {layerB} collision: {willCollide}");
 
 ### Layer Number List
 
-```
+```text
 0  = Default
 9  = Player
 10 = PlayerLocal

--- a/skills/unity-vrc-world-sdk-3/references/lighting.md
+++ b/skills/unity-vrc-world-sdk-3/references/lighting.md
@@ -26,6 +26,7 @@ Lighting settings and optimization guide for VRChat worlds.
 ### Recommended Approach
 
 ```text
+
 ✅ Recommended:
 1. Environment lights → Baked
 2. Light Probes → For dynamic objects
@@ -35,6 +36,7 @@ Lighting settings and optimization guide for VRChat worlds.
 1. Realtime lights (dynamic shadows)
 2. Excessive lightmap resolution
 3. Many Mixed lights
+
 ```
 
 ---
@@ -44,6 +46,7 @@ Lighting settings and optimization guide for VRChat worlds.
 ### Lightmap Settings
 
 ```text
+
 Window > Rendering > Lighting
 
 Recommended settings:
@@ -56,11 +59,13 @@ Recommended settings:
 │   ├── Max Distance: 1-3
 │   └── Indirect/Direct Contribution: 0.5-1
 └── Directional Mode: Non-Directional (Quest)
+
 ```
 
 ### Object Settings
 
 ```text
+
 Static objects (Static):
 ├── Inspector > Static check
 ├── Contribute GI: ✅
@@ -69,17 +74,20 @@ Static objects (Static):
 Dynamic objects:
 ├── Contribute GI: ❌
 └── Receive GI: Light Probes
+
 ```
 
 ### Baking Procedure
 
 ```text
+
 1. Set all lights to Baked/Mixed
 2. Mark static objects as Static
 3. Place Light Probes
 4. Click "Generate Lighting" in the Lighting window
 5. Wait for completion (minutes to hours)
 6. Review results and adjust as needed
+
 ```
 
 ---
@@ -89,16 +97,19 @@ Dynamic objects:
 ### Purpose
 
 ```text
+
 Light Probes:
 - Apply baked lighting influence to
   dynamic objects (players, pickups)
 - For objects that can't use Lightmaps
 - Achieve dynamic lighting effects at low cost
+
 ```
 
 ### Placement Guidelines
 
 ```text
+
 Place at:
 ✅ Where players walk
 ✅ Light/dark boundaries
@@ -110,26 +121,31 @@ Do NOT place at:
 ❌ Inside walls
 ❌ Unreachable areas
 ❌ Areas with only static objects
+
 ```
 
 ### Creation Steps
 
 ```text
+
 1. GameObject > Light > Light Probe Group
 2. Click Edit Light Probes button
 3. Add/move probes
 4. Place in 3D (not just on the floor, include height)
 5. Update with Generate Lighting
+
 ```
 
 ### Placement Density
 
 ```text
+
 Recommended density:
 ├── Indoor corridors: 2-3m intervals
 ├── Large open spaces: 3-5m intervals
 ├── Light/dark boundaries: 1m or less
 └── Height: Multiple levels at 0.5m, 1.5m, 3m, etc.
+
 ```
 
 ---
@@ -139,15 +155,18 @@ Recommended density:
 ### Purpose
 
 ```text
+
 Reflection Probes:
 - Provide environmental reflections
 - Improve quality of metallic/glossy surfaces
 - Alternative to realtime reflections
+
 ```
 
 ### Settings
 
 ```text
+
 Recommended settings:
 ├── Type: Baked (avoid Realtime)
 ├── Resolution: 128-256
@@ -155,11 +174,13 @@ Recommended settings:
 ├── Box Projection: Only when needed
 ├── Importance: 1 (default)
 └── Blend Distance: 1-3
+
 ```
 
 ### Placement
 
 ```text
+
 Place at:
 ├── One per room
 ├── One large one outdoors
@@ -169,6 +190,7 @@ Place at:
 Notes:
 - Too many increases overhead
 - Proper Bounds settings are important
+
 ```
 
 ---
@@ -178,6 +200,7 @@ Notes:
 ### Quest-Specific Settings
 
 ```text
+
 Required:
 ├── All lights set to Baked
 ├── Directional Mode: Non-Directional
@@ -189,11 +212,13 @@ Recommended shaders:
 ├── Mobile/VRChat/Lightmapped
 ├── Mobile/Diffuse
 └── Mobile/Particles
+
 ```
 
 ### Quest Lighting Procedure
 
 ```text
+
 1. Switch Platform to Android
 2. Remove all Realtime lights
 3. Change Mixed → Baked
@@ -201,6 +226,7 @@ Recommended shaders:
 5. Place Light Probes
 6. Generate Lighting
 7. Test on Quest hardware
+
 ```
 
 ---
@@ -210,39 +236,51 @@ Recommended shaders:
 ### Blurry Lightmaps
 
 **Solution**:
+
 ```text
+
 1. Increase Lightmap Resolution (10→20)
 2. Increase Lightmap Size (1024→2048)
 3. Check object UV2
 4. Enable Generate Lightmap UVs
+
 ```
 
 ### Visible Seams
 
 **Solution**:
+
 ```text
+
 1. Increase Lightmap Padding (2→4)
 2. Check object scale
 3. Adjust UV2 seams
+
 ```
 
 ### Dark Dynamic Objects
 
 **Solution**:
+
 ```text
+
 1. Place Light Probes
 2. Set Receive GI to Light Probes
 3. Re-run Generate Lighting
+
 ```
 
 ### Slow Baking
 
 **Solution**:
+
 ```text
+
 1. Use Progressive GPU
 2. Lower Lightmap Resolution
 3. Remove unnecessary objects from Static
 4. Reduce Bounces (2-3)
+
 ```
 
 ---
@@ -250,6 +288,7 @@ Recommended shaders:
 ## Shader Global Variables
 
 ```csharp
+
 // Lighting-related shader variables
 // _VRChatCameraMode:
 //   0 = Normal
@@ -258,6 +297,7 @@ Recommended shaders:
 //   3 = Screenshot
 
 // Available for use in custom shaders
+
 ```
 
 ---
@@ -267,6 +307,7 @@ Recommended shaders:
 ### Settings Checklist
 
 ```text
+
 □ All lights are Baked/Mixed
 □ Static objects are marked Static
 □ Light Probes placed
@@ -274,6 +315,7 @@ Recommended shaders:
 □ Lightmaps baked
 □ Quest: Realtime lights = 0
 □ Quest: Directional Mode = Non-Directional
+
 ```
 
 ### Performance Guidelines
@@ -313,9 +355,12 @@ Bounces control how many times indirect light reflects off surfaces. More bounce
 | PC | 3–4 | Use 4 only for complex interiors with many reflective surfaces (approximate guideline — adjust based on profiling) |
 
 In Unity Lighting Settings:
+
 ```text
+
 Window > Rendering > Lighting > Lightmapping Settings
 └── Indirect Bounces: 2  (Quest)  /  3  (PC)
+
 ```
 
 ### Baked vs Mixed Lighting: Quest Guidance
@@ -323,11 +368,13 @@ Window > Rendering > Lighting > Lightmapping Settings
 On Quest, **Baked lighting is strongly preferred over Mixed**. Use this decision guide:
 
 ```text
+
 Does the world have any moving lights or real-time shadows?
 ├── Yes → Is this required? (gameplay mechanic, not just aesthetics)
 │   ├── Yes → Use Mixed (PC only); remove or replace with Baked on Android build
 │   └── No  → Switch to Baked and use light probes for dynamics
 └── No  → Use Baked for everything
+
 ```
 
 | Mode | Quest Support | Notes |
@@ -344,6 +391,7 @@ Practical rule: **convert all Mixed lights to Baked before the Android build**. 
 Baked AO adds depth cues where surfaces meet, at zero runtime cost. Screen-space AO (SSAO) is unavailable on Quest.
 
 ```text
+
 Window > Rendering > Lighting > Lightmapping Settings
 
 Recommended settings for Quest:
@@ -353,6 +401,7 @@ Recommended settings for Quest:
 └── Direct AO:          0 (default — direct AO can look artificial)
 
 PC can use higher Max Distance (2–3 m) for richer results.
+
 ```
 
 > Baked AO is included in the base lightmap texture — no extra textures or memory.
@@ -387,6 +436,7 @@ Aim for one probe per enclosed room and one large probe outdoors. Avoid overlapp
 ## Lighting Workflow Summary: PC vs Quest
 
 ```text
+
 PC Build                           Quest/Android Build
 ────────────────────────────────   ──────────────────────────────────
 Resolution: 10–20 texels/unit      Resolution: 5–10 texels/unit
@@ -397,6 +447,7 @@ Compress:   Optional               Compress:   Required
 AO:         Optional (baked)       AO:         Baked only (no SSAO)
 Refl. res:  256                    Refl. res:  128
 Lights:     Mixed or Baked         Lights:     Baked only
+
 ```
 
 ## See Also

--- a/skills/unity-vrc-world-sdk-3/references/lighting.md
+++ b/skills/unity-vrc-world-sdk-3/references/lighting.md
@@ -25,7 +25,7 @@ Lighting settings and optimization guide for VRChat worlds.
 
 ### Recommended Approach
 
-```
+```text
 ✅ Recommended:
 1. Environment lights → Baked
 2. Light Probes → For dynamic objects
@@ -43,7 +43,7 @@ Lighting settings and optimization guide for VRChat worlds.
 
 ### Lightmap Settings
 
-```
+```text
 Window > Rendering > Lighting
 
 Recommended settings:
@@ -60,7 +60,7 @@ Recommended settings:
 
 ### Object Settings
 
-```
+```text
 Static objects (Static):
 ├── Inspector > Static check
 ├── Contribute GI: ✅
@@ -73,7 +73,7 @@ Dynamic objects:
 
 ### Baking Procedure
 
-```
+```text
 1. Set all lights to Baked/Mixed
 2. Mark static objects as Static
 3. Place Light Probes
@@ -88,7 +88,7 @@ Dynamic objects:
 
 ### Purpose
 
-```
+```text
 Light Probes:
 - Apply baked lighting influence to
   dynamic objects (players, pickups)
@@ -98,7 +98,7 @@ Light Probes:
 
 ### Placement Guidelines
 
-```
+```text
 Place at:
 ✅ Where players walk
 ✅ Light/dark boundaries
@@ -114,7 +114,7 @@ Do NOT place at:
 
 ### Creation Steps
 
-```
+```text
 1. GameObject > Light > Light Probe Group
 2. Click Edit Light Probes button
 3. Add/move probes
@@ -124,7 +124,7 @@ Do NOT place at:
 
 ### Placement Density
 
-```
+```text
 Recommended density:
 ├── Indoor corridors: 2-3m intervals
 ├── Large open spaces: 3-5m intervals
@@ -138,7 +138,7 @@ Recommended density:
 
 ### Purpose
 
-```
+```text
 Reflection Probes:
 - Provide environmental reflections
 - Improve quality of metallic/glossy surfaces
@@ -147,7 +147,7 @@ Reflection Probes:
 
 ### Settings
 
-```
+```text
 Recommended settings:
 ├── Type: Baked (avoid Realtime)
 ├── Resolution: 128-256
@@ -159,7 +159,7 @@ Recommended settings:
 
 ### Placement
 
-```
+```text
 Place at:
 ├── One per room
 ├── One large one outdoors
@@ -177,7 +177,7 @@ Notes:
 
 ### Quest-Specific Settings
 
-```
+```text
 Required:
 ├── All lights set to Baked
 ├── Directional Mode: Non-Directional
@@ -193,7 +193,7 @@ Recommended shaders:
 
 ### Quest Lighting Procedure
 
-```
+```text
 1. Switch Platform to Android
 2. Remove all Realtime lights
 3. Change Mixed → Baked
@@ -210,7 +210,7 @@ Recommended shaders:
 ### Blurry Lightmaps
 
 **Solution**:
-```
+```text
 1. Increase Lightmap Resolution (10→20)
 2. Increase Lightmap Size (1024→2048)
 3. Check object UV2
@@ -220,7 +220,7 @@ Recommended shaders:
 ### Visible Seams
 
 **Solution**:
-```
+```text
 1. Increase Lightmap Padding (2→4)
 2. Check object scale
 3. Adjust UV2 seams
@@ -229,7 +229,7 @@ Recommended shaders:
 ### Dark Dynamic Objects
 
 **Solution**:
-```
+```text
 1. Place Light Probes
 2. Set Receive GI to Light Probes
 3. Re-run Generate Lighting
@@ -238,7 +238,7 @@ Recommended shaders:
 ### Slow Baking
 
 **Solution**:
-```
+```text
 1. Use Progressive GPU
 2. Lower Lightmap Resolution
 3. Remove unnecessary objects from Static
@@ -266,7 +266,7 @@ Recommended shaders:
 
 ### Settings Checklist
 
-```
+```text
 □ All lights are Baked/Mixed
 □ Static objects are marked Static
 □ Light Probes placed

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -12,7 +12,7 @@
 
 ### Performance Tiers
 
-```
+```text
 Excellent: 90+ FPS (PC), 72 FPS stable (Quest)
 Good: 60-90 FPS (PC), 60-72 FPS (Quest)
 Acceptable: 45-60 FPS (PC), 45-60 FPS (Quest)
@@ -25,7 +25,7 @@ Poor: < 45 FPS - improvement required
 
 ### 1. Mirrors
 
-```
+```text
 Impact: ⚠️ Very high
 
 Problem:
@@ -43,7 +43,7 @@ Countermeasures:
 
 ### 2. Video Players
 
-```
+```text
 Impact: ⚠️ High
 
 Problem:
@@ -58,7 +58,7 @@ Countermeasures:
 
 ### 3. Realtime Lights
 
-```
+```text
 Impact: ⚠️ High
 
 Problem:
@@ -74,7 +74,7 @@ Countermeasures:
 
 ### 4. Draw Calls
 
-```
+```text
 Impact: ⚠️ Medium to High
 
 Problem:
@@ -94,7 +94,7 @@ Countermeasures:
 
 ### Baked Lighting (Required)
 
-```
+```text
 ✅ Recommended settings:
 
 Lighting Settings:
@@ -111,7 +111,7 @@ Light Settings:
 
 ### Light Probes
 
-```
+```text
 Purpose:
 - Apply baked lighting influence to
   dynamic objects (players, pickups)
@@ -125,7 +125,7 @@ Placement:
 
 ### Reflection Probes
 
-```
+```text
 Purpose:
 - Improve reflection quality
 - Reduce load with baking
@@ -157,7 +157,7 @@ Settings:
 
 ### Quest/Android Shaders
 
-```
+```text
 ✅ Required:
 - Use Mobile shaders
 - Mobile/VRChat/Lightmapped (recommended)
@@ -171,7 +171,7 @@ Settings:
 
 ### Transparency Warning
 
-```
+```text
 ⚠️ Transparency (Alpha) issues:
 
 Mobile GPUs are weak at Alpha fill rate:
@@ -197,7 +197,7 @@ Countermeasures:
 
 ### Optimization Techniques
 
-```
+```text
 □ Set up LOD (Level of Detail)
 □ Enable Occlusion Culling
 □ Remove invisible meshes
@@ -222,7 +222,7 @@ Inspector:
 
 ### Setup
 
-```
+```text
 1. Window > Rendering > Occlusion Culling
 2. Set static objects as Occluder/Occludee
 3. Bake
@@ -235,7 +235,7 @@ Settings:
 
 ### Best Practices
 
-```
+```text
 □ Set walls, floors, ceilings as Occluder
 □ Small objects as Occludee only
 □ Don't set transparent objects as Occluder
@@ -262,7 +262,7 @@ Sound effects:
 
 ### Spatial Audio
 
-```
+```text
 □ Disable unnecessary audio sources
 □ Set Max Distance appropriately
 □ Fall back to 2D for distant sources
@@ -318,7 +318,7 @@ public void SlowUpdate()
 
 ### Quest Optimization Checklist
 
-```
+```text
 □ Polygon count < 100K
 □ Material count < 25
 □ Texture resolution ≤ 1024x1024
@@ -332,7 +332,7 @@ public void SlowUpdate()
 
 ### PC Optimization Checklist
 
-```
+```text
 □ 45+ FPS in VR
 □ Minimal realtime lights
 □ Mirror = default OFF
@@ -348,7 +348,7 @@ public void SlowUpdate()
 
 ### Unity Profiler
 
-```
+```text
 Window > Analysis > Profiler
 
 Items to check:
@@ -359,7 +359,7 @@ Items to check:
 
 ### Frame Debugger
 
-```
+```text
 Window > Analysis > Frame Debugger
 
 Use for:
@@ -370,7 +370,7 @@ Use for:
 
 ### VRChat Debug Menu
 
-```
+```text
 In-game checks:
 - FPS
 - Network stats
@@ -393,7 +393,7 @@ In-game checks:
 
 ## Quick Optimization Checklist
 
-```
+```text
 □ 45+ FPS (VR) achieved
 □ Light baking complete
 □ Realtime lights ≤ 1
@@ -429,7 +429,7 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 
 ### Features Not Available on Quest
 
-```
+```text
 ⚠️ Custom shaders (worlds only: allowed with caution; avoid complex HLSL/ShaderLab features that stress the mobile GPU. Avatar shaders are restricted to VRChat Mobile shaders.)
 ❌ Post-processing stack (any effect)
 ❌ Real-time shadow casting and receiving
@@ -443,7 +443,7 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 
 ### World Build Size Management
 
-```
+```text
 Target size breakdown (5–8 MB goal):
 
 Textures:       2–4 MB  (largest contributor — compress aggressively)
@@ -465,7 +465,7 @@ Reduction strategies:
 
 ### Texture Compression and Sizing
 
-```
+```text
 Quest-native format: ASTC (Adaptive Scalable Texture Compression)
 
 Settings per texture type:
@@ -489,7 +489,7 @@ Steps:
 
 ### Material Merging and Texture Atlasing
 
-```
+```text
 Goal: minimize unique material count (target < 25)
 
 Draw call reduction math:
@@ -508,7 +508,7 @@ Tools: Unity Sprite Atlas, third-party atlas packers, manual UV remap
 
 ### Mesh Optimization
 
-```
+```text
 LOD (Level of Detail) setup:
 ├── LOD0: full detail   (within ~10m)
 ├── LOD1: 50% tris      (10–30m)
@@ -529,7 +529,7 @@ Additional steps:
 
 ### Baked Lighting Workflow for Quest
 
-```
+```text
 Mandatory: all lighting must be baked before uploading the Quest build.
 
 Recommended settings for Quest:
@@ -551,7 +551,7 @@ Checklist:
 
 ### Draw Call Reduction
 
-```
+```text
 Target draw calls for Quest: < 50 (excellent), < 100 (acceptable)
 
 Techniques:
@@ -570,7 +570,7 @@ GPU Instancing in UdonSharp:
 
 ### Occlusion Culling for Quest
 
-```
+```text
 Occlusion culling is especially important on Quest due to limited fill rate.
 
 Aggressive settings for Quest:
@@ -593,7 +593,7 @@ Verify all items below before uploading a Quest-compatible world build.
 
 ### Build Size
 
-```
+```text
 □ Android build size after compression < 100 MB
 □ Targeting 5–8 MB for typical worlds
 □ No uncompressed or oversized textures (check via Project > Stats)
@@ -602,7 +602,7 @@ Verify all items below before uploading a Quest-compatible world build.
 
 ### Shaders and Materials
 
-```
+```text
 □ All materials use Mobile-compatible shaders:
     - Mobile/Diffuse
     - Mobile/Bumped Diffuse
@@ -616,7 +616,7 @@ Verify all items below before uploading a Quest-compatible world build.
 
 ### Lighting
 
-```
+```text
 □ Lighting fully baked (Window > Rendering > Lighting shows no pending bake)
 □ Realtime lights = 0 (or removed entirely)
 □ No Mixed lights with Shadowmask (baked-only mode required)
@@ -628,7 +628,7 @@ Verify all items below before uploading a Quest-compatible world build.
 
 ### Geometry
 
-```
+```text
 □ Total triangle count < 200K (target 50K–100K)
 □ LOD groups configured for all objects > 1K triangles
 □ No excessive particle systems (count ≤ 10, particles/system ≤ 100)
@@ -638,7 +638,7 @@ Verify all items below before uploading a Quest-compatible world build.
 
 ### Platform-Specific Features
 
-```
+```text
 □ No AVPro video player components — replaced with Unity Video Player
 □ No post-processing components (Post Process Volume, etc.)
 □ No real-time shadow settings on any light
@@ -648,7 +648,7 @@ Verify all items below before uploading a Quest-compatible world build.
 
 ### Testing
 
-```
+```text
 □ Build and Run targeting Android in Unity — check for shader errors
 □ Tested in VRChat on actual Quest hardware or using a Quest emulator
 □ Frame rate monitored: stable 72 FPS at spawn with 1 player
@@ -711,7 +711,7 @@ Reduce draw calls with Static Batching, GPU Instancing, and texture atlasing (se
 
 Quest uses the Qualcomm Adreno GPU, which natively supports **ASTC** (Adaptive Scalable Texture Compression). Always override textures to ASTC for the Android platform:
 
-```
+```text
 Inspector → Texture → Android override:
 ├── Format: ASTC 6x6 block  (diffuse, albedo — good quality/size balance)
 ├── Format: ASTC 4x4 block  (UI, normal maps — higher quality)

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -22,7 +22,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Error saying SceneDescriptor is missing during build
 
 **Solution**:
-```
+```text
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. "Add VRChat World" or add VRCWorld Prefab
@@ -46,7 +46,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Upload succeeded but world doesn't appear
 
 **Solution**:
-```
+```text
 1. Log in to the VRChat website
 2. Check "My Worlds"
 3. Check privacy settings
@@ -59,7 +59,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Build was cancelled
 
 **Solution**:
-```
+```text
 1. Check Unity Console for errors
 2. Resolve script compilation errors
 3. Fix Missing References
@@ -75,7 +75,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Appears at an unexpected location when joining
 
 **Solution**:
-```
+```text
 1. Check the VRC_SceneDescriptor Spawns array
 2. Confirm valid Transforms are set in Spawns
 3. Verify spawn positions aren't inside obstacles
@@ -87,7 +87,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Keeps respawning immediately after joining
 
 **Solution**:
-```
+```text
 1. Check Respawn Height
 2. Confirm spawn positions are above Respawn Height
 3. Verify spawn positions aren't below the floor
@@ -99,7 +99,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Camera settings aren't being applied
 
 **Solution**:
-```
+```text
 1. Confirm the Reference Camera's Camera component is disabled
 2. Verify it's correctly assigned to SceneDescriptor's Reference Camera field
 3. For Post Processing, also check the Volume
@@ -127,7 +127,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Grabbed object not visible to other players
 
 **Solution**:
-```
+```text
 1. Add VRC_ObjectSync component
 2. Confirm a Rigidbody exists
 3. Check Is Kinematic settings
@@ -138,7 +138,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't release a grabbed object
 
 **Solution**:
-```
+```text
 1. Check Auto Hold settings (SDK 3.9+)
 2. Check if an Udon script is preventing Drop
 3. Re-add the VRC_Pickup component
@@ -149,7 +149,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't interact with the Station
 
 **Solution**:
-```
+```text
 1. Check that a Collider exists
 2. Confirm VRC_Station's Disable Station Exit is false
 3. If using UseAttachedStation() in Udon,
@@ -161,7 +161,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't exit after sitting
 
 **Solution**:
-```
+```text
 1. If Disable Station Exit is true, set it to false
 2. Verify Exit Transform isn't inside an obstacle
 3. Implement forced exit in Udon
@@ -172,7 +172,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Nothing displays in the mirror
 
 **Solution**:
-```
+```text
 1. Check MirrorReflection layer settings
 2. Confirm the mirror is enabled
 3. Check the camera's Near/Far Clip
@@ -184,7 +184,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Synced object position differs between players
 
 **Solution**:
-```
+```text
 1. Call FlagDiscontinuity() on teleport
 2. Check Allow Collision Ownership Transfer settings
 3. Avoid frequent ownership transfers
@@ -199,7 +199,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Passes through walls or objects
 
 **Solution**:
-```
+```text
 1. Set walls to Environment layer
 2. Confirm a Collider exists
 3. Check Collider's Is Trigger is false
@@ -223,7 +223,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Specific objects don't appear in the mirror
 
 **Solution**:
-```
+```text
 1. Check the object's layer
 2. Verify relationship with MirrorReflection layer
 3. Confirm the object's Renderer is enabled
@@ -253,7 +253,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: FPS drops drastically when mirror is enabled
 
 **Solution**:
-```
+```text
 1. Lower mirror resolution
 2. Limit to 1 mirror
 3. Default OFF with toggle
@@ -265,7 +265,7 @@ Common problems encountered during world development and their solutions.
 **Symptom**: FPS drops near lights
 
 **Solution**:
-```
+```text
 1. Remove realtime lights
 2. Change to Mixed or Baked
 3. Bake lightmaps
@@ -347,7 +347,7 @@ public override void OnDeserialization()
 
 #### Step 1: Check Unity Console
 
-```
+```text
 Window > General > Console
 - Prioritize errors (red)
 - Also check warnings (yellow)
@@ -356,7 +356,7 @@ Window > General > Console
 
 #### Step 2: VRChat SDK Validation
 
-```
+```text
 VRChat SDK > Show Control Panel
 Builder tab > Validations section
 - Auto-fixable issues have buttons for fixing
@@ -374,13 +374,13 @@ Builder tab > "Build & Test New Build"
 
 #### Step 4: Search Official Documentation (WebSearch)
 
-```
+```yaml
 WebSearch: "error message or keyword site:creators.vrchat.com"
 ```
 
 #### Step 5: VRChat Forums Search (WebSearch)
 
-```
+```yaml
 WebSearch:
   query: "error message site:ask.vrchat.com"
   allowed_domains: ["ask.vrchat.com"]
@@ -388,7 +388,7 @@ WebSearch:
 
 #### Step 6: Canny (Known Bugs) Search
 
-```
+```yaml
 WebSearch:
   query: "issue site:feedback.vrchat.com"
   allowed_domains: ["feedback.vrchat.com"]
@@ -396,7 +396,7 @@ WebSearch:
 
 #### Step 7: GitHub Issues Search
 
-```
+```yaml
 WebSearch:
   query: "issue site:github.com/vrchat-community"
   allowed_domains: ["github.com"]

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -22,11 +22,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Error saying SceneDescriptor is missing during build
 
 **Solution**:
+
 ```text
+
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. "Add VRChat World" or add VRCWorld Prefab
 4. Confirm exactly 1 exists in the scene
+
 ```
 
 ### "Layer collision matrix needs setup"
@@ -34,11 +37,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Warning that layer settings are incorrect
 
 **Solution**:
+
 ```text
+
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. Click "Setup Layers for VRChat"
 4. Layers and collision matrix are automatically configured
+
 ```
 
 ### World not found after upload
@@ -46,12 +52,15 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Upload succeeded but world doesn't appear
 
 **Solution**:
+
 ```text
+
 1. Log in to the VRChat website
 2. Check "My Worlds"
 3. Check privacy settings
 4. Wait a few minutes (may take time to propagate)
 5. Restart the VRChat client
+
 ```
 
 ### "Build was cancelled"
@@ -59,11 +68,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Build was cancelled
 
 **Solution**:
+
 ```text
+
 1. Check Unity Console for errors
 2. Resolve script compilation errors
 3. Fix Missing References
 4. Build again
+
 ```
 
 ---
@@ -75,11 +87,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Appears at an unexpected location when joining
 
 **Solution**:
+
 ```text
+
 1. Check the VRC_SceneDescriptor Spawns array
 2. Confirm valid Transforms are set in Spawns
 3. Verify spawn positions aren't inside obstacles
 4. Confirm spawn Y coordinates are above Respawn Height
+
 ```
 
 ### Player continuously respawns
@@ -87,11 +102,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Keeps respawning immediately after joining
 
 **Solution**:
+
 ```text
+
 1. Check Respawn Height
 2. Confirm spawn positions are above Respawn Height
 3. Verify spawn positions aren't below the floor
 4. Set Respawn Height low enough (e.g., -100)
+
 ```
 
 ### Reference Camera not taking effect
@@ -99,10 +117,13 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Camera settings aren't being applied
 
 **Solution**:
+
 ```text
+
 1. Confirm the Reference Camera's Camera component is disabled
 2. Verify it's correctly assigned to SceneDescriptor's Reference Camera field
 3. For Post Processing, also check the Volume
+
 ```
 
 ---
@@ -114,12 +135,15 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't interact with or grab the object
 
 **Solution**:
+
 ```text
+
 1. Check that a Collider exists
 2. Check that a Rigidbody exists
 3. Confirm VRC_Pickup's Pickupable is true
 4. Verify the layer is correct (Pickup layer recommended)
 5. Confirm the Collider is enabled
+
 ```
 
 ### VRC_Pickup doesn't sync
@@ -127,10 +151,13 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Grabbed object not visible to other players
 
 **Solution**:
+
 ```text
+
 1. Add VRC_ObjectSync component
 2. Confirm a Rigidbody exists
 3. Check Is Kinematic settings
+
 ```
 
 ### Can't release VRC_Pickup
@@ -138,10 +165,13 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't release a grabbed object
 
 **Solution**:
+
 ```text
+
 1. Check Auto Hold settings (SDK 3.9+)
 2. Check if an Udon script is preventing Drop
 3. Re-add the VRC_Pickup component
+
 ```
 
 ### Can't sit in VRC_Station
@@ -149,11 +179,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't interact with the Station
 
 **Solution**:
+
 ```text
+
 1. Check that a Collider exists
 2. Confirm VRC_Station's Disable Station Exit is false
 3. If using UseAttachedStation() in Udon,
    verify the script is on the same object as the Station
+
 ```
 
 ### Can't exit VRC_Station
@@ -161,10 +194,13 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Can't exit after sitting
 
 **Solution**:
+
 ```text
+
 1. If Disable Station Exit is true, set it to false
 2. Verify Exit Transform isn't inside an obstacle
 3. Implement forced exit in Udon
+
 ```
 
 ### VRC_Mirror doesn't reflect
@@ -172,11 +208,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Nothing displays in the mirror
 
 **Solution**:
+
 ```text
+
 1. Check MirrorReflection layer settings
 2. Confirm the mirror is enabled
 3. Check the camera's Near/Far Clip
 4. Check mirror resolution
+
 ```
 
 ### VRC_ObjectSync is misaligned
@@ -184,10 +223,13 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Synced object position differs between players
 
 **Solution**:
+
 ```text
+
 1. Call FlagDiscontinuity() on teleport
 2. Check Allow Collision Ownership Transfer settings
 3. Avoid frequent ownership transfers
+
 ```
 
 ---
@@ -199,11 +241,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Passes through walls or objects
 
 **Solution**:
+
 ```text
+
 1. Set walls to Environment layer
 2. Confirm a Collider exists
 3. Check Collider's Is Trigger is false
 4. Verify Player and Environment collide in Collision Matrix
+
 ```
 
 ### Pickup falls through floor
@@ -211,11 +256,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Dropped objects fall through the floor
 
 **Solution**:
+
 ```text
+
 1. Set Pickup to Pickup layer
 2. Set floor to Environment layer
 3. Verify Pickup and Environment collide in Collision Matrix
 4. Set Rigidbody's Collision Detection to Continuous
+
 ```
 
 ### Object not visible in mirror
@@ -223,10 +271,13 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Specific objects don't appear in the mirror
 
 **Solution**:
+
 ```text
+
 1. Check the object's layer
 2. Verify relationship with MirrorReflection layer
 3. Confirm the object's Renderer is enabled
+
 ```
 
 ---
@@ -238,7 +289,9 @@ Common problems encountered during world development and their solutions.
 **Symptom**: Low frame rate
 
 **Solution**:
+
 ```text
+
 1. Set mirror to default OFF
 2. Reduce/remove realtime lights
 3. Bake lights
@@ -246,6 +299,7 @@ Common problems encountered during world development and their solutions.
 5. Reduce Draw Calls
 6. Reduce polygon count
 7. Lower texture resolution
+
 ```
 
 ### Mirror is slow
@@ -253,11 +307,14 @@ Common problems encountered during world development and their solutions.
 **Symptom**: FPS drops drastically when mirror is enabled
 
 **Solution**:
+
 ```text
+
 1. Lower mirror resolution
 2. Limit to 1 mirror
 3. Default OFF with toggle
 4. Implement auto-disable by distance
+
 ```
 
 ### Lighting is slow
@@ -265,12 +322,15 @@ Common problems encountered during world development and their solutions.
 **Symptom**: FPS drops near lights
 
 **Solution**:
+
 ```text
+
 1. Remove realtime lights
 2. Change to Mixed or Baked
 3. Bake lightmaps
 4. Place Light Probes
 5. Lower shadow quality
+
 ```
 
 ---
@@ -282,12 +342,15 @@ Common problems encountered during world development and their solutions.
 **Symptom**: SetOwner doesn't work
 
 **Solution**:
+
 ```csharp
+
 // Correct call:
 Networking.SetOwner(Networking.LocalPlayer, gameObject);
 
 // If VRC_ObjectSync is present:
 // Check Allow Collision Ownership Transfer settings
+
 ```
 
 ### State doesn't sync for Late Joiners
@@ -295,7 +358,9 @@ Networking.SetOwner(Networking.LocalPlayer, gameObject);
 **Symptom**: State not reflected for players who join later
 
 **Solution**:
+
 ```csharp
+
 // Apply state in OnDeserialization
 public override void OnDeserialization()
 {
@@ -304,6 +369,7 @@ public override void OnDeserialization()
 
 // VRC_ObjectSync auto-syncs
 // For Udon variables, use [UdonSynced] attribute
+
 ```
 
 ---
@@ -315,13 +381,16 @@ public override void OnDeserialization()
 **Symptom**: Works on PC but not on Quest
 
 **Solution**:
+
 ```text
+
 1. Verify with Android build target
 2. Change shaders to Mobile-compatible
 3. Remove Dynamic Bones (disabled on Quest)
 4. Remove Cloth (disabled on Quest)
 5. Remove Post Processing (disabled on Quest)
 6. Reduce polygon count (recommended under 100K)
+
 ```
 
 ### Poor performance on Quest
@@ -329,7 +398,9 @@ public override void OnDeserialization()
 **Symptom**: Low FPS on Quest
 
 **Solution**:
+
 ```text
+
 1. Polygon count: Under 100K
 2. Material count: Under 25
 3. Textures: 1024x1024 or less
@@ -337,6 +408,7 @@ public override void OnDeserialization()
 5. Shaders: Mobile/VRChat/Lightmapped
 6. Minimize transparency
 7. Remove or minimize mirrors
+
 ```
 
 ---
@@ -348,58 +420,72 @@ public override void OnDeserialization()
 #### Step 1: Check Unity Console
 
 ```text
+
 Window > General > Console
 - Prioritize errors (red)
 - Also check warnings (yellow)
 - Identify the source from the stack trace
+
 ```
 
 #### Step 2: VRChat SDK Validation
 
 ```text
+
 VRChat SDK > Show Control Panel
 Builder tab > Validations section
 - Auto-fixable issues have buttons for fixing
 - Follow instructions for manual fixes
+
 ```
 
 #### Step 3: Build and Test
 
 ```text
+
 VRChat SDK > Show Control Panel
 Builder tab > "Build & Test New Build"
 - Multi-player test with Number of Clients
 - Check debug information inside VRChat
+
 ```
 
 #### Step 4: Search Official Documentation (WebSearch)
 
 ```yaml
+
 WebSearch: "error message or keyword site:creators.vrchat.com"
+
 ```
 
 #### Step 5: VRChat Forums Search (WebSearch)
 
 ```yaml
+
 WebSearch:
   query: "error message site:ask.vrchat.com"
   allowed_domains: ["ask.vrchat.com"]
+
 ```
 
 #### Step 6: Canny (Known Bugs) Search
 
 ```yaml
+
 WebSearch:
   query: "issue site:feedback.vrchat.com"
   allowed_domains: ["feedback.vrchat.com"]
+
 ```
 
 #### Step 7: GitHub Issues Search
 
 ```yaml
+
 WebSearch:
   query: "issue site:github.com/vrchat-community"
   allowed_domains: ["github.com"]
+
 ```
 
 ---

--- a/skills/unity-vrc-world-sdk-3/references/upload.md
+++ b/skills/unity-vrc-world-sdk-3/references/upload.md
@@ -20,7 +20,7 @@ Complete upload procedure and best practices.
 
 ### Required Checks
 
-```
+```text
 □ Scene Setup
   □ Exactly 1 VRC_SceneDescriptor exists
   □ Transforms set in Spawns
@@ -51,7 +51,7 @@ Complete upload procedure and best practices.
 
 ### Recommended Checks
 
-```
+```text
 □ Local verification with Build & Test
 □ Multi-player testing conducted
 □ Quest support (if applicable)
@@ -65,7 +65,7 @@ Complete upload procedure and best practices.
 
 ### Local Testing Procedure
 
-```
+```text
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. "Build & Test New Build" section
@@ -76,7 +76,7 @@ Complete upload procedure and best practices.
 
 ### Test Items
 
-```
+```text
 Single Player Test:
 □ Spawn position is correct
 □ Respawn Height causes correct respawn
@@ -98,7 +98,7 @@ Multi-Player Test (multiple clients):
 
 ### Number of Clients Settings
 
-```
+```text
 Recommended by test purpose:
 
 Basic functionality: 1 client
@@ -117,7 +117,7 @@ Notes:
 
 ### Validation Check Procedure
 
-```
+```text
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. Check Validations section
@@ -137,7 +137,7 @@ Notes:
 
 ### Auto-Fix Feature
 
-```
+```text
 Some issues can be auto-fixed:
 
 Items with "Auto Fix" button:
@@ -157,7 +157,7 @@ Items that can't be auto-fixed:
 
 ### Upload Procedure
 
-```
+```text
 1. Confirm no Validation errors
 
 2. VRChat SDK > Show Control Panel
@@ -183,7 +183,7 @@ Items that can't be auto-fixed:
 
 ### Blueprint ID
 
-```
+```text
 Blueprint ID:
 - Unique identifier for the world
 - Stored in VRC_PipelineManager
@@ -200,7 +200,7 @@ Updating an existing world:
 
 ### World Thumbnail
 
-```
+```text
 Thumbnail settings:
 
 Method 1: Screenshot
@@ -232,7 +232,7 @@ Recommended specifications:
 
 ### Release Status
 
-```
+```text
 Private:
 - Only you and invited people can access
 - For testing and development
@@ -255,7 +255,7 @@ Public:
 
 ### Required Settings
 
-```
+```text
 Must be set if applicable:
 
 □ Adult Language
@@ -279,7 +279,7 @@ Must be set if applicable:
 
 ### Importance of Warning Settings
 
-```
+```text
 ⚠️ Warning:
 
 If not set:
@@ -308,7 +308,7 @@ Best practices:
 
 ### Configuration Guidelines
 
-```
+```text
 Recommended Capacity:
 - Number of players for comfortable play
 - Number where performance is maintained
@@ -327,7 +327,7 @@ Examples:
 
 ### Capacity Best Practices
 
-```
+```text
 ✅ Recommended:
 
 1. Determine through performance testing
@@ -355,7 +355,7 @@ Examples:
 
 ### Verification Items
 
-```
+```text
 1. Verify on VRChat website
    - https://vrchat.com/home/
    - "My Worlds" section
@@ -372,7 +372,7 @@ Examples:
 
 ### Notes After Updating
 
-```
+```text
 After update:
 - Existing instances remain on the old version
 - Only new instances use the new version
@@ -385,7 +385,7 @@ Propagation time:
 
 ### World Management
 
-```
+```text
 On the VRChat website:
 
 □ Change Release Status
@@ -415,7 +415,7 @@ On the VRChat website:
 
 #### World not found
 
-```
+```text
 Cause:
 1. Still set to Private
 2. Search index not yet updated
@@ -430,7 +430,7 @@ Solution:
 
 #### Upload takes too long
 
-```
+```text
 Cause:
 1. Build size is large
 2. Slow network
@@ -444,7 +444,7 @@ Solution:
 
 #### Changes not reflected
 
-```
+```text
 Cause:
 1. Joined an old instance
 2. Cache issue
@@ -458,7 +458,7 @@ Solution:
 
 ### Debug Checklist
 
-```
+```text
 □ No errors in Console
 □ All Validations pass
 □ Blueprint ID is correct
@@ -473,7 +473,7 @@ Solution:
 
 ### PC + Quest Cross-Platform
 
-```
+```yaml
 Procedure:
 
 1. Build for PC
@@ -495,7 +495,7 @@ Notes:
 
 ### Quest-Only World
 
-```
+```text
 Settings:
 
 1. Platform: Android
@@ -513,7 +513,7 @@ Notes:
 
 ### Upload Checklist (Minimum)
 
-```
+```text
 □ VRC_SceneDescriptor × 1
 □ Spawns configured
 □ Validation passed
@@ -524,7 +524,7 @@ Notes:
 
 ### SDK Panel Shortcuts
 
-```
+```text
 VRChat SDK > Show Control Panel
 
 Builder tab:


### PR DESCRIPTION
## Summary

- Adds language specifiers to all 191 bare opening code fences across `skills/` to satisfy the MD040 markdownlint rule
- 182 fences labeled `text` (ASCII diagrams, prose checklists, error messages, Inspector layouts, decision trees)
- 9 fences labeled `yaml` (genuine `WebSearch:` tool-call blocks in troubleshooting files)
- 0 net new `csharp` fences — all 475 C# examples were already specified; the 9 auto-detected candidates were manually confirmed to be ASCII art / pseudo-code / error strings

## Files modified (19)

| Skill | File | Fences fixed |
|---|---|---|
| udon-sharp | `CHEATSHEET.md` | 1 |
| udon-sharp | `references/api.md` | 1 |
| udon-sharp | `references/dynamics.md` | 2 |
| udon-sharp | `references/events.md` | 3 |
| udon-sharp | `references/image-loading-vram.md` | 5 |
| udon-sharp | `references/patterns-performance.md` | 1 |
| udon-sharp | `references/patterns-utilities.md` | 1 |
| udon-sharp | `references/patterns-video.md` | 3 |
| udon-sharp | `references/troubleshooting.md` | 13 |
| udon-sharp | `rules/udonsharp-sync-selection.md` | 1 |
| world-sdk-3 | `CHEATSHEET.md` | 10 |
| world-sdk-3 | `SKILL.md` | 7 |
| world-sdk-3 | `references/audio-video.md` | 17 |
| world-sdk-3 | `references/components.md` | 13 |
| world-sdk-3 | `references/layers.md` | 12 |
| world-sdk-3 | `references/lighting.md` | 18 |
| world-sdk-3 | `references/performance.md` | 35 |
| world-sdk-3 | `references/troubleshooting.md` | 22 |
| world-sdk-3 | `references/upload.md` | 26 |

## Verification

- `npx markdownlint-cli2 'skills/**/*.md' | grep MD040` → empty (zero violations)
- Fence balance check: 697 opening fences with specifiers == 697 closing bare fences across all files

Closes #212

## Test plan

- [ ] CI: Symlink Integrity passes
- [ ] CI: Hook Scripts passes
- [ ] CI: npm Pack Test passes
- [ ] CI: Markdown Links passes
- [ ] MD040 check clean (no bare fences remain)