### PR TITLE
docs: add binary-backed SDK coverage-audit policy and candidate ledger

### DIFF
--- a/.claude/audit/.gitignore
+++ b/.claude/audit/.gitignore
@@ -1,0 +1,5 @@
+# Generated census/diff output is a near-complete symbol listing. Keep it out of
+# git so the repo does not read as an SDK API mirror (the tooling reproduces it
+# on demand). Curated decisions live in sdk-coverage-ledger.md instead.
+*.json
+.generated/

--- a/.claude/audit/README.md
+++ b/.claude/audit/README.md
@@ -1,0 +1,80 @@
+# SDK Coverage Audit (maintainer procedure)
+
+This directory holds the **how-to-run** for the binary-backed coverage audit.
+The **policy** — what may and may not enter a skill, and how undocumented APIs
+are labeled — lives in [`CONTRIBUTING.md`](../../CONTRIBUTING.md) under
+"Content Scope". This file does not restate the policy; it only describes the
+mechanics. Keep the two in their lanes to avoid drift (this repo has a
+documentation-sync rule for exactly this reason).
+
+## Why this exists
+
+Skill coverage is derived from the official VRChat docs, which lag and sometimes
+omit what the SDK binary ships (precedents: missing Udon events, #213/#214;
+`VRCObjectPool.Shuffle()`, #190). Inspecting the SDK binary closes that blind
+spot — but only as a **discovery / drift-detection** tool. Binary presence never
+justifies inclusion on its own; see the policy.
+
+## When to run
+
+On each **SDK version bump**. Run the census against the new SDK, diff against
+the previous run, and triage only what changed. Do not re-audit the full surface
+every time — that is the treadmill this procedure is designed to avoid.
+
+## Prerequisites
+
+- A local SDK workspace as described in
+  [`unity-project-for-sdk-search/README.md`](../../unity-project-for-sdk-search/README.md)
+  (gitignored; the SDK is non-redistributable).
+- `pip install dnfile pefile`
+- Python 3.9+
+
+## Pipeline
+
+Run from the repo root. By default all three scripts read/write under
+`.claude/audit/.generated/`, which is gitignored — the generated JSON is a
+near-complete symbol listing we never commit; curated decisions go in the ledger.
+
+```bash
+# 1. Census: enumerate per-component Udon-callable methods from the wrapper DLL.
+#    -> writes .claude/audit/.generated/census.json
+python .claude/audit/scripts/census.py --dll <path-to>/VRC.Udon.VRCWrapperModules.dll
+
+# 2. Diff: binary-minus-skill, split into Tier 1 (covered-but-incomplete) / Tier 2 (unmentioned).
+#    -> reads .generated/census.json, writes .generated/diff.json
+python .claude/audit/scripts/diff.py
+
+# 3. Refine: reduce Tier 1 to missing non-accessor (verb) methods — the decision-relevant signal.
+python .claude/audit/scripts/refine.py
+```
+
+## Triage (the editorial gate — by hand)
+
+The pipeline output is "binary minus skill", **not** "binary minus official
+docs". For each high-signal candidate:
+
+1. **Documentation oracle** — apply the oracle defined in CONTRIBUTING.md
+   "Content Scope" (documented = on a human-readable creators.vrchat.com /
+   udonsharp.docs.vrchat.com page; Udon-graph exposure does not count).
+   *Procedure note:* asymmetric rigor — marking something "undocumented" requires
+   a thorough negative check of the decisive page(s); otherwise record
+   "inconclusive", never "undocumented".
+2. **Technical-relevance bar** — apply the existing "Content Scope" Reviewer
+   test (the relevance axis, orthogonal to sourcing).
+3. **Behavior verification** — per CONTRIBUTING.md "Never infer behavior from
+   existence": verify runtime semantics (ownership, sync, late-joiner, return
+   semantics) against official docs or hands-on multi-client testing before any
+   behavioral claim enters a skill.
+
+Record every decision — including skips and their reason — in
+[`sdk-coverage-ledger.md`](sdk-coverage-ledger.md). Promote at most a few
+verified, high-value candidates per release; everything else stays in the ledger.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/census.py` | stage 1 — metadata parse, per-type method enumeration |
+| `scripts/diff.py` | stage 2 — diff vs current skill text |
+| `scripts/refine.py` | stage 3 — reduce to high-signal verb methods |
+| `sdk-coverage-ledger.md` | decision ledger (candidates, verdicts, skips + why) |

--- a/.claude/audit/README.md
+++ b/.claude/audit/README.md
@@ -17,9 +17,16 @@ justifies inclusion on its own; see the policy.
 
 ## When to run
 
-On each **SDK version bump**. Run the census against the new SDK, diff against
-the previous run, and triage only what changed. Do not re-audit the full surface
-every time — that is the treadmill this procedure is designed to avoid.
+On each **SDK version bump**. Re-run the pipeline against the new SDK, then
+triage its output against the [ledger](sdk-coverage-ledger.md): any API already
+recorded there (`included` / `skip` / `inconclusive`) needs no re-work — only
+APIs new to this SDK, or whose status changed, deserve attention.
+
+The pipeline recomputes the full binary-minus-skill set each run (it does not
+diff one census against another — the generated census is gitignored and
+overwritten). The **ledger is the cross-version memory** that keeps this from
+being a re-audit-from-scratch treadmill: it persists every prior decision, so a
+bump is "what's not already in the ledger", not "read 78 types again".
 
 ## Prerequisites
 

--- a/.claude/audit/scripts/census.py
+++ b/.claude/audit/scripts/census.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""SDK coverage census — stage 1 of the binary-backed discovery audit.
+
+Parses the Udon wrapper module assembly's metadata (TypeDef -> MethodList) to
+enumerate, per VRC extern type, the methods Udon can dispatch. The extern
+signatures (e.g. ``__Shuffle__SystemVoid``) are the wrapper class's own
+MethodDefs, so type->method ownership is recovered exactly — ``strings | grep``
+cannot do this because the metadata string heap is not grouped by type.
+
+This is a DISCOVERY tool. Binary presence is never sufficient for inclusion;
+see CONTRIBUTING.md "Content Scope" and ../README.md for the policy.
+
+Requires: pip install dnfile pefile
+
+Usage:
+    python census.py [--dll PATH] [--out census.json]
+
+Default --dll points at the gitignored local SDK workspace described in
+unity-project-for-sdk-search/README.md. Override for a different SDK version.
+"""
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+try:
+    import dnfile
+except ImportError:
+    sys.exit("dnfile is required: pip install dnfile pefile")
+
+DEFAULT_DLL = (
+    "unity-project-for-sdk-search/sdk-search-project/Packages/com.vrchat.worlds/"
+    "Runtime/Udon/External/VRC.Udon.VRCWrapperModules.dll"
+)
+# Generated output goes here — covered by .claude/audit/.gitignore so the
+# near-complete symbol listing is never committed (it is not an API mirror).
+DEFAULT_OUT = ".claude/audit/.generated/census.json"
+
+# Method names that appear on many extern types are Unity/Object boilerplate
+# (GetComponent family, Equals, get_transform, ...), not a component's own API.
+BOILERPLATE_MIN_TYPES = 8
+
+INFRA_NAMES = {".ctor", ".cctor", "get_Name", "get_GetterType"}
+
+
+def sval(x):
+    return x.value if hasattr(x, "value") else str(x)
+
+
+def is_infra(name):
+    if name in INFRA_NAMES:
+        return True
+    if name.startswith("GetExternFunction"):
+        return True
+    if "." in name:  # interface-explicit re-implementations (dup of __ form)
+        return True
+    if not name.startswith("__"):
+        return True
+    return False
+
+
+def decode(sym):
+    """__Name__[Args__]Return  ->  (name, [args], return)."""
+    body = sym[2:] if sym.startswith("__") else sym
+    parts = body.split("__")
+    if len(parts) == 1:
+        return parts[0], [], ""
+    if len(parts) == 2:
+        return parts[0], [], parts[1]
+    name, ret = parts[0], parts[-1]
+    args = "__".join(parts[1:-1])
+    return name, (args.split("_") if args else []), ret
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dll", default=DEFAULT_DLL, help="path to VRC.Udon.VRCWrapperModules.dll")
+    ap.add_argument("--out", default=DEFAULT_OUT)
+    args = ap.parse_args()
+
+    dn = dnfile.dnPE(args.dll)
+    tds = dn.net.mdtables.TypeDef
+
+    census = {}
+    name_freq = Counter()
+    for td in tds.rows:
+        nm = sval(td.TypeName)
+        if not nm.startswith("ExternVRC") or nm.endswith("Array"):
+            continue
+        methods, seen = [], set()
+        for m in td.MethodList:
+            mname = sval(m.row.Name) if hasattr(m, "row") else sval(m.Name)
+            if is_infra(mname) or mname in seen:
+                continue
+            seen.add(mname)
+            dn_name, margs, ret = decode(mname)
+            methods.append({"raw": mname, "name": dn_name, "args": margs, "ret": ret})
+        census[nm] = methods
+        for dn_name in {x["name"] for x in methods}:
+            name_freq[dn_name] += 1
+
+    boiler = {n for n, c in name_freq.items() if c >= BOILERPLATE_MIN_TYPES}
+    summary = {}
+    for t, ms in census.items():
+        distinct = sorted({m["name"] for m in ms if m["name"] not in boiler})
+        summary[t] = {"total": len(ms), "distinctive": len(distinct), "distinctive_methods": distinct}
+
+    out = {"n_types": len(census), "boilerplate": sorted(boiler), "census": census, "summary": summary}
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=1, ensure_ascii=False)
+    print(f"wrote {args.out}: {len(census)} extern types, {len(boiler)} boilerplate names dropped")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/audit/scripts/census.py
+++ b/.claude/audit/scripts/census.py
@@ -45,19 +45,19 @@ INFRA_NAMES = {".ctor", ".cctor", "get_Name", "get_GetterType"}
 
 
 def sval(x):
+    """Return the plain string value of a dnfile string-heap field."""
     return x.value if hasattr(x, "value") else str(x)
 
 
 def is_infra(name):
+    """True for wrapper-class members that are not Udon extern signatures."""
     if name in INFRA_NAMES:
         return True
     if name.startswith("GetExternFunction"):
         return True
     if "." in name:  # interface-explicit re-implementations (dup of __ form)
         return True
-    if not name.startswith("__"):
-        return True
-    return False
+    return not name.startswith("__")
 
 
 def decode(sym):
@@ -74,6 +74,7 @@ def decode(sym):
 
 
 def main():
+    """Parse the wrapper DLL and write the per-type method census to --out."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--dll", default=DEFAULT_DLL, help="path to VRC.Udon.VRCWrapperModules.dll")
     ap.add_argument("--out", default=DEFAULT_OUT)

--- a/.claude/audit/scripts/diff.py
+++ b/.claude/audit/scripts/diff.py
@@ -38,6 +38,7 @@ NS = sorted([
 
 
 def clean_name(extern):
+    """Recover a component's short name by stripping namespace segments."""
     s = extern[len("Extern"):] if extern.startswith("Extern") else extern
     changed = True
     while changed:
@@ -51,16 +52,19 @@ def clean_name(extern):
 
 
 def cand2(extern):
+    """Fallback short name: the trailing VRC-prefixed token, if any."""
     s = extern[len("Extern"):] if extern.startswith("Extern") else extern
     m = re.search(r"(VRC[A-Za-z0-9]+)$", s)
     return m.group(1) if m else None
 
 
 def prop_token(name):
+    """Strip a get_/set_ accessor prefix to the underlying property name."""
     return name.split("_", 1)[1] if name.startswith(("get_", "set_")) else name
 
 
 def main():
+    """Diff the census against skill text; write tiered gaps to --out."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--census", default=DEFAULT_CENSUS)
     ap.add_argument("--skill-dir", default=DEFAULT_SKILL_DIR)
@@ -77,6 +81,7 @@ def main():
     skill = "\n".join(texts)
 
     def in_skill(tok):
+        """True if token appears in skill text on a word-ish boundary."""
         return bool(tok) and re.search(r"(?<![A-Za-z0-9])" + re.escape(tok) + r"(?![A-Za-z0-9])", skill) is not None
 
     tier1, tier2 = [], []

--- a/.claude/audit/scripts/diff.py
+++ b/.claude/audit/scripts/diff.py
@@ -71,13 +71,15 @@ def main():
     ap.add_argument("--out", default=DEFAULT_OUT)
     args = ap.parse_args()
 
-    data = json.load(open(args.census, encoding="utf-8"))
+    with open(args.census, encoding="utf-8") as f:
+        data = json.load(f)
     census, boiler = data["census"], set(data["boilerplate"])
 
     texts = []
     for ext in ("**/*.md", "**/*.cs"):
         for p in glob.glob(os.path.join(args.skill_dir, ext), recursive=True):
-            texts.append(open(p, encoding="utf-8", errors="ignore").read())
+            with open(p, encoding="utf-8", errors="ignore") as f:
+                texts.append(f.read())
     skill = "\n".join(texts)
 
     def in_skill(tok):
@@ -107,7 +109,8 @@ def main():
     tier1.sort(key=lambda r: -len(r["missing_from_skill"]))
     tier2.sort(key=lambda r: -r["n_distinct"])
     os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
-    json.dump({"tier1": tier1, "tier2": tier2}, open(args.out, "w", encoding="utf-8"), indent=1, ensure_ascii=False)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump({"tier1": tier1, "tier2": tier2}, f, indent=1, ensure_ascii=False)
     print(f"wrote {args.out}: tier1={len(tier1)} (covered-but-incomplete), tier2={len(tier2)} (unmentioned)")
 
 

--- a/.claude/audit/scripts/diff.py
+++ b/.claude/audit/scripts/diff.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""SDK coverage diff — stage 2 of the binary-backed discovery audit.
+
+Diffs the per-component distinctive-method census (census.json) against what the
+skill text currently mentions, producing two tiers:
+
+  Tier 1 — skill already covers the component, but binary methods are unmentioned
+           (the "already here but incomplete" gap, e.g. VRCObjectPool/Shuffle).
+  Tier 2 — components the skill does not mention at all.
+
+This is "binary minus skill". It is NOT "binary minus official docs" — the
+official-docs check is the editorial gate (stage performed by hand, see
+../README.md and ../sdk-coverage-ledger.md). Most Tier-1 entries are
+doc-covered and get skipped.
+
+Usage:
+    python diff.py [--census census.json] [--skill-dir PATH] [--out diff.json]
+"""
+import argparse
+import glob
+import json
+import os
+import re
+
+DEFAULT_SKILL_DIR = "skills/unity-vrc-udon-sharp"
+# Generated output goes here — covered by .claude/audit/.gitignore (never committed).
+DEFAULT_CENSUS = ".claude/audit/.generated/census.json"
+DEFAULT_OUT = ".claude/audit/.generated/diff.json"
+
+# Namespace segments stripped (longest-first) to recover a component's short name.
+NS = sorted([
+    "VRCSDK3", "VRCSDKBase", "VRCSDK", "VRCDynamics", "VRCEconomy",
+    "ConstraintComponents", "ContactComponents", "PhysBoneComponents", "ComponentsBase",
+    "Components", "Constraint", "Contact", "Dynamics", "PhysBone", "Rendering", "Persistence",
+    "Image", "Midi", "Video", "StringLoading", "Platform", "UdonNetworkCalling", "NetworkCalling",
+    "Udon", "Economy", "Data", "SDK3", "SDKBase", "Base",
+], key=len, reverse=True)
+
+
+def clean_name(extern):
+    s = extern[len("Extern"):] if extern.startswith("Extern") else extern
+    changed = True
+    while changed:
+        changed = False
+        for tok in NS:
+            if s.startswith(tok) and len(s) > len(tok):
+                s = s[len(tok):]
+                changed = True
+                break
+    return s
+
+
+def cand2(extern):
+    s = extern[len("Extern"):] if extern.startswith("Extern") else extern
+    m = re.search(r"(VRC[A-Za-z0-9]+)$", s)
+    return m.group(1) if m else None
+
+
+def prop_token(name):
+    return name.split("_", 1)[1] if name.startswith(("get_", "set_")) else name
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--census", default=DEFAULT_CENSUS)
+    ap.add_argument("--skill-dir", default=DEFAULT_SKILL_DIR)
+    ap.add_argument("--out", default=DEFAULT_OUT)
+    args = ap.parse_args()
+
+    data = json.load(open(args.census, encoding="utf-8"))
+    census, boiler = data["census"], set(data["boilerplate"])
+
+    texts = []
+    for ext in ("**/*.md", "**/*.cs"):
+        for p in glob.glob(os.path.join(args.skill_dir, ext), recursive=True):
+            texts.append(open(p, encoding="utf-8", errors="ignore").read())
+    skill = "\n".join(texts)
+
+    def in_skill(tok):
+        return bool(tok) and re.search(r"(?<![A-Za-z0-9])" + re.escape(tok) + r"(?![A-Za-z0-9])", skill) is not None
+
+    tier1, tier2 = [], []
+    for extern, methods in census.items():
+        label, c2 = clean_name(extern), cand2(extern)
+        distinct = sorted({m["name"] for m in methods if m["name"] not in boiler})
+        if not distinct:
+            continue
+        comp_mentioned = in_skill(label) or in_skill(c2)
+        mentioned, missing = [], []
+        for meth in distinct:
+            (mentioned if in_skill(prop_token(meth)) else missing).append(meth)
+        # Keys are SKILL-PRESENCE only, not official-doc status. "missing_from_skill"
+        # is a discovery signal; whether it is truly undocumented is decided by the
+        # by-hand editorial gate (see ../README.md "Triage"), never by this script.
+        rec = {"type": extern, "label": label, "n_distinct": len(distinct),
+               "mentioned_in_skill": mentioned, "missing_from_skill": missing}
+        if comp_mentioned and missing:
+            tier1.append(rec)
+        elif not comp_mentioned:
+            tier2.append(rec)
+
+    tier1.sort(key=lambda r: -len(r["missing_from_skill"]))
+    tier2.sort(key=lambda r: -r["n_distinct"])
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    json.dump({"tier1": tier1, "tier2": tier2}, open(args.out, "w", encoding="utf-8"), indent=1, ensure_ascii=False)
+    print(f"wrote {args.out}: tier1={len(tier1)} (covered-but-incomplete), tier2={len(tier2)} (unmentioned)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/audit/scripts/refine.py
+++ b/.claude/audit/scripts/refine.py
@@ -25,7 +25,8 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--diff", default=".claude/audit/.generated/diff.json")
     args = ap.parse_args()
-    d = json.load(open(args.diff, encoding="utf-8"))
+    with open(args.diff, encoding="utf-8") as f:
+        d = json.load(f)
 
     print("== TIER 1 high-signal: missing NON-ACCESSOR methods on skill-taught components ==")
     rows = []

--- a/.claude/audit/scripts/refine.py
+++ b/.claude/audit/scripts/refine.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""SDK coverage refine — stage 3 of the binary-backed discovery audit.
+
+Reduces the Tier-1 diff to the decision-relevant signal: missing NON-ACCESSOR
+(verb) methods on skill-taught components. Property get_/set_ accessors are
+summarized as a count (low knowledge-delta). This is what a maintainer reads
+before doing the editorial / official-docs triage (see ../README.md).
+
+Usage:
+    python refine.py [--diff diff.json]
+"""
+import argparse
+import json
+
+
+def split(ms):
+    methods = [m for m in ms if not m.startswith(("get_", "set_"))]
+    acc = [m for m in ms if m.startswith(("get_", "set_"))]
+    return methods, acc
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--diff", default=".claude/audit/.generated/diff.json")
+    args = ap.parse_args()
+    d = json.load(open(args.diff, encoding="utf-8"))
+
+    print("== TIER 1 high-signal: missing NON-ACCESSOR methods on skill-taught components ==")
+    rows = []
+    for r in d["tier1"]:
+        meth, acc = split(r["missing_from_skill"])
+        if meth:
+            rows.append((len(meth), r["label"], meth, len(acc)))
+    rows.sort(key=lambda x: -x[0])
+    for n, label, meth, nacc in rows:
+        print(f"  [{label}]  methods={n} (+{nacc} accessors)")
+        print(f"      {', '.join(meth)}")
+    print(f"\n  components with missing verb-methods: {len(rows)}")
+
+    only_acc = [r["label"] for r in d["tier1"] if not split(r["missing_from_skill"])[0]]
+    print("\n== components where ONLY accessors are missing (likely low value) ==")
+    print("   " + ", ".join(only_acc))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/audit/scripts/refine.py
+++ b/.claude/audit/scripts/refine.py
@@ -14,12 +14,14 @@ import json
 
 
 def split(ms):
+    """Partition method names into (verb methods, get_/set_ accessors)."""
     methods = [m for m in ms if not m.startswith(("get_", "set_"))]
     acc = [m for m in ms if m.startswith(("get_", "set_"))]
     return methods, acc
 
 
 def main():
+    """Print the high-signal Tier-1 verb-method gaps from --diff."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--diff", default=".claude/audit/.generated/diff.json")
     args = ap.parse_args()

--- a/.claude/audit/sdk-coverage-ledger.md
+++ b/.claude/audit/sdk-coverage-ledger.md
@@ -1,0 +1,53 @@
+# SDK Coverage Ledger
+
+Decision log for the binary-backed coverage audit. Records candidates, verdicts,
+and **skip reasons** — the skips matter as much as the inclusions, so the same
+proposal does not get re-litigated later. This is not an API dump; it lists only
+triaged items.
+
+Policy: [`CONTRIBUTING.md`](../../CONTRIBUTING.md) "Content Scope". Procedure:
+[`README.md`](README.md).
+
+Status values: `candidate` (found, not yet behavior-verified) · `verified`
+(behavior confirmed, eligible for inclusion) · `included` (in a skill) ·
+`skip` (decided against — reason required) · `inconclusive` (doc status unresolved).
+
+> **Nothing in this ledger is in the skill yet.** A `candidate` is a discovery
+> pending behavior verification (gate 3), not an inclusion decision.
+
+## Audit: SDK 3.10.3 (initial)
+
+### Candidates — undocumented-but-shipped, pending behavior verification
+
+| API | methods | doc status (oracle) | AI-relevance | status | notes |
+|-----|---------|---------------------|--------------|--------|-------|
+| VRCPlayerApi voice getters | `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceLowpass`, `GetVoiceVolumetricRadius` | undocumented — player-audio page documents all 5 **setters**, getters absent there + on players + udonsharp api pages (decisive page checked) | high — clean setter/getter asymmetry; agents know the documented setters but not these | `candidate` | strongest, lowest-risk candidate. Gate 3: confirm getter return semantics (current vs last-set; local vs remote) before any claim |
+| VRCPlayerApi Combat | `CombatSetup`, `CombatSetMaxHitpoints`, `CombatGetCurrentHitpoints`, `CombatSetCurrentHitpoints`, `CombatSetDamageGraphic`, `CombatSetRespawn`, `CombatGetDestructible` | undocumented — absent from players page, udonsharp api; no combat-system doc page exists | high (existence) | `candidate` | purest undocumented-but-shipped, but **legacy** (SDK2-era). Inclusion is a value call: is it used enough today to warrant skill space? |
+| VRCPlayerApi voice moderation | `ClearSilence`, `SetSilencedToTagged`, `SetSilencedToUntagged` | undocumented — absent from player-audio (canonical), players, api | med-high | `candidate` | framing-sensitive (moderation). Behavior unverified |
+| PlayerData | `IsType` | undocumented — absent from player-data page, persistence overview, api; documented siblings are `GetType`/`TryGetType` | med-high — agents confuse it with the documented siblings | `candidate` | lower-confidence negative; re-verify independently before inclusion |
+| Economy Store | `OpenGroupListing` | undocumented — release-3-5-1 notes only, no signature; absent from economy/sdk/udon-documentation | med — confused with `OpenListing` / `OpenGroupStorePage` | `candidate` | lower-confidence negative; re-verify independently before inclusion |
+
+### Candidates — low value / probable skip
+
+| API | method | reason |
+|-----|--------|--------|
+| Networking | `GetEventDispatcher` | undocumented but internal-sounding; low agent value. `skip` unless a use case appears |
+
+### Notable skips (documented → not the skill's job)
+
+The audit's raw Tier-1 looked large (e.g. VRCUrlInputField 69, VRCPhysBone 68)
+but most of that was Unity-inherited methods and property accessors. After
+removing noise and checking the docs, the following high-signal items were all
+confirmed **documented** and therefore skipped:
+
+- VRCPlayerApi: locomotion getters (`GetWalkSpeed`/`GetRunSpeed`/`GetStrafeSpeed`/`GetJumpImpulse`/`GetGravityStrength`), `GetPlayerId`, `IsPlayerGrounded`, `GetPlayerObjects`, `GetPlayersWithTag`, avatar-scaling get/set, all `SetVoice*` setters
+- Networking: `GetNetworkDateTime`, `IsObjectReady`, `GetUniqueName`, `CalculateServerDeltaTime`, `SimulationTime`, `InstanceOwner`/`IsInstanceOwner`/`IsNetworkSettled`, `GetPlayerObjectStorageLimit`/`Usage`
+- PlayerData: all typed `Get`/`Set`/`TryGet` accessors except `IsType`
+- DataList / DataDictionary: all 12 methods (note: `RemoveAll` takes a value not a `Predicate<T>`; `ShallowClone` has no C# analog — documented, but a "differs from C#" skill note may have independent merit)
+- Constraints: `ActivateConstraint`, `ZeroConstraint`
+- Economy: 12 of 13 (all but `OpenGroupListing`)
+- Pickup / Contacts: `PlayHaptics` (udonsharp api only — discoverability gap, but documented), `CalculateProximity`, `UpdateCollisionTags`
+
+Reversed during review: `GetPlayerObjectStorageLimit`/`Usage` were briefly flagged
+as undocumented by name-mismatch inference; the player-object page documents them.
+Inference is not a negative check — record `inconclusive`, never `undocumented`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ skills/                          # Skill content (distributed to users)
     doc-sync-reminder.sh         # PostToolUse hook: reminds about doc updates
   skills/
     unity-vrc-skills-renovator/  # Meta-skill for maintaining skills (dev only, not distributed)
+  audit/                         # SDK coverage-audit tooling + ledger (maintainer-only, not distributed)
+    README.md                    # How to run the SDK-bump diff audit
+    sdk-coverage-ledger.md       # Decision ledger (candidates, verdicts, skips)
+    scripts/                     # census / diff / refine pipeline
 templates/                       # AI tool config templates (distributed to users)
   CLAUDE.md                      # Claude Code project instructions
   AGENTS.md                      # Codex CLI / generic agent instructions
@@ -203,6 +207,10 @@ Public VRChat creator docs and the `vrchat-community/UdonSharp` API page sometim
 This repo uses a gitignored local workspace pattern at `unity-project-for-sdk-search/` for that verification. The directory is intentionally not packed into the npm tarball — only its `README.md` is tracked so the convention is discoverable on clone. See [`unity-project-for-sdk-search/README.md`](unity-project-for-sdk-search/README.md) for one-time setup steps, the canonical `strings | grep` command, and the Udon wrapper symbol legend.
 
 Use this verification path before documenting any API that you cannot confirm against the official public docs.
+
+### Coverage audit (SDK bumps)
+
+Beyond point verification of a single API, the same workspace backs a repeatable **coverage audit** that diffs the full Udon-callable surface against current skill coverage to surface undocumented-but-shipped gaps — the structural problem behind #190 (`VRCObjectPool.Shuffle()`) and #213/#214 (missing events). Run it on each SDK bump and triage only what changed. The procedure and tooling are in [`.claude/audit/README.md`](.claude/audit/README.md); the inclusion policy it feeds — binary presence is a discovery signal only, never grounds for inclusion — is in [`CONTRIBUTING.md`](CONTRIBUTING.md) ("Content Scope").
 
 ## Editing Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,45 @@ If the only reason "this is bad" is "the community dislikes it" or "it's ethical
 
 **NEVER #19** (removed in v1.7.1 via [PR #157](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/157)) prescribed against VRChat+ gameplay-gating. It was removed because the failure mode was a community/design preference, not a technical or platform-enforced one. That removal is the precedent for this policy: rules whose justification collapses to "social consequence only" are rejected going forward.
 
+### SDK API knowledge — documented vs undocumented-but-shipped
+
+The Reviewer test above gates on *why* something is bad (technical/platform vs
+social). A second, **orthogonal** axis governs SDK API coverage: *where the
+knowledge comes from*. An API earns a skill slot only if it clears **both**.
+
+The skills are not an API reference and do not aim for exhaustive SDK coverage.
+The official docs (creators.vrchat.com, udonsharp.docs.vrchat.com) are the API
+reference. The skills add the *delta* the docs miss.
+
+- **Binary presence is discovery, not grounds for inclusion.** A symbol being
+  callable from Udon (visible in the wrapper DLL / Udon graph) only means it is
+  *callable* — it is never, by itself, a reason to document it. Most of the SDK
+  surface is adequately documented officially and belongs to the docs, not here.
+  Mirroring it would dilute the skills' knowledge-delta value.
+- **Documented APIs → skip.** If an API is documented on a human-readable page
+  at creators.vrchat.com or udonsharp.docs.vrchat.com (signature + description),
+  the docs already cover it. The skill adds something only when the API also
+  clears the Reviewer test (a non-obvious, VRChat-specific footgun).
+- **Undocumented-but-shipped APIs may be included — carefully.** When an API is
+  in the shipped SDK, used in practice, and **absent from official docs**, an AI
+  agent cannot know it exists and will mislead users by omission. That is exactly
+  the delta the skill should carry (e.g. `VRCObjectPool.Shuffle()`, #190). Such
+  entries must be labeled as undocumented-but-shipped, with the observed SDK
+  version, the evidence, and — separately — what behavior is verified vs unknown.
+- **Never infer behavior from existence.** The binary confirms a method is
+  *callable*; it says nothing about ownership, sync timing, late-joiner effects,
+  or return semantics. Those must be verified against official docs or hands-on
+  multi-client testing before any behavioral claim is written (the [#194](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/194) lesson).
+- **Events vs methods.** Udon events/callbacks are a small, bounded set where
+  knowing one *exists* is itself the technical-relevance bar — an agent that does
+  not know an event exists cannot write correct code (the misleads-by-omission
+  case), so the event still clears the Reviewer test rather than bypassing it,
+  and near-complete coverage is justified. Component methods are a long tail —
+  curate hard; do not bulk-add.
+
+Maintainer tooling and the decision ledger for this audit live under
+[`.claude/audit/`](.claude/audit/README.md) (not distributed in the npm package).
+
 ## What to Report
 
 - **Incorrect constraints**: A rule says something is blocked but it actually works (or vice versa)


### PR DESCRIPTION
## Summary

Institutionalizes a repeatable, sustainable process for catching skill coverage gaps against the actual SDK binary. Skill coverage is derived from the official docs, which lag/omit what the SDK ships — one structural blind spot behind the missing-events (#213/#214) and `VRCObjectPool.Shuffle()` (#190) precedents.

Guiding principle: **binary inspection is a discovery / drift-detection tool, never grounds for inclusion.** An API still has to clear the existing "Content Scope" technical-relevance bar AND have verified sourcing; runtime behavior is never inferred from symbol existence.

## Changes

- **CONTRIBUTING.md** — extend "Content Scope" with an SDK-API-knowledge axis (documented vs undocumented-but-shipped) that **composes with** the existing Reviewer test as an orthogonal axis. Pre-empts the "doesn't documenting undocumented APIs contradict the skill's restraint?" objection: skills carry the *delta* the docs miss; documented APIs are skipped; undocumented-but-shipped entries must be labeled with SDK version, evidence, and verified-vs-unknown behavior.
- **.claude/audit/README.md** — the maintainer *procedure* (how to run the SDK-bump diff audit, scope budget). Policy lives only in CONTRIBUTING; this links back to avoid drift.
- **.claude/audit/sdk-coverage-ledger.md** — candidate ledger seeded with the initial audit. Entries are **candidates pending behavior verification, not inclusion decisions**; records skip reasons too.
- **.claude/audit/scripts/** — census/diff/refine tooling (parameterized DLL path; output defaults under `.claude/audit/.generated/`, which is gitignored so the repo never reads as an API mirror).
- **CLAUDE.md** — add the coverage-audit step to SDK Verification; update the structure tree.

## Scope / packaging

Maintainer-only. All new files are under `.claude/`; nothing is added to the npm tarball (`package.json` `files` allowlists only `skills/`, `templates/`, READMEs, `LICENSE`). No `skills/` or `templates/` content is changed. Actually adding any discovered API to a skill is **out of scope** and tracked separately (each needs its own behavior verification).

## Test plan

- [x] `python -m py_compile` clean on all three scripts
- [x] Pipeline reproduces the audit (78 extern types; tier1=37/tier2=30) and writes only under `.claude/audit/.generated/`
- [x] `git check-ignore` confirms generated JSON is ignored (never committed)
- [x] No `skills/`/`templates/` paths touched; `git diff --check` clean
- [x] All relative markdown links resolve
- [ ] CI green (Symlink Integrity, Hook Scripts, EditorConfig, Markdown Links, npm Pack Test)

Closes #228