### PR TITLE
chore(version): bump to v2.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.2.0"
+    version: "2.3.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.2.0"
+    version: "2.3.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.2.0"
+    version: "2.3.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 


### PR DESCRIPTION
## Summary

Pre-release version bump for Step 2 of the release flow (dev → main release PR).

Bumps all 5 version-sync fields from `2.2.0` to `2.3.0`:

- `package.json` → `.version`
- `.claude-plugin/marketplace.json` → `.metadata.version`
- `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
- `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
- `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`

Target version resolved as **minor** (`v2.2.0` → `v2.3.0`): the unreleased batch since v2.2.0 includes a `release: feature` PR (#226, new context-preservation reference), which outranks the `fix`/`docs`/`maintenance` labels on #227/#229/#232/#233.

## Verification

`git diff --stat` shows exactly 5 files, 1 line each — only the version fields changed. Version Sync CI is the substantive check on this PR.