### PR TITLE
Release v2.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "plugins": [
     {

--- a/.claude/audit/.gitignore
+++ b/.claude/audit/.gitignore
@@ -1,0 +1,5 @@
+# Generated census/diff output is a near-complete symbol listing. Keep it out of
+# git so the repo does not read as an SDK API mirror (the tooling reproduces it
+# on demand). Curated decisions live in sdk-coverage-ledger.md instead.
+*.json
+.generated/

--- a/.claude/audit/README.md
+++ b/.claude/audit/README.md
@@ -1,0 +1,87 @@
+# SDK Coverage Audit (maintainer procedure)
+
+This directory holds the **how-to-run** for the binary-backed coverage audit.
+The **policy** — what may and may not enter a skill, and how undocumented APIs
+are labeled — lives in [`CONTRIBUTING.md`](../../CONTRIBUTING.md) under
+"Content Scope". This file does not restate the policy; it only describes the
+mechanics. Keep the two in their lanes to avoid drift (this repo has a
+documentation-sync rule for exactly this reason).
+
+## Why this exists
+
+Skill coverage is derived from the official VRChat docs, which lag and sometimes
+omit what the SDK binary ships (precedents: missing Udon events, #213/#214;
+`VRCObjectPool.Shuffle()`, #190). Inspecting the SDK binary closes that blind
+spot — but only as a **discovery / drift-detection** tool. Binary presence never
+justifies inclusion on its own; see the policy.
+
+## When to run
+
+On each **SDK version bump**. Re-run the pipeline against the new SDK, then
+triage its output against the [ledger](sdk-coverage-ledger.md): any API already
+recorded there (`included` / `skip` / `inconclusive`) needs no re-work — only
+APIs new to this SDK, or whose status changed, deserve attention.
+
+The pipeline recomputes the full binary-minus-skill set each run (it does not
+diff one census against another — the generated census is gitignored and
+overwritten). The **ledger is the cross-version memory** that keeps this from
+being a re-audit-from-scratch treadmill: it persists every prior decision, so a
+bump is "what's not already in the ledger", not "read 78 types again".
+
+## Prerequisites
+
+- A local SDK workspace as described in
+  [`unity-project-for-sdk-search/README.md`](../../unity-project-for-sdk-search/README.md)
+  (gitignored; the SDK is non-redistributable).
+- `pip install dnfile pefile`
+- Python 3.9+
+
+## Pipeline
+
+Run from the repo root. By default all three scripts read/write under
+`.claude/audit/.generated/`, which is gitignored — the generated JSON is a
+near-complete symbol listing we never commit; curated decisions go in the ledger.
+
+```bash
+# 1. Census: enumerate per-component Udon-callable methods from the wrapper DLL.
+#    -> writes .claude/audit/.generated/census.json
+python .claude/audit/scripts/census.py --dll <path-to>/VRC.Udon.VRCWrapperModules.dll
+
+# 2. Diff: binary-minus-skill, split into Tier 1 (covered-but-incomplete) / Tier 2 (unmentioned).
+#    -> reads .generated/census.json, writes .generated/diff.json
+python .claude/audit/scripts/diff.py
+
+# 3. Refine: reduce Tier 1 to missing non-accessor (verb) methods — the decision-relevant signal.
+python .claude/audit/scripts/refine.py
+```
+
+## Triage (the editorial gate — by hand)
+
+The pipeline output is "binary minus skill", **not** "binary minus official
+docs". For each high-signal candidate:
+
+1. **Documentation oracle** — apply the oracle defined in CONTRIBUTING.md
+   "Content Scope" (documented = on a human-readable creators.vrchat.com /
+   udonsharp.docs.vrchat.com page; Udon-graph exposure does not count).
+   *Procedure note:* asymmetric rigor — marking something "undocumented" requires
+   a thorough negative check of the decisive page(s); otherwise record
+   "inconclusive", never "undocumented".
+2. **Technical-relevance bar** — apply the existing "Content Scope" Reviewer
+   test (the relevance axis, orthogonal to sourcing).
+3. **Behavior verification** — per CONTRIBUTING.md "Never infer behavior from
+   existence": verify runtime semantics (ownership, sync, late-joiner, return
+   semantics) against official docs or hands-on multi-client testing before any
+   behavioral claim enters a skill.
+
+Record every decision — including skips and their reason — in
+[`sdk-coverage-ledger.md`](sdk-coverage-ledger.md). Promote at most a few
+verified, high-value candidates per release; everything else stays in the ledger.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/census.py` | stage 1 — metadata parse, per-type method enumeration |
+| `scripts/diff.py` | stage 2 — diff vs current skill text |
+| `scripts/refine.py` | stage 3 — reduce to high-signal verb methods |
+| `sdk-coverage-ledger.md` | decision ledger (candidates, verdicts, skips + why) |

--- a/.claude/audit/scripts/census.py
+++ b/.claude/audit/scripts/census.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""SDK coverage census — stage 1 of the binary-backed discovery audit.
+
+Parses the Udon wrapper module assembly's metadata (TypeDef -> MethodList) to
+enumerate, per VRC extern type, the methods Udon can dispatch. The extern
+signatures (e.g. ``__Shuffle__SystemVoid``) are the wrapper class's own
+MethodDefs, so type->method ownership is recovered exactly — ``strings | grep``
+cannot do this because the metadata string heap is not grouped by type.
+
+This is a DISCOVERY tool. Binary presence is never sufficient for inclusion;
+see CONTRIBUTING.md "Content Scope" and ../README.md for the policy.
+
+Requires: pip install dnfile pefile
+
+Usage:
+    python census.py [--dll PATH] [--out census.json]
+
+Default --dll points at the gitignored local SDK workspace described in
+unity-project-for-sdk-search/README.md. Override for a different SDK version.
+"""
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+try:
+    import dnfile
+except ImportError:
+    sys.exit("dnfile is required: pip install dnfile pefile")
+
+DEFAULT_DLL = (
+    "unity-project-for-sdk-search/sdk-search-project/Packages/com.vrchat.worlds/"
+    "Runtime/Udon/External/VRC.Udon.VRCWrapperModules.dll"
+)
+# Generated output goes here — covered by .claude/audit/.gitignore so the
+# near-complete symbol listing is never committed (it is not an API mirror).
+DEFAULT_OUT = ".claude/audit/.generated/census.json"
+
+# Method names that appear on many extern types are Unity/Object boilerplate
+# (GetComponent family, Equals, get_transform, ...), not a component's own API.
+BOILERPLATE_MIN_TYPES = 8
+
+INFRA_NAMES = {".ctor", ".cctor", "get_Name", "get_GetterType"}
+
+
+def sval(x):
+    """Return the plain string value of a dnfile string-heap field."""
+    return x.value if hasattr(x, "value") else str(x)
+
+
+def is_infra(name):
+    """True for wrapper-class members that are not Udon extern signatures."""
+    if name in INFRA_NAMES:
+        return True
+    if name.startswith("GetExternFunction"):
+        return True
+    if "." in name:  # interface-explicit re-implementations (dup of __ form)
+        return True
+    return not name.startswith("__")
+
+
+def decode(sym):
+    """__Name__[Args__]Return  ->  (name, [args], return)."""
+    body = sym[2:] if sym.startswith("__") else sym
+    parts = body.split("__")
+    if len(parts) == 1:
+        return parts[0], [], ""
+    if len(parts) == 2:
+        return parts[0], [], parts[1]
+    name, ret = parts[0], parts[-1]
+    args = "__".join(parts[1:-1])
+    return name, (args.split("_") if args else []), ret
+
+
+def main():
+    """Parse the wrapper DLL and write the per-type method census to --out."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dll", default=DEFAULT_DLL, help="path to VRC.Udon.VRCWrapperModules.dll")
+    ap.add_argument("--out", default=DEFAULT_OUT)
+    args = ap.parse_args()
+
+    dn = dnfile.dnPE(args.dll)
+    tds = dn.net.mdtables.TypeDef
+
+    census = {}
+    name_freq = Counter()
+    for td in tds.rows:
+        nm = sval(td.TypeName)
+        if not nm.startswith("ExternVRC") or nm.endswith("Array"):
+            continue
+        methods, seen = [], set()
+        for m in td.MethodList:
+            mname = sval(m.row.Name) if hasattr(m, "row") else sval(m.Name)
+            if is_infra(mname) or mname in seen:
+                continue
+            seen.add(mname)
+            dn_name, margs, ret = decode(mname)
+            methods.append({"raw": mname, "name": dn_name, "args": margs, "ret": ret})
+        census[nm] = methods
+        for dn_name in {x["name"] for x in methods}:
+            name_freq[dn_name] += 1
+
+    boiler = {n for n, c in name_freq.items() if c >= BOILERPLATE_MIN_TYPES}
+    summary = {}
+    for t, ms in census.items():
+        distinct = sorted({m["name"] for m in ms if m["name"] not in boiler})
+        summary[t] = {"total": len(ms), "distinctive": len(distinct), "distinctive_methods": distinct}
+
+    out = {"n_types": len(census), "boilerplate": sorted(boiler), "census": census, "summary": summary}
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=1, ensure_ascii=False)
+    print(f"wrote {args.out}: {len(census)} extern types, {len(boiler)} boilerplate names dropped")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/audit/scripts/diff.py
+++ b/.claude/audit/scripts/diff.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""SDK coverage diff — stage 2 of the binary-backed discovery audit.
+
+Diffs the per-component distinctive-method census (census.json) against what the
+skill text currently mentions, producing two tiers:
+
+  Tier 1 — skill already covers the component, but binary methods are unmentioned
+           (the "already here but incomplete" gap, e.g. VRCObjectPool/Shuffle).
+  Tier 2 — components the skill does not mention at all.
+
+This is "binary minus skill". It is NOT "binary minus official docs" — the
+official-docs check is the editorial gate (stage performed by hand, see
+../README.md and ../sdk-coverage-ledger.md). Most Tier-1 entries are
+doc-covered and get skipped.
+
+Usage:
+    python diff.py [--census census.json] [--skill-dir PATH] [--out diff.json]
+"""
+import argparse
+import glob
+import json
+import os
+import re
+
+DEFAULT_SKILL_DIR = "skills/unity-vrc-udon-sharp"
+# Generated output goes here — covered by .claude/audit/.gitignore (never committed).
+DEFAULT_CENSUS = ".claude/audit/.generated/census.json"
+DEFAULT_OUT = ".claude/audit/.generated/diff.json"
+
+# Namespace segments stripped (longest-first) to recover a component's short name.
+NS = sorted([
+    "VRCSDK3", "VRCSDKBase", "VRCSDK", "VRCDynamics", "VRCEconomy",
+    "ConstraintComponents", "ContactComponents", "PhysBoneComponents", "ComponentsBase",
+    "Components", "Constraint", "Contact", "Dynamics", "PhysBone", "Rendering", "Persistence",
+    "Image", "Midi", "Video", "StringLoading", "Platform", "UdonNetworkCalling", "NetworkCalling",
+    "Udon", "Economy", "Data", "SDK3", "SDKBase", "Base",
+], key=len, reverse=True)
+
+
+def clean_name(extern):
+    """Recover a component's short name by stripping namespace segments."""
+    s = extern[len("Extern"):] if extern.startswith("Extern") else extern
+    changed = True
+    while changed:
+        changed = False
+        for tok in NS:
+            if s.startswith(tok) and len(s) > len(tok):
+                s = s[len(tok):]
+                changed = True
+                break
+    return s
+
+
+def cand2(extern):
+    """Fallback short name: the trailing VRC-prefixed token, if any."""
+    s = extern[len("Extern"):] if extern.startswith("Extern") else extern
+    m = re.search(r"(VRC[A-Za-z0-9]+)$", s)
+    return m.group(1) if m else None
+
+
+def prop_token(name):
+    """Strip a get_/set_ accessor prefix to the underlying property name."""
+    return name.split("_", 1)[1] if name.startswith(("get_", "set_")) else name
+
+
+def main():
+    """Diff the census against skill text; write tiered gaps to --out."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--census", default=DEFAULT_CENSUS)
+    ap.add_argument("--skill-dir", default=DEFAULT_SKILL_DIR)
+    ap.add_argument("--out", default=DEFAULT_OUT)
+    args = ap.parse_args()
+
+    with open(args.census, encoding="utf-8") as f:
+        data = json.load(f)
+    census, boiler = data["census"], set(data["boilerplate"])
+
+    texts = []
+    for ext in ("**/*.md", "**/*.cs"):
+        for p in glob.glob(os.path.join(args.skill_dir, ext), recursive=True):
+            with open(p, encoding="utf-8", errors="ignore") as f:
+                texts.append(f.read())
+    skill = "\n".join(texts)
+
+    def in_skill(tok):
+        """True if token appears in skill text on a word-ish boundary."""
+        return bool(tok) and re.search(r"(?<![A-Za-z0-9])" + re.escape(tok) + r"(?![A-Za-z0-9])", skill) is not None
+
+    tier1, tier2 = [], []
+    for extern, methods in census.items():
+        label, c2 = clean_name(extern), cand2(extern)
+        distinct = sorted({m["name"] for m in methods if m["name"] not in boiler})
+        if not distinct:
+            continue
+        comp_mentioned = in_skill(label) or in_skill(c2)
+        mentioned, missing = [], []
+        for meth in distinct:
+            (mentioned if in_skill(prop_token(meth)) else missing).append(meth)
+        # Keys are SKILL-PRESENCE only, not official-doc status. "missing_from_skill"
+        # is a discovery signal; whether it is truly undocumented is decided by the
+        # by-hand editorial gate (see ../README.md "Triage"), never by this script.
+        rec = {"type": extern, "label": label, "n_distinct": len(distinct),
+               "mentioned_in_skill": mentioned, "missing_from_skill": missing}
+        if comp_mentioned and missing:
+            tier1.append(rec)
+        elif not comp_mentioned:
+            tier2.append(rec)
+
+    tier1.sort(key=lambda r: -len(r["missing_from_skill"]))
+    tier2.sort(key=lambda r: -r["n_distinct"])
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump({"tier1": tier1, "tier2": tier2}, f, indent=1, ensure_ascii=False)
+    print(f"wrote {args.out}: tier1={len(tier1)} (covered-but-incomplete), tier2={len(tier2)} (unmentioned)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/audit/scripts/refine.py
+++ b/.claude/audit/scripts/refine.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""SDK coverage refine — stage 3 of the binary-backed discovery audit.
+
+Reduces the Tier-1 diff to the decision-relevant signal: missing NON-ACCESSOR
+(verb) methods on skill-taught components. Property get_/set_ accessors are
+summarized as a count (low knowledge-delta). This is what a maintainer reads
+before doing the editorial / official-docs triage (see ../README.md).
+
+Usage:
+    python refine.py [--diff diff.json]
+"""
+import argparse
+import json
+
+
+def split(ms):
+    """Partition method names into (verb methods, get_/set_ accessors)."""
+    methods = [m for m in ms if not m.startswith(("get_", "set_"))]
+    acc = [m for m in ms if m.startswith(("get_", "set_"))]
+    return methods, acc
+
+
+def main():
+    """Print the high-signal Tier-1 verb-method gaps from --diff."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--diff", default=".claude/audit/.generated/diff.json")
+    args = ap.parse_args()
+    with open(args.diff, encoding="utf-8") as f:
+        d = json.load(f)
+
+    print("== TIER 1 high-signal: missing NON-ACCESSOR methods on skill-taught components ==")
+    rows = []
+    for r in d["tier1"]:
+        meth, acc = split(r["missing_from_skill"])
+        if meth:
+            rows.append((len(meth), r["label"], meth, len(acc)))
+    rows.sort(key=lambda x: -x[0])
+    for n, label, meth, nacc in rows:
+        print(f"  [{label}]  methods={n} (+{nacc} accessors)")
+        print(f"      {', '.join(meth)}")
+    print(f"\n  components with missing verb-methods: {len(rows)}")
+
+    only_acc = [r["label"] for r in d["tier1"] if not split(r["missing_from_skill"])[0]]
+    print("\n== components where ONLY accessors are missing (likely low value) ==")
+    print("   " + ", ".join(only_acc))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/audit/sdk-coverage-ledger.md
+++ b/.claude/audit/sdk-coverage-ledger.md
@@ -12,16 +12,25 @@ Status values: `candidate` (found, not yet behavior-verified) · `verified`
 (behavior confirmed, eligible for inclusion) · `included` (in a skill) ·
 `skip` (decided against — reason required) · `inconclusive` (doc status unresolved).
 
-> **Nothing in this ledger is in the skill yet.** A `candidate` is a discovery
-> pending behavior verification (gate 3), not an inclusion decision.
+> A `candidate` is a discovery pending behavior verification (gate 3), not an
+> inclusion decision. Rows marked `included` have shipped to a skill — see the
+> status column. An item may go `candidate → included` without a `verified`
+> stop when it ships as a reference-gap entry: documented signatures with
+> runtime behavior explicitly disclaimed in its notes (gate-3 verification
+> recorded as out-of-scope).
 
 ## Audit: SDK 3.10.3 (initial)
+
+### Included
+
+| API | methods | doc status (oracle) | AI-relevance | status | notes |
+|-----|---------|---------------------|--------------|--------|-------|
+| VRCPlayerApi voice getters | `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceLowpass`, `GetVoiceVolumetricRadius` | release-noted, reference-missing — named in [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) (added to VRCPlayerApi, exposed to Udon); absent from player-audio / players / udonsharp-api pages (15/15 cells verified absent) | high — clean setter/getter asymmetry; agents know the documented setters but not these | `included` | Shipped in api.md (Issue #230). Reclassified from `undocumented` during verification: the 3.6.1 release note names them, so this is a reference-gap, not a binary-only discovery. Behavior edge-cases (value-before-set, last-set vs effective, local vs remote read) intentionally NOT asserted — out of scope without hands-on. Voice Audio Rework (#209) verified not to touch this surface. |
 
 ### Candidates — undocumented-but-shipped, pending behavior verification
 
 | API | methods | doc status (oracle) | AI-relevance | status | notes |
 |-----|---------|---------------------|--------------|--------|-------|
-| VRCPlayerApi voice getters | `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceLowpass`, `GetVoiceVolumetricRadius` | undocumented — player-audio page documents all 5 **setters**, getters absent there + on players + udonsharp api pages (decisive page checked) | high — clean setter/getter asymmetry; agents know the documented setters but not these | `candidate` | strongest, lowest-risk candidate. Gate 3: confirm getter return semantics (current vs last-set; local vs remote) before any claim |
 | VRCPlayerApi Combat | `CombatSetup`, `CombatSetMaxHitpoints`, `CombatGetCurrentHitpoints`, `CombatSetCurrentHitpoints`, `CombatSetDamageGraphic`, `CombatSetRespawn`, `CombatGetDestructible` | undocumented — absent from players page, udonsharp api; no combat-system doc page exists | high (existence) | `candidate` | purest undocumented-but-shipped, but **legacy** (SDK2-era). Inclusion is a value call: is it used enough today to warrant skill space? |
 | VRCPlayerApi voice moderation | `ClearSilence`, `SetSilencedToTagged`, `SetSilencedToUntagged` | undocumented — absent from player-audio (canonical), players, api | med-high | `candidate` | framing-sensitive (moderation). Behavior unverified |
 | PlayerData | `IsType` | undocumented — absent from player-data page, persistence overview, api; documented siblings are `GetType`/`TryGetType` | med-high — agents confuse it with the documented siblings | `candidate` | lower-confidence negative; re-verify independently before inclusion |

--- a/.claude/audit/sdk-coverage-ledger.md
+++ b/.claude/audit/sdk-coverage-ledger.md
@@ -1,0 +1,53 @@
+# SDK Coverage Ledger
+
+Decision log for the binary-backed coverage audit. Records candidates, verdicts,
+and **skip reasons** — the skips matter as much as the inclusions, so the same
+proposal does not get re-litigated later. This is not an API dump; it lists only
+triaged items.
+
+Policy: [`CONTRIBUTING.md`](../../CONTRIBUTING.md) "Content Scope". Procedure:
+[`README.md`](README.md).
+
+Status values: `candidate` (found, not yet behavior-verified) · `verified`
+(behavior confirmed, eligible for inclusion) · `included` (in a skill) ·
+`skip` (decided against — reason required) · `inconclusive` (doc status unresolved).
+
+> **Nothing in this ledger is in the skill yet.** A `candidate` is a discovery
+> pending behavior verification (gate 3), not an inclusion decision.
+
+## Audit: SDK 3.10.3 (initial)
+
+### Candidates — undocumented-but-shipped, pending behavior verification
+
+| API | methods | doc status (oracle) | AI-relevance | status | notes |
+|-----|---------|---------------------|--------------|--------|-------|
+| VRCPlayerApi voice getters | `GetVoiceGain`, `GetVoiceDistanceNear`, `GetVoiceDistanceFar`, `GetVoiceLowpass`, `GetVoiceVolumetricRadius` | undocumented — player-audio page documents all 5 **setters**, getters absent there + on players + udonsharp api pages (decisive page checked) | high — clean setter/getter asymmetry; agents know the documented setters but not these | `candidate` | strongest, lowest-risk candidate. Gate 3: confirm getter return semantics (current vs last-set; local vs remote) before any claim |
+| VRCPlayerApi Combat | `CombatSetup`, `CombatSetMaxHitpoints`, `CombatGetCurrentHitpoints`, `CombatSetCurrentHitpoints`, `CombatSetDamageGraphic`, `CombatSetRespawn`, `CombatGetDestructible` | undocumented — absent from players page, udonsharp api; no combat-system doc page exists | high (existence) | `candidate` | purest undocumented-but-shipped, but **legacy** (SDK2-era). Inclusion is a value call: is it used enough today to warrant skill space? |
+| VRCPlayerApi voice moderation | `ClearSilence`, `SetSilencedToTagged`, `SetSilencedToUntagged` | undocumented — absent from player-audio (canonical), players, api | med-high | `candidate` | framing-sensitive (moderation). Behavior unverified |
+| PlayerData | `IsType` | undocumented — absent from player-data page, persistence overview, api; documented siblings are `GetType`/`TryGetType` | med-high — agents confuse it with the documented siblings | `candidate` | lower-confidence negative; re-verify independently before inclusion |
+| Economy Store | `OpenGroupListing` | undocumented — release-3-5-1 notes only, no signature; absent from economy/sdk/udon-documentation | med — confused with `OpenListing` / `OpenGroupStorePage` | `candidate` | lower-confidence negative; re-verify independently before inclusion |
+
+### Candidates — low value / probable skip
+
+| API | method | reason |
+|-----|--------|--------|
+| Networking | `GetEventDispatcher` | undocumented but internal-sounding; low agent value. `skip` unless a use case appears |
+
+### Notable skips (documented → not the skill's job)
+
+The audit's raw Tier-1 looked large (e.g. VRCUrlInputField 69, VRCPhysBone 68)
+but most of that was Unity-inherited methods and property accessors. After
+removing noise and checking the docs, the following high-signal items were all
+confirmed **documented** and therefore skipped:
+
+- VRCPlayerApi: locomotion getters (`GetWalkSpeed`/`GetRunSpeed`/`GetStrafeSpeed`/`GetJumpImpulse`/`GetGravityStrength`), `GetPlayerId`, `IsPlayerGrounded`, `GetPlayerObjects`, `GetPlayersWithTag`, avatar-scaling get/set, all `SetVoice*` setters
+- Networking: `GetNetworkDateTime`, `IsObjectReady`, `GetUniqueName`, `CalculateServerDeltaTime`, `SimulationTime`, `InstanceOwner`/`IsInstanceOwner`/`IsNetworkSettled`, `GetPlayerObjectStorageLimit`/`Usage`
+- PlayerData: all typed `Get`/`Set`/`TryGet` accessors except `IsType`
+- DataList / DataDictionary: all 12 methods (note: `RemoveAll` takes a value not a `Predicate<T>`; `ShallowClone` has no C# analog — documented, but a "differs from C#" skill note may have independent merit)
+- Constraints: `ActivateConstraint`, `ZeroConstraint`
+- Economy: 12 of 13 (all but `OpenGroupListing`)
+- Pickup / Contacts: `PlayHaptics` (udonsharp api only — discoverability gap, but documented), `CalculateProximity`, `UpdateCollisionTags`
+
+Reversed during review: `GetPlayerObjectStorageLimit`/`Usage` were briefly flagged
+as undocumented by name-mismatch inference; the player-object page documents them.
+Inference is not a negative check — record `inconclusive`, never `undocumented`.

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.2.0"
+    version: "2.3.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ skills/                          # Skill content (distributed to users)
     doc-sync-reminder.sh         # PostToolUse hook: reminds about doc updates
   skills/
     unity-vrc-skills-renovator/  # Meta-skill for maintaining skills (dev only, not distributed)
+  audit/                         # SDK coverage-audit tooling + ledger (maintainer-only, not distributed)
+    README.md                    # How to run the SDK-bump diff audit
+    sdk-coverage-ledger.md       # Decision ledger (candidates, verdicts, skips)
+    scripts/                     # census / diff / refine pipeline
 templates/                       # AI tool config templates (distributed to users)
   CLAUDE.md                      # Claude Code project instructions
   AGENTS.md                      # Codex CLI / generic agent instructions
@@ -203,6 +207,10 @@ Public VRChat creator docs and the `vrchat-community/UdonSharp` API page sometim
 This repo uses a gitignored local workspace pattern at `unity-project-for-sdk-search/` for that verification. The directory is intentionally not packed into the npm tarball — only its `README.md` is tracked so the convention is discoverable on clone. See [`unity-project-for-sdk-search/README.md`](unity-project-for-sdk-search/README.md) for one-time setup steps, the canonical `strings | grep` command, and the Udon wrapper symbol legend.
 
 Use this verification path before documenting any API that you cannot confirm against the official public docs.
+
+### Coverage audit (SDK bumps)
+
+Beyond point verification of a single API, the same workspace backs a repeatable **coverage audit** that diffs the full Udon-callable surface against current skill coverage to surface undocumented-but-shipped gaps — the structural problem behind #190 (`VRCObjectPool.Shuffle()`) and #213/#214 (missing events). Run it on each SDK bump and triage only what changed. The procedure and tooling are in [`.claude/audit/README.md`](.claude/audit/README.md); the inclusion policy it feeds — binary presence is a discovery signal only, never grounds for inclusion — is in [`CONTRIBUTING.md`](CONTRIBUTING.md) ("Content Scope").
 
 ## Editing Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,45 @@ If the only reason "this is bad" is "the community dislikes it" or "it's ethical
 
 **NEVER #19** (removed in v1.7.1 via [PR #157](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/157)) prescribed against VRChat+ gameplay-gating. It was removed because the failure mode was a community/design preference, not a technical or platform-enforced one. That removal is the precedent for this policy: rules whose justification collapses to "social consequence only" are rejected going forward.
 
+### SDK API knowledge — documented vs undocumented-but-shipped
+
+The Reviewer test above gates on *why* something is bad (technical/platform vs
+social). A second, **orthogonal** axis governs SDK API coverage: *where the
+knowledge comes from*. An API earns a skill slot only if it clears **both**.
+
+The skills are not an API reference and do not aim for exhaustive SDK coverage.
+The official docs (creators.vrchat.com, udonsharp.docs.vrchat.com) are the API
+reference. The skills add the *delta* the docs miss.
+
+- **Binary presence is discovery, not grounds for inclusion.** A symbol being
+  callable from Udon (visible in the wrapper DLL / Udon graph) only means it is
+  *callable* — it is never, by itself, a reason to document it. Most of the SDK
+  surface is adequately documented officially and belongs to the docs, not here.
+  Mirroring it would dilute the skills' knowledge-delta value.
+- **Documented APIs → skip.** If an API is documented on a human-readable page
+  at creators.vrchat.com or udonsharp.docs.vrchat.com (signature + description),
+  the docs already cover it. The skill adds something only when the API also
+  clears the Reviewer test (a non-obvious, VRChat-specific footgun).
+- **Undocumented-but-shipped APIs may be included — carefully.** When an API is
+  in the shipped SDK, used in practice, and **absent from official docs**, an AI
+  agent cannot know it exists and will mislead users by omission. That is exactly
+  the delta the skill should carry (e.g. `VRCObjectPool.Shuffle()`, #190). Such
+  entries must be labeled as undocumented-but-shipped, with the observed SDK
+  version, the evidence, and — separately — what behavior is verified vs unknown.
+- **Never infer behavior from existence.** The binary confirms a method is
+  *callable*; it says nothing about ownership, sync timing, late-joiner effects,
+  or return semantics. Those must be verified against official docs or hands-on
+  multi-client testing before any behavioral claim is written (the [#194](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/194) lesson).
+- **Events vs methods.** Udon events/callbacks are a small, bounded set where
+  knowing one *exists* is itself the technical-relevance bar — an agent that does
+  not know an event exists cannot write correct code (the misleads-by-omission
+  case), so the event still clears the Reviewer test rather than bypassing it,
+  and near-complete coverage is justified. Component methods are a long tail —
+  curate hard; do not bulk-add.
+
+Maintainer tooling and the decision ledger for this audit live under
+[`.claude/audit/`](.claude/audit/README.md) (not distributed in the npm package).
+
 ## What to Report
 
 - **Incorrect constraints**: A rule says something is blocked but it actually works (or vice versa)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ If the only reason "this is bad" is "the community dislikes it" or "it's ethical
 
 **NEVER #19** (removed in v1.7.1 via [PR #157](https://github.com/niaka3dayo/agent-skills-vrc-udon/pull/157)) prescribed against VRChat+ gameplay-gating. It was removed because the failure mode was a community/design preference, not a technical or platform-enforced one. That removal is the precedent for this policy: rules whose justification collapses to "social consequence only" are rejected going forward.
 
-### SDK API knowledge — documented vs undocumented-but-shipped
+### SDK API knowledge — documented, release-noted, or undocumented-but-shipped
 
 The Reviewer test above gates on *why* something is bad (technical/platform vs
 social). A second, **orthogonal** axis governs SDK API coverage: *where the
@@ -64,6 +64,18 @@ reference. The skills add the *delta* the docs miss.
   at creators.vrchat.com or udonsharp.docs.vrchat.com (signature + description),
   the docs already cover it. The skill adds something only when the API also
   clears the Reviewer test (a non-obvious, VRChat-specific footgun).
+- **Release-noted but reference-missing → may be included.** An API named on an
+  official VRChat SDK release page (creators.vrchat.com/releases/), but with no
+  reference-page entry (signature + description on creators.vrchat.com /
+  udonsharp.docs.vrchat.com), is a distinct, *stronger* case than binary-only
+  discovery: the release note is official evidence the API exists and was meant to
+  be used. Still confirm it ships in the target SDK binary — the release note
+  establishes intent, the wrapper DLL confirms delivery. It is still **not
+  "documented"** in the skip sense above — an agent consulting the reference pages
+  cannot find it, so the misleads-by-omission bar is met. Include it with the same
+  labeling discipline as undocumented-but-shipped entries (classification +
+  observed SDK version + evidence + verified-vs-unknown behavior). The
+  `VRCPlayerApi` voice getters (#230) are the worked example.
 - **Undocumented-but-shipped APIs may be included — carefully.** When an API is
   in the shipped SDK, used in practice, and **absent from official docs**, an AI
   agent cannot know it exists and will mislead users by omission. That is exactly

--- a/README.ja.md
+++ b/README.ja.md
@@ -99,7 +99,7 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（22ファイル）
+    references/                          # 詳細ドキュメント（23ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7ファイル）
 templates/                               # AIツール設定テンプレート

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,7 +99,7 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (22개 파일)
+    references/                          # 상세 문서 (23개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7개 파일)
 templates/                               # AI 도구 설정 템플릿

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (22 files)
+    references/                          # Detailed documentation (23 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7 files)
 templates/                               # AI tool config templates

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（22 个文件）
+    references/                          # 详细文档（23 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 个文件）
 templates/                               # AI 工具配置模板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（22 個檔案）
+    references/                          # 詳細文件（23 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 個檔案）
 templates/                               # AI 工具設定範本

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -32,8 +32,8 @@ Four architectural decisions that must be made before choosing sync modes or wri
 
 - **Who owns this state?** One owner writes; all others read. If two players can both write (e.g., a shared toggle), you need an ownership transfer protocol — writes without ownership are silently discarded.
 - **When does ownership transfer?** On grab? Interact? Game event? `OnPlayerLeft`? `Networking.SetOwner` is **locally immediate** on the calling client — `Networking.IsOwner(gameObject)` is `true` synchronously after the call, and writing `[UdonSynced]` fields plus `RequestSerialization()` immediately afterwards is safe under an `IsOwner` guard. Concurrent `SetOwner` calls from multiple clients are resolved by network arrival order — there is no client-side arbitration, so accept that the loser's write is overwritten.
-- **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Persistent state requires `[UdonSynced]` variables; the owner calls `RequestSerialization()` on join events to push current state to newcomers.
-- **What if the owner leaves mid-session?** Without explicit `OnPlayerLeft` handling, the object's synced state can never change again. Decide upfront: auto-transfer to master, reset to a known default, or the next interacting player claims ownership.
+- **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Late-joiner-visible state must live in `[UdonSynced]` variables, which are delivered automatically via `OnDeserialization`; no manual `RequestSerialization()` on join is needed.
+- **What if the owner leaves mid-session?** VRChat automatically transfers ownership to a remaining player (selection rule is not publicly documented), and `OnOwnershipTransferred` fires on all clients. Synced variables are preserved, so state is not frozen; decide upfront whether to keep the current value, reset to a known default, or re-apply/re-broadcast derived state in `OnOwnershipTransferred`.
 
 ## Context Preservation
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -35,6 +35,13 @@ Four architectural decisions that must be made before choosing sync modes or wri
 - **What do late joiners see?** State set only by one-time events (`SendCustomNetworkEvent`) is invisible to late joiners. Persistent state requires `[UdonSynced]` variables; the owner calls `RequestSerialization()` on join events to push current state to newcomers.
 - **What if the owner leaves mid-session?** Without explicit `OnPlayerLeft` handling, the object's synced state can never change again. Decide upfront: auto-transfer to master, reset to a known default, or the next interacting player claims ownership.
 
+## Context Preservation
+
+For complex synced systems, ownership-sensitive refactors, or work resumed after compaction/handoff, consider loading `references/context-preservation.md`.
+It provides a lightweight task-context note for source of truth, transport, sync mode, storage, ownership, late-joiner behavior, and validation rationale.
+This is optional guidance for complex work, not a step for small mechanical edits.
+Keep private data and raw transcripts out of any note.
+
 ## Core Principles
 
 1. **Constraints First** — Assume standard C# features are blocked until verified. Check `udonsharp-constraints.md` before using any API.
@@ -117,6 +124,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
+| Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 
@@ -238,6 +246,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |
 | `testing.md` | Testing and debugging guide: ClientSim editor testing, Build and Test (single and multi-client), Debug.Log patterns, pre-release cleanup, testing checklist | ClientSim, Build and Test, multi-client, late joiner test, debug, Debug.Log, ownership test, sync test, testing checklist |
+| `context-preservation.md` | Context-preservation guide: recording task-specific design intent (source of truth, sync strategy, ownership, late-joiner behavior, validation) across context compaction/handoff; minimal task-context note; privacy guidance; resume checklist | context preservation, design intent, compaction, handoff, resume, task context note, why this design, ownership rationale, design-context loss |
 
 ## Templates (`assets/templates/`)
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.2.0"
+    version: "2.3.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -74,13 +74,22 @@ VRCPlayerApi.TrackingData trackingData = player.GetTrackingData(TrackingDataType
 ### Voice and Audio
 
 ```csharp
-// Voice settings (affects how others hear this player)
+// Voice settings — how the local (listening) player hears the target player
 player.SetVoiceGain(float gain);              // 0-24 dB, default 15
 player.SetVoiceDistanceNear(float distance);  // Default: 0
 player.SetVoiceDistanceFar(float distance);   // Default: 25
 player.SetVoiceVolumetricRadius(float radius); // Default: 0
 player.SetVoiceLowpass(bool enabled);         // Default: true
+
+// Getters for the same settings (release-noted in SDK 3.6.1; see Note)
+float gain    = player.GetVoiceGain();
+float near    = player.GetVoiceDistanceNear();
+float far     = player.GetVoiceDistanceFar();
+float radius  = player.GetVoiceVolumetricRadius();
+bool  lowpass = player.GetVoiceLowpass();
 ```
+
+> **Note**: The voice getters are named in the [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) — added to `VRCPlayerApi` and exposed to Udon — but do not appear on the current [Player Audio](https://creators.vrchat.com/worlds/udon/players/player-audio/), Players, or UdonSharp API reference pages. Each is parameterless and returns the value type of its matching setter (4 `float`, 1 `bool`). This entry records that they exist and their signatures; it does not specify runtime read semantics. What a getter returns before its setter has run, whether it reflects the last value set versus the live effective value, and whether local- and remote-player reads behave identically, are not verified here — confirm against your SDK/client before relying on a getter's return value (for example, before using one in place of your own tracked state). Re-check after the Voice Audio Rework (SDK 3.10.4) lands.
 
 ### Avatar Methods
 

--- a/skills/unity-vrc-udon-sharp/references/context-preservation.md
+++ b/skills/unity-vrc-udon-sharp/references/context-preservation.md
@@ -1,0 +1,250 @@
+# Context Preservation for UdonSharp Agent Work
+
+Lightweight guide for keeping task-specific design intent available across long or resumed UdonSharp work.
+
+**Applies to:** all supported SDK versions
+
+This guide is optional and intended for complex work only. Use the format as a reusable note inside an existing task note, issue comment, scratchpad, or other user-approved location; it is not needed for trivial edits, and it does not ask for a new project file.
+
+## Table of Contents
+
+- [Why this exists](#why-this-exists)
+- [Rule loss vs design-context loss](#rule-loss-vs-design-context-loss)
+- [When to use a context-preservation note](#when-to-use-a-context-preservation-note)
+- [When not to use one](#when-not-to-use-one)
+- [Minimal task context note](#minimal-task-context-note)
+- [Concrete example](#concrete-example)
+- [Privacy notes](#privacy-notes)
+- [Resume checklist after compaction](#resume-checklist-after-compaction)
+- [See Also](#see-also)
+
+---
+
+## Why this exists
+
+The reusable UdonSharp constraints already live in rules, references, cheatsheets, templates, and validation hooks. Those files preserve shared knowledge: which APIs are available, how ownership works, what late joiners receive, and how to test networking behavior.
+
+Long agent tasks can lose a different kind of context: why this particular design was chosen. A later pass may remember that networking matters, yet miss that this door state is owner-written, restored from a synced variable, and intentionally not replayed from an event. The note below preserves that task-specific reasoning so resumed work does not rely only on conversation memory.
+
+The goal is small and practical. Capture the few decisions that would be expensive to rediscover: source of truth, event transport, sync mode, storage, ownership behavior, late joiner behavior, and validation status.
+
+---
+
+## Rule loss vs design-context loss
+
+### Rule loss
+
+Rule loss happens when an agent forgets reusable UdonSharp facts already documented elsewhere.
+
+Examples:
+
+- Treating a non-owner write to a synced field as authoritative.
+- Calling `RequestSerialization()` for Continuous sync, where automatic transmission is already expected.
+- Reading PlayerData or PlayerObject values before `OnPlayerRestored` has fired.
+- Expecting a network event to rebuild state for a player who joined after the event.
+
+Use the existing references for this class of problem. This note format is not a replacement for `networking.md`, `persistence.md`, or `testing.md`.
+
+### Design-context loss
+
+Design-context loss happens when the reusable rules are remembered, but the task-specific reason is gone.
+
+Examples:
+
+- A synced field exists, but the next pass cannot tell whether it is the source of truth or a transport copy.
+- A non-owner request path exists, but the ownership-transfer trigger is unclear.
+- A PlayerObject is involved, but the note does not say which reads wait for `OnPlayerRestored`.
+- A late-joiner bug was fixed, but the validation that proved it is not recorded.
+
+Use a context-preservation note to keep this local reasoning visible during complex work.
+
+---
+
+## When to use a context-preservation note
+
+Consider a note for work that includes any of these traits:
+
+- New synced systems or changes to existing synced state.
+- Ownership-sensitive interactions, late-joiner-sensitive behavior, or PlayerData/PlayerObject persistence.
+- Complex multi-file refactors where the design reason is easy to lose.
+- Work resumed after context compaction, restart, handoff, or split across multiple agent runs.
+
+---
+
+## When not to use one
+
+Skip the note for work where the design context is obvious from the diff:
+
+- Typo fixes.
+- Small documentation edits or formatting-only changes.
+- One-file mechanical updates or metadata-only maintenance.
+
+---
+
+## Minimal task context note
+
+This is a lightweight prompt, not a heavy planning framework. Keep only the fields that help the next pass continue safely.
+
+### Goal
+
+- Behavior being added, fixed, or preserved.
+- Existing behavior that should remain unchanged.
+
+### Relevant files
+
+- Edited files, reference files, validation files, scenes, or assets.
+
+### UdonSharp constraints relevant to this task
+
+- Constraints that shaped this task: ownership writes, sync mode, restore timing, unsupported APIs, or unsupported language features.
+
+### Source of truth
+
+Choose the authoritative state holder for this task:
+
+- Local-only state, scene object owner, instance master, or per-player owner.
+- PlayerObject state with automatic per-player ownership, PlayerData storage, or derived state.
+- Hybrid model; name the authoritative field or object for each part.
+
+Why this was chosen:
+
+- Record the reason this source is authoritative, and note which state is only cached or derived locally.
+
+### Transport (events)
+
+Choose how one-shot messages are transported, if any:
+
+- No network event, or local-only `SendCustomEvent`.
+- `SendCustomNetworkEvent`, `[NetworkCallable]`, or a hybrid event path.
+
+Why this was chosen:
+
+- Record whether the event is a request, notification, effect trigger, or convenience call.
+- Capture that network events are not replayed to late joiners; persistent state should be restored from synced or stored state instead.
+
+### Sync mode (Manual vs Continuous)
+
+Choose how state replication works, if any:
+
+- No synced variables.
+- `[UdonSynced]` with Manual sync, Continuous sync, or a mixed split.
+- Synced transport copy with local derived presentation state.
+
+Why this was chosen:
+
+- For Manual sync, record where `RequestSerialization()` is called after changed synced fields.
+- For Continuous sync, record why automatic transmission fits and why `RequestSerialization()` is not part of the path.
+- Capture that synced variables are automatically sent to late joiners.
+
+### Storage & persistence
+
+Choose whether state persists beyond the current instance:
+
+- No persistence, synced state only for the live instance, PlayerData, or PlayerObject.
+- Hybrid storage; list which fields persist and which reset.
+
+Why this was chosen:
+
+- Record the lifecycle: per-session, per-player, per-object, or durable player preference.
+- For PlayerObject, note that ownership is auto-assigned and `Networking.SetOwner()` is not needed for the PlayerObject itself.
+- For PlayerData or PlayerObject reads, record which code waits for `OnPlayerRestored`.
+
+### Ownership model
+
+- Record the initial owner, ownership transfer trigger, non-owner request path, owner-left behavior, and concurrent interaction behavior.
+
+Capture owner-left handling as an observable design choice. Ownership transfers automatically; if state needs to be re-broadcast or presentation needs to be re-applied, record the `OnOwnershipTransferred` follow-up.
+
+### Late joiner behavior
+
+- Record what the late joiner should see, which synced fields or stored values restore that state, which event-only effects are intentionally not replayed, and which callback applies the received state locally.
+
+### Synced fields & bandwidth
+
+- List synced fields, derived-locally fields, intentionally-not-synced fields, and throttling, batching, or packing decisions.
+
+### Decisions & rejected alternatives
+
+- Record the decision made, the alternative considered, and the reason the alternative was left out for this task.
+
+### Validation
+
+- Repo checks run and validation hooks triggered.
+- Unity Editor, ClientSim, Build & Test multi-client, late-joiner, and owner-left checks planned or completed.
+
+---
+
+## Concrete example
+
+```text
+Task context note: shared door controller
+
+Goal:
+- Preserve open/closed state for all players.
+
+Relevant files:
+- DoorController.cs
+- references/networking.md
+- references/testing.md
+
+Source of truth:
+- Door object's synced bool.
+- Why: late joiners need open/closed state without replaying past events.
+
+Transport (events):
+- SendCustomNetworkEvent only for the click sound.
+- Why: sound is momentary and does not need late-joiner replay.
+
+Sync mode (Manual vs Continuous):
+- Manual sync for the open/closed bool.
+- Why: value changes only on interaction; owner writes the bool and requests serialization.
+
+Storage & persistence:
+- No PlayerData or PlayerObject storage.
+- Why: the door resets between instances.
+
+Ownership model:
+- Default scene owner initially; non-owner interaction requests ownership before changing the bool.
+- OnOwnershipTransferred reapplies the current bool and re-serializes if this client became owner after a handoff.
+
+Late joiner behavior:
+- Late joiners receive the synced bool and apply the animator state from it.
+
+Validation:
+- Multi-client interaction test.
+- Late-joiner test after opening and closing.
+- Owner-left test while open.
+```
+
+---
+
+## Privacy notes
+
+Keep the note focused on decisions and evidence. Avoid storing secrets, API keys, tokens, private URLs, private client information, raw private email contents, full conversation transcripts, or unnecessary personal data.
+
+Summarize the relevant decision, file, test, or observed behavior instead.
+
+---
+
+## Resume checklist after compaction
+
+1. Re-read the current user instruction or task issue.
+2. Re-read the relevant UdonSharp rules for the edited file type.
+3. Read the existing context-preservation note.
+4. Re-open every file named in the note's Relevant files section.
+5. Confirm the recorded source of truth and transport path against the current code.
+6. Confirm whether any event-only behavior affects late joiners.
+7. Confirm the sync mode and the current `RequestSerialization()` or Continuous-sync path.
+8. Confirm PlayerData or PlayerObject reads wait for `OnPlayerRestored` when persistence is involved.
+9. Confirm ownership transfer and owner-left behavior in the current code.
+10. Confirm late-joiner restoration from synced or stored state.
+11. Confirm the validation status by reading the most recent command output or running the next listed check.
+12. Update the note when a design decision changes.
+
+---
+
+## See Also
+
+- [networking.md](networking.md) - Ownership, network events, sync modes, late joiners, and owner-left behavior
+- [persistence.md](persistence.md) - PlayerData and PlayerObject restore timing
+- [testing.md](testing.md) - ClientSim, Build & Test, multi-client, late-joiner, and owner-left validation

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1199,5 +1199,6 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 - [networking-antipatterns.md](networking-antipatterns.md) - 6 anti-patterns and 5 advanced patterns
 - [patterns-networking.md](patterns-networking.md) - Object pooling, game state management, NetworkCallable patterns
 - [persistence.md](persistence.md) - PlayerData/PlayerObject API for persisting data across sessions
+- [context-preservation.md](context-preservation.md) - Task-context notes for source-of-truth, ownership, sync, and late-joiner decisions
 - [sync-examples.md](sync-examples.md) - Concrete synced gimmick patterns with data budget reference
 - [troubleshooting.md](troubleshooting.md) - Debugging networking issues, ownership race conditions

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -848,4 +848,5 @@ public void DebugPrintAllData()
 
 - [sync-examples.md](sync-examples.md) - Practical patterns for syncing persistent state with other players
 - [networking.md](networking.md) - Ownership and serialization needed for PlayerObject sync
+- [context-preservation.md](context-preservation.md) - Task-context notes for persistence, source-of-truth, ownership, and restore decisions
 - [events.md](events.md) - `OnPlayerRestored` and `OnPersistenceUsageUpdated` event reference

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -251,6 +251,7 @@ Run through this checklist before publishing any world.
 
 - [api.md](api.md) - VRCObjectPool API, VRCPlayerApi methods, and Camera Dolly API reference
 - [networking.md](networking.md) - Ownership model, sync modes, and RequestSerialization
+- [context-preservation.md](context-preservation.md) - Lightweight task-context notes for resumed or ownership-sensitive work
 - [networking-antipatterns.md](networking-antipatterns.md) - Common networking mistakes and how to avoid them
 - [troubleshooting.md](troubleshooting.md) - Common errors and solutions
 - [events.md](events.md) - Complete event list including OnDeserialization and OnPlayerRestored

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -15,7 +15,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.2.0"
+    version: "2.3.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -42,6 +42,13 @@ Use web search to reference official documentation and community resources:
 | `site:feedback.vrchat.com` | Known bugs and feature requests | `site:feedback.vrchat.com PhysBones worlds` |
 | `site:github.com/vrchat-community` | Samples and libraries | `site:github.com/vrchat-community ClientSim` |
 
+## Context Preservation
+
+For complex synced systems, ownership-sensitive multi-file refactors, or work resumed after context compaction/handoff, consider the lightweight guide at `skills/unity-vrc-udon-sharp/references/context-preservation.md`.
+Use it to preserve task-specific source of truth, sync strategy, ownership, late-joiner, owner-left, and validation decisions.
+Skip it for small mechanical edits.
+Keep secrets, private data, and raw transcripts out of any note.
+
 ## Hooks
 
 PostToolUse auto-validation when editing `.cs` files:

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -42,6 +42,13 @@ Use web search to reference official documentation and community resources:
 | `site:feedback.vrchat.com` | Known bugs and feature requests | `site:feedback.vrchat.com PhysBones worlds` |
 | `site:github.com/vrchat-community` | Samples and libraries | `site:github.com/vrchat-community ClientSim` |
 
+## Context Preservation
+
+For complex synced systems, ownership-sensitive multi-file refactors, or work resumed after context compaction/handoff, consider the lightweight guide at `skills/unity-vrc-udon-sharp/references/context-preservation.md`.
+Use it to preserve task-specific source of truth, sync strategy, ownership, late-joiner, owner-left, and validation decisions.
+Skip it for small mechanical edits.
+Keep secrets, private data, and raw transcripts out of any note.
+
 ## Hooks
 
 PostToolUse auto-validation when editing `.cs` files:

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -41,3 +41,10 @@ Use web search to reference official documentation and community resources:
 | `site:ask.vrchat.com` | Community Q&A and troubleshooting | `site:ask.vrchat.com PlayerData persistence` |
 | `site:feedback.vrchat.com` | Known bugs and feature requests | `site:feedback.vrchat.com PhysBones worlds` |
 | `site:github.com/vrchat-community` | Samples and libraries | `site:github.com/vrchat-community ClientSim` |
+
+## Context Preservation
+
+For complex synced systems, ownership-sensitive multi-file refactors, or work resumed after context compaction/handoff, consider the lightweight guide at `skills/unity-vrc-udon-sharp/references/context-preservation.md`.
+Use it to preserve task-specific source of truth, sync strategy, ownership, late-joiner, owner-left, and validation decisions.
+Skip it for small mechanical edits.
+Keep secrets, private data, and raw transcripts out of any note.


### PR DESCRIPTION
Merge `dev` into `main` for the v2.3.0 release.

Bundles 5 PRs merged since v2.2.0:

- #226 (closes #224) — context-preservation reference + discoverability wiring (`release: feature`)
- #227 (closes #225) — late-joiner / owner-leave networking guidance fix (`release: fix`)
- #229 (closes #228) — binary-backed SDK coverage-audit policy + candidate ledger, maintainer-only (`release: maintenance`)
- #232 (closes #230) — VRCPlayerApi voice setting getters in api.md (`release: docs`)
- #233 (closes #231) — formalize the release-noted-but-reference-missing API category in CONTRIBUTING (`release: maintenance`)

Version resolved as minor (feature outranks). `package.json#version` on dev is already `2.3.0` (bumped in #234). Merge with a merge commit (not squash) so Release Drafter sees each underlying PR commit.