### PR TITLE
feat(skills/udon-sharp): add context-preservation reference and pointers

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -99,7 +99,7 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（22ファイル）
+    references/                          # 詳細ドキュメント（23ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7ファイル）
 templates/                               # AIツール設定テンプレート

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,7 +99,7 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (22개 파일)
+    references/                          # 상세 문서 (23개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7개 파일)
 templates/                               # AI 도구 설정 템플릿

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (22 files)
+    references/                          # Detailed documentation (23 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7 files)
 templates/                               # AI tool config templates

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（22 个文件）
+    references/                          # 详细文档（23 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 个文件）
 templates/                               # AI 工具配置模板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（22 個檔案）
+    references/                          # 詳細文件（23 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 個檔案）
 templates/                               # AI 工具設定範本

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -35,6 +35,13 @@ Four architectural decisions that must be made before choosing sync modes or wri
 - **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Persistent state requires `[UdonSynced]` variables; the owner calls `RequestSerialization()` on join events to push current state to newcomers.
 - **What if the owner leaves mid-session?** Without explicit `OnPlayerLeft` handling, the object's synced state can never change again. Decide upfront: auto-transfer to master, reset to a known default, or the next interacting player claims ownership.
 
+## Context Preservation
+
+For complex synced systems, ownership-sensitive refactors, or work resumed after compaction/handoff, consider loading `references/context-preservation.md`.
+It provides a lightweight task-context note for source of truth, transport, sync mode, storage, ownership, late-joiner behavior, and validation rationale.
+This is optional guidance for complex work, not a step for small mechanical edits.
+Keep private data and raw transcripts out of any note.
+
 ## Core Principles
 
 1. **Constraints First** — Assume standard C# features are blocked until verified. Check `udonsharp-constraints.md` before using any API.
@@ -117,6 +124,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
+| Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
@@ -238,6 +246,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |
 | `testing.md` | Testing and debugging guide: ClientSim editor testing, Build and Test (single and multi-client), Debug.Log patterns, pre-release cleanup, testing checklist | ClientSim, Build and Test, multi-client, late joiner test, debug, Debug.Log, ownership test, sync test, testing checklist |
+| `context-preservation.md` | Context-preservation guide: recording task-specific design intent (source of truth, sync strategy, ownership, late-joiner behavior, validation) across context compaction/handoff; minimal task-context note; privacy guidance; resume checklist | context preservation, design intent, compaction, handoff, resume, task context note, why this design, ownership rationale, design-context loss |
 
 ## Templates (`assets/templates/`)
 

--- a/skills/unity-vrc-udon-sharp/references/context-preservation.md
+++ b/skills/unity-vrc-udon-sharp/references/context-preservation.md
@@ -1,0 +1,250 @@
+# Context Preservation for UdonSharp Agent Work
+
+Lightweight guide for keeping task-specific design intent available across long or resumed UdonSharp work.
+
+**Applies to:** all supported SDK versions
+
+This guide is optional and intended for complex work only. Use the format as a reusable note inside an existing task note, issue comment, scratchpad, or other user-approved location; it is not needed for trivial edits, and it does not ask for a new project file.
+
+## Table of Contents
+
+- [Why this exists](#why-this-exists)
+- [Rule loss vs design-context loss](#rule-loss-vs-design-context-loss)
+- [When to use a context-preservation note](#when-to-use-a-context-preservation-note)
+- [When not to use one](#when-not-to-use-one)
+- [Minimal task context note](#minimal-task-context-note)
+- [Concrete example](#concrete-example)
+- [Privacy notes](#privacy-notes)
+- [Resume checklist after compaction](#resume-checklist-after-compaction)
+- [See Also](#see-also)
+
+---
+
+## Why this exists
+
+The reusable UdonSharp constraints already live in rules, references, cheatsheets, templates, and validation hooks. Those files preserve shared knowledge: which APIs are available, how ownership works, what late joiners receive, and how to test networking behavior.
+
+Long agent tasks can lose a different kind of context: why this particular design was chosen. A later pass may remember that networking matters, yet miss that this door state is owner-written, restored from a synced variable, and intentionally not replayed from an event. The note below preserves that task-specific reasoning so resumed work does not rely only on conversation memory.
+
+The goal is small and practical. Capture the few decisions that would be expensive to rediscover: source of truth, event transport, sync mode, storage, ownership behavior, late joiner behavior, and validation status.
+
+---
+
+## Rule loss vs design-context loss
+
+### Rule loss
+
+Rule loss happens when an agent forgets reusable UdonSharp facts already documented elsewhere.
+
+Examples:
+
+- Treating a non-owner write to a synced field as authoritative.
+- Calling `RequestSerialization()` for Continuous sync, where automatic transmission is already expected.
+- Reading PlayerData or PlayerObject values before `OnPlayerRestored` has fired.
+- Expecting a network event to rebuild state for a player who joined after the event.
+
+Use the existing references for this class of problem. This note format is not a replacement for `networking.md`, `persistence.md`, or `testing.md`.
+
+### Design-context loss
+
+Design-context loss happens when the reusable rules are remembered, but the task-specific reason is gone.
+
+Examples:
+
+- A synced field exists, but the next pass cannot tell whether it is the source of truth or a transport copy.
+- A non-owner request path exists, but the ownership-transfer trigger is unclear.
+- A PlayerObject is involved, but the note does not say which reads wait for `OnPlayerRestored`.
+- A late-joiner bug was fixed, but the validation that proved it is not recorded.
+
+Use a context-preservation note to keep this local reasoning visible during complex work.
+
+---
+
+## When to use a context-preservation note
+
+Consider a note for work that includes any of these traits:
+
+- New synced systems or changes to existing synced state.
+- Ownership-sensitive interactions, late-joiner-sensitive behavior, or PlayerData/PlayerObject persistence.
+- Complex multi-file refactors where the design reason is easy to lose.
+- Work resumed after context compaction, restart, handoff, or split across multiple agent runs.
+
+---
+
+## When not to use one
+
+Skip the note for work where the design context is obvious from the diff:
+
+- Typo fixes.
+- Small documentation edits or formatting-only changes.
+- One-file mechanical updates or metadata-only maintenance.
+
+---
+
+## Minimal task context note
+
+This is a lightweight prompt, not a heavy planning framework. Keep only the fields that help the next pass continue safely.
+
+### Goal
+
+- Behavior being added, fixed, or preserved.
+- Existing behavior that should remain unchanged.
+
+### Relevant files
+
+- Edited files, reference files, validation files, scenes, or assets.
+
+### UdonSharp constraints relevant to this task
+
+- Constraints that shaped this task: ownership writes, sync mode, restore timing, unsupported APIs, or unsupported language features.
+
+### Source of truth
+
+Choose the authoritative state holder for this task:
+
+- Local-only state, scene object owner, instance master, or per-player owner.
+- PlayerObject state with automatic per-player ownership, PlayerData storage, or derived state.
+- Hybrid model; name the authoritative field or object for each part.
+
+Why this was chosen:
+
+- Record the reason this source is authoritative, and note which state is only cached or derived locally.
+
+### Transport (events)
+
+Choose how one-shot messages are transported, if any:
+
+- No network event, or local-only `SendCustomEvent`.
+- `SendCustomNetworkEvent`, `[NetworkCallable]`, or a hybrid event path.
+
+Why this was chosen:
+
+- Record whether the event is a request, notification, effect trigger, or convenience call.
+- Capture that network events are not replayed to late joiners; persistent state should be restored from synced or stored state instead.
+
+### Sync mode (Manual vs Continuous)
+
+Choose how state replication works, if any:
+
+- No synced variables.
+- `[UdonSynced]` with Manual sync, Continuous sync, or a mixed split.
+- Synced transport copy with local derived presentation state.
+
+Why this was chosen:
+
+- For Manual sync, record where `RequestSerialization()` is called after changed synced fields.
+- For Continuous sync, record why automatic transmission fits and why `RequestSerialization()` is not part of the path.
+- Capture that synced variables are automatically sent to late joiners.
+
+### Storage & persistence
+
+Choose whether state persists beyond the current instance:
+
+- No persistence, synced state only for the live instance, PlayerData, or PlayerObject.
+- Hybrid storage; list which fields persist and which reset.
+
+Why this was chosen:
+
+- Record the lifecycle: per-session, per-player, per-object, or durable player preference.
+- For PlayerObject, note that ownership is auto-assigned and `Networking.SetOwner()` is not needed for the PlayerObject itself.
+- For PlayerData or PlayerObject reads, record which code waits for `OnPlayerRestored`.
+
+### Ownership model
+
+- Record the initial owner, ownership transfer trigger, non-owner request path, owner-left behavior, and concurrent interaction behavior.
+
+Capture owner-left handling as an observable design choice. Ownership transfers automatically; if state needs to be re-broadcast or presentation needs to be re-applied, record the `OnOwnershipTransferred` follow-up.
+
+### Late joiner behavior
+
+- Record what the late joiner should see, which synced fields or stored values restore that state, which event-only effects are intentionally not replayed, and which callback applies the received state locally.
+
+### Synced fields & bandwidth
+
+- List synced fields, derived-locally fields, intentionally-not-synced fields, and throttling, batching, or packing decisions.
+
+### Decisions & rejected alternatives
+
+- Record the decision made, the alternative considered, and the reason the alternative was left out for this task.
+
+### Validation
+
+- Repo checks run and validation hooks triggered.
+- Unity Editor, ClientSim, Build & Test multi-client, late-joiner, and owner-left checks planned or completed.
+
+---
+
+## Concrete example
+
+```text
+Task context note: shared door controller
+
+Goal:
+- Preserve open/closed state for all players.
+
+Relevant files:
+- DoorController.cs
+- references/networking.md
+- references/testing.md
+
+Source of truth:
+- Door object's synced bool.
+- Why: late joiners need open/closed state without replaying past events.
+
+Transport (events):
+- SendCustomNetworkEvent only for the click sound.
+- Why: sound is momentary and does not need late-joiner replay.
+
+Sync mode (Manual vs Continuous):
+- Manual sync for the open/closed bool.
+- Why: value changes only on interaction; owner writes the bool and requests serialization.
+
+Storage & persistence:
+- No PlayerData or PlayerObject storage.
+- Why: the door resets between instances.
+
+Ownership model:
+- Default scene owner initially; non-owner interaction requests ownership before changing the bool.
+- OnOwnershipTransferred reapplies the current bool and re-serializes if this client became owner after a handoff.
+
+Late joiner behavior:
+- Late joiners receive the synced bool and apply the animator state from it.
+
+Validation:
+- Multi-client interaction test.
+- Late-joiner test after opening and closing.
+- Owner-left test while open.
+```
+
+---
+
+## Privacy notes
+
+Keep the note focused on decisions and evidence. Avoid storing secrets, API keys, tokens, private URLs, private client information, raw private email contents, full conversation transcripts, or unnecessary personal data.
+
+Summarize the relevant decision, file, test, or observed behavior instead.
+
+---
+
+## Resume checklist after compaction
+
+1. Re-read the current user instruction or task issue.
+2. Re-read the relevant UdonSharp rules for the edited file type.
+3. Read the existing context-preservation note.
+4. Re-open every file named in the note's Relevant files section.
+5. Confirm the recorded source of truth and transport path against the current code.
+6. Confirm whether any event-only behavior affects late joiners.
+7. Confirm the sync mode and the current `RequestSerialization()` or Continuous-sync path.
+8. Confirm PlayerData or PlayerObject reads wait for `OnPlayerRestored` when persistence is involved.
+9. Confirm ownership transfer and owner-left behavior in the current code.
+10. Confirm late-joiner restoration from synced or stored state.
+11. Confirm the validation status by reading the most recent command output or running the next listed check.
+12. Update the note when a design decision changes.
+
+---
+
+## See Also
+
+- [networking.md](networking.md) - Ownership, network events, sync modes, late joiners, and owner-left behavior
+- [persistence.md](persistence.md) - PlayerData and PlayerObject restore timing
+- [testing.md](testing.md) - ClientSim, Build & Test, multi-client, late-joiner, and owner-left validation

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1199,5 +1199,6 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 - [networking-antipatterns.md](networking-antipatterns.md) - 6 anti-patterns and 5 advanced patterns
 - [patterns-networking.md](patterns-networking.md) - Object pooling, game state management, NetworkCallable patterns
 - [persistence.md](persistence.md) - PlayerData/PlayerObject API for persisting data across sessions
+- [context-preservation.md](context-preservation.md) - Task-context notes for source-of-truth, ownership, sync, and late-joiner decisions
 - [sync-examples.md](sync-examples.md) - Concrete synced gimmick patterns with data budget reference
 - [troubleshooting.md](troubleshooting.md) - Debugging networking issues, ownership race conditions

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -848,4 +848,5 @@ public void DebugPrintAllData()
 
 - [sync-examples.md](sync-examples.md) - Practical patterns for syncing persistent state with other players
 - [networking.md](networking.md) - Ownership and serialization needed for PlayerObject sync
+- [context-preservation.md](context-preservation.md) - Task-context notes for persistence, source-of-truth, ownership, and restore decisions
 - [events.md](events.md) - `OnPlayerRestored` and `OnPersistenceUsageUpdated` event reference

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -251,6 +251,7 @@ Run through this checklist before publishing any world.
 
 - [api.md](api.md) - VRCObjectPool API, VRCPlayerApi methods, and Camera Dolly API reference
 - [networking.md](networking.md) - Ownership model, sync modes, and RequestSerialization
+- [context-preservation.md](context-preservation.md) - Lightweight task-context notes for resumed or ownership-sensitive work
 - [networking-antipatterns.md](networking-antipatterns.md) - Common networking mistakes and how to avoid them
 - [troubleshooting.md](troubleshooting.md) - Common errors and solutions
 - [events.md](events.md) - Complete event list including OnDeserialization and OnPlayerRestored

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -42,6 +42,13 @@ Use web search to reference official documentation and community resources:
 | `site:feedback.vrchat.com` | Known bugs and feature requests | `site:feedback.vrchat.com PhysBones worlds` |
 | `site:github.com/vrchat-community` | Samples and libraries | `site:github.com/vrchat-community ClientSim` |
 
+## Context Preservation
+
+For complex synced systems, ownership-sensitive multi-file refactors, or work resumed after context compaction/handoff, consider the lightweight guide at `skills/unity-vrc-udon-sharp/references/context-preservation.md`.
+Use it to preserve task-specific source of truth, sync strategy, ownership, late-joiner, owner-left, and validation decisions.
+Skip it for small mechanical edits.
+Keep secrets, private data, and raw transcripts out of any note.
+
 ## Hooks
 
 PostToolUse auto-validation when editing `.cs` files:

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -42,6 +42,13 @@ Use web search to reference official documentation and community resources:
 | `site:feedback.vrchat.com` | Known bugs and feature requests | `site:feedback.vrchat.com PhysBones worlds` |
 | `site:github.com/vrchat-community` | Samples and libraries | `site:github.com/vrchat-community ClientSim` |
 
+## Context Preservation
+
+For complex synced systems, ownership-sensitive multi-file refactors, or work resumed after context compaction/handoff, consider the lightweight guide at `skills/unity-vrc-udon-sharp/references/context-preservation.md`.
+Use it to preserve task-specific source of truth, sync strategy, ownership, late-joiner, owner-left, and validation decisions.
+Skip it for small mechanical edits.
+Keep secrets, private data, and raw transcripts out of any note.
+
 ## Hooks
 
 PostToolUse auto-validation when editing `.cs` files:

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -41,3 +41,10 @@ Use web search to reference official documentation and community resources:
 | `site:ask.vrchat.com` | Community Q&A and troubleshooting | `site:ask.vrchat.com PlayerData persistence` |
 | `site:feedback.vrchat.com` | Known bugs and feature requests | `site:feedback.vrchat.com PhysBones worlds` |
 | `site:github.com/vrchat-community` | Samples and libraries | `site:github.com/vrchat-community ClientSim` |
+
+## Context Preservation
+
+For complex synced systems, ownership-sensitive multi-file refactors, or work resumed after context compaction/handoff, consider the lightweight guide at `skills/unity-vrc-udon-sharp/references/context-preservation.md`.
+Use it to preserve task-specific source of truth, sync strategy, ownership, late-joiner, owner-left, and validation decisions.
+Skip it for small mechanical edits.
+Keep secrets, private data, and raw transcripts out of any note.


### PR DESCRIPTION
## Summary

Adds an optional, lightweight context-preservation guide for complex UdonSharp agent work — synced systems, persistence, multi-file refactors, and work resumed after context compaction or handoff. It records *task-specific design intent* (the "why" behind a design), complementing the reusable constraints that rules, references, and hooks already cover.

Scope is intentionally small: one new reference plus discoverability pointers. No hooks, no installer changes, no project-local plan files (the larger "planning framework" ideas from the issue are left out).

## Changes

- **New** `skills/unity-vrc-udon-sharp/references/context-preservation.md`: rule-loss vs design-context loss, when / when-not to keep a note, a minimal task-context note template (source of truth → transport → sync mode → storage → ownership → late-joiner → validation), privacy guidance, and a resume-after-compaction checklist. Options are presented neutrally with a "why this was chosen" prompt — it records rationale rather than prescribing a design.
- `SKILL.md`: References table row, a dedicated Reference Loading Guide row, and a short Context Preservation pointer section.
- `templates/AGENTS.md`, `templates/CLAUDE.md`, `templates/GEMINI.md`: matching pointer section.
- Reciprocal See Also links from `networking.md`, `persistence.md`, `testing.md`.
- README (en / ja / zh-CN / zh-TW / ko): references count 22 → 23.

## Out of scope

While checking networking accuracy for the new guide, two pre-existing statements in SKILL.md's "Before Writing Network Code" section were found to contradict `networking.md` (owner-leave and late-joiner behavior). Tracked separately in #225 to keep this change single-purpose.

## Validation

- `npm pack --dry-run` includes the new reference.
- All five README reference counts now read 23; the world-sdk count is unchanged.
- See Also links resolve to existing siblings; ToC anchors match the headings.
- No version field touched, so Version Sync is unaffected.

Closes #224