### PR TITLE
docs(skills/udon-sharp): add VRCPlayerApi voice setting getters to api.md

### DIFF
--- a/.claude/audit/sdk-coverage-ledger.md
+++ b/.claude/audit/sdk-coverage-ledger.md
@@ -12,16 +12,25 @@ Status values: `candidate` (found, not yet behavior-verified) · `verified`
 (behavior confirmed, eligible for inclusion) · `included` (in a skill) ·
 `skip` (decided against — reason required) · `inconclusive` (doc status unresolved).
 
-> **Nothing in this ledger is in the skill yet.** A `candidate` is a discovery
-> pending behavior verification (gate 3), not an inclusion decision.
+> A `candidate` is a discovery pending behavior verification (gate 3), not an
+> inclusion decision. Rows marked `included` have shipped to a skill — see the
+> status column. An item may go `candidate → included` without a `verified`
+> stop when it ships as a reference-gap entry: documented signatures with
+> runtime behavior explicitly disclaimed in its notes (gate-3 verification
+> recorded as out-of-scope).
 
 ## Audit: SDK 3.10.3 (initial)
+
+### Included
+
+| API | methods | doc status (oracle) | AI-relevance | status | notes |
+|-----|---------|---------------------|--------------|--------|-------|
+| VRCPlayerApi voice getters | `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceLowpass`, `GetVoiceVolumetricRadius` | release-noted, reference-missing — named in [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) (added to VRCPlayerApi, exposed to Udon); absent from player-audio / players / udonsharp-api pages (15/15 cells verified absent) | high — clean setter/getter asymmetry; agents know the documented setters but not these | `included` | Shipped in api.md (Issue #230). Reclassified from `undocumented` during verification: the 3.6.1 release note names them, so this is a reference-gap, not a binary-only discovery. Behavior edge-cases (value-before-set, last-set vs effective, local vs remote read) intentionally NOT asserted — out of scope without hands-on. Voice Audio Rework (#209) verified not to touch this surface. |
 
 ### Candidates — undocumented-but-shipped, pending behavior verification
 
 | API | methods | doc status (oracle) | AI-relevance | status | notes |
 |-----|---------|---------------------|--------------|--------|-------|
-| VRCPlayerApi voice getters | `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceLowpass`, `GetVoiceVolumetricRadius` | undocumented — player-audio page documents all 5 **setters**, getters absent there + on players + udonsharp api pages (decisive page checked) | high — clean setter/getter asymmetry; agents know the documented setters but not these | `candidate` | strongest, lowest-risk candidate. Gate 3: confirm getter return semantics (current vs last-set; local vs remote) before any claim |
 | VRCPlayerApi Combat | `CombatSetup`, `CombatSetMaxHitpoints`, `CombatGetCurrentHitpoints`, `CombatSetCurrentHitpoints`, `CombatSetDamageGraphic`, `CombatSetRespawn`, `CombatGetDestructible` | undocumented — absent from players page, udonsharp api; no combat-system doc page exists | high (existence) | `candidate` | purest undocumented-but-shipped, but **legacy** (SDK2-era). Inclusion is a value call: is it used enough today to warrant skill space? |
 | VRCPlayerApi voice moderation | `ClearSilence`, `SetSilencedToTagged`, `SetSilencedToUntagged` | undocumented — absent from player-audio (canonical), players, api | med-high | `candidate` | framing-sensitive (moderation). Behavior unverified |
 | PlayerData | `IsType` | undocumented — absent from player-data page, persistence overview, api; documented siblings are `GetType`/`TryGetType` | med-high — agents confuse it with the documented siblings | `candidate` | lower-confidence negative; re-verify independently before inclusion |

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -74,13 +74,22 @@ VRCPlayerApi.TrackingData trackingData = player.GetTrackingData(TrackingDataType
 ### Voice and Audio
 
 ```csharp
-// Voice settings (affects how others hear this player)
+// Voice settings — how the local (listening) player hears the target player
 player.SetVoiceGain(float gain);              // 0-24 dB, default 15
 player.SetVoiceDistanceNear(float distance);  // Default: 0
 player.SetVoiceDistanceFar(float distance);   // Default: 25
 player.SetVoiceVolumetricRadius(float radius); // Default: 0
 player.SetVoiceLowpass(bool enabled);         // Default: true
+
+// Getters for the same settings (release-noted in SDK 3.6.1; see Note)
+float gain    = player.GetVoiceGain();
+float near    = player.GetVoiceDistanceNear();
+float far     = player.GetVoiceDistanceFar();
+float radius  = player.GetVoiceVolumetricRadius();
+bool  lowpass = player.GetVoiceLowpass();
 ```
+
+> **Note**: The voice getters are named in the [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) — added to `VRCPlayerApi` and exposed to Udon — but do not appear on the current [Player Audio](https://creators.vrchat.com/worlds/udon/players/player-audio/), Players, or UdonSharp API reference pages. Each is parameterless and returns the value type of its matching setter (4 `float`, 1 `bool`). This entry records that they exist and their signatures; it does not specify runtime read semantics. What a getter returns before its setter has run, whether it reflects the last value set versus the live effective value, and whether local- and remote-player reads behave identically, are not verified here — confirm against your SDK/client before relying on a getter's return value (for example, before using one in place of your own tracked state). Re-check after the Voice Audio Rework (SDK 3.10.4) lands.
 
 ### Avatar Methods
 


### PR DESCRIPTION
## Summary

Fills a reference-page gap in the UdonSharp API reference: the five `VRCPlayerApi` voice **getters** were missing even though their setters were already documented. Also corrects an inaccurate setter comment found in the same section, and records the inclusion in the coverage ledger.

Closes #230.

## What changed

- **`skills/unity-vrc-udon-sharp/references/api.md`** (Voice and Audio):
  - Added the 5 getters next to the setters: `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceVolumetricRadius`, `GetVoiceLowpass`.
  - Corrected the setter comment: it read "affects how others hear this player," which is backwards. The official Player Audio page states these settings change "how a Player hears _other_ players' voices" — i.e. how the local/listening player hears a target.
- **`.claude/audit/sdk-coverage-ledger.md`** (maintainer-only, not packed): moved the voice-getters row `candidate → included` and reclassified it (see below). Adjusted the intro blockquote now that a row has shipped.

## Why these qualify (classification: release-noted, reference-missing)

This is the first inclusion under the #229 policy. It is stronger than a binary-only discovery (`VRCObjectPool.Shuffle`, #190) because there is official textual authority, not just a wrapper symbol:

- **Release-noted**: the [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) explicitly state the five getters were added to `VRCPlayerApi` and exposed to Udon.
- **Reference-missing**: all five are absent from every reference page (Player Audio, Players, UdonSharp `/vrchat-api/`) — 15/15 cells checked individually. The setters are documented there, so an agent sees the setters and assumes no getter exists. Surfacing that they exist (with signatures, and read semantics left to verify) closes that misleads-by-omission gap.
- **Signatures** (SDK 3.10.3 Udon wrapper metadata): parameterless; return types match each setter's value type (4 `float`, 1 `bool`).

## What is and isn't asserted

Per the policy's "never infer behavior from existence" rule, the entry asserts only what traces to the release note, the documented setter, or the binary signature. It explicitly marks as **unverified** (needs a live client): value before the setter is first called; last-set vs live-effective; whether local- and remote-player reads behave identically. A watchpoint to re-check after the Voice Audio Rework (SDK 3.10.4) is included.

The Voice Audio Rework (#209) was checked and does **not** touch this getter/setter surface — it is internal-pipeline work.

## Test plan

- [x] Signatures confirmed from `VRC.Udon.VRCWrapperModules.dll` (`strings | grep '__(Get|Set)Voice'`).
- [x] Release-note claim verified verbatim at the 3.6.1 URL (with surrounding unrelated bullets, ruling out a fabricated line).
- [x] Per-getter reference absence verified individually across the 3 pages.
- [x] Setter-comment correction grounded in the Player Audio page intro quote.
- [x] `git diff --check` clean; table column count intact; new external links fall under lychee's VRChat-docs excludes.

## Scope / follow-ups

- Out of scope (needs hands-on, cannot run solo): behavior gate-3 for the unverified edge-cases above. The entry is honest about this rather than guessing.
- Follow-up: formalize the "release-noted but reference-missing" category in CONTRIBUTING "Content Scope" (currently a two-way documented/undocumented split). Filed as #231.
