### PR TITLE
docs(skills/udon-sharp): add IEditorOnly setup component and inspector setup UX coverage

### DIFF
--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -377,4 +377,5 @@ For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` arr
 | Web / Image loading, VRCUrl constraints | [references/web-loading.md](references/web-loading.md) |
 | UI / Canvas patterns | [references/patterns-ui.md](references/patterns-ui.md) |
 | Video player patterns | [references/patterns-video.md](references/patterns-video.md) |
+| Custom inspectors, editor-only setup components (IEditorOnly) | [references/editor-scripting.md](references/editor-scripting.md) |
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -127,6 +127,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
+| Building editor setup tools / placement UX (custom inspectors, scene wiring helpers, IEditorOnly) | `editor-scripting.md` | `constraints.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
 
 ## Pattern Selection Guide
 
@@ -241,7 +242,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | `web-loading-advanced.md` | Advanced data loading: Base64 texture embedding via StringDownloader, cross-platform compression, URL double-key indexing, LRU decode cache | Base64, LoadRawTextureData, StringDownloader texture, DXT1, ETC_RGB4, UNITY_ANDROID, LRU cache, packed resources, binary format |
 | `api.md` | VRCPlayerApi, Networking, enums reference, VRCObjectPool methods + Interact-driven ownership patterns | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity, Drone, VRCDroneApi, VRCObjectPool, TryToSpawn, Return, Shuffle, pool owner, Interact pool, pool forwarded spawn, pool ownership transfer |
 | `events.md` | All Udon events (including OnPlayerRestored, OnContactEnter) | OnPlayerJoined, OnPlayerLeft, OnPlayerTriggerEnter, OnOwnershipTransferred, OnControllerColliderHitPlayer, CharacterController, OnMasterTransferred, OnAvatarChanged, OnSpawn, VRC Economy, OnPurchaseConfirmed, OnAsyncGpuReadbackComplete |
-| `editor-scripting.md` | Editor scripting, proxy system, and UdonSharpProgramAsset auto-generation | UdonSharpEditor, UdonSharpBehaviourProxy, SerializedObject, UdonSharpProgramAsset, auto-generate, AssetPostprocessor, .asset missing |
+| `editor-scripting.md` | Editor scripting, proxy system, custom inspectors, editor-only setup components (IEditorOnly), and UdonSharpProgramAsset auto-generation | UdonSharpEditor, UdonSharpBehaviourProxy, SerializedObject, UdonSharpProgramAsset, auto-generate, AssetPostprocessor, .asset missing, IEditorOnly, EditorOnly tag, setup helper, setup component, build exclusion, custom inspector, ContextMenu |
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -307,17 +307,17 @@ public class MyToolWindow : EditorWindow
 
 ### The Problem
 
-In-scene setup tooling such as light-probe placers, multi-component wiring helpers, and prefab configurators is editor-only by nature. A plain `MonoBehaviour` in a world scene is not on the world component whitelist, so SDK validation reports it as an incompatible script. It would never execute in the VRChat client anyway, because only Udon programs run in worlds. Creators need a supported way to keep these helpers in the scene without validation complaints.
+In-scene setup tooling such as light-probe placers, multi-component wiring helpers, and prefab configurators is editor-only by nature. A plain `MonoBehaviour` in a world scene is not on the world component whitelist, so SDK validation reports it as an incompatible script. It would never execute in the VRChat client anyway, because custom MonoBehaviour scripts do not run in the client — Udon is the only user scripting runtime in worlds. Creators need a supported way to keep these helpers in the scene without validation complaints.
 
 ### The IEditorOnly Marker Interface
 
-`VRC.SDKBase.IEditorOnly` is a marker interface with no members (verified against SDK 3.10.3). The [official build-pipeline callbacks and interfaces docs](https://creators.vrchat.com/sdk/build-pipeline-callbacks-and-interfaces/) state that implementing it marks a script as editor-only for SDK validation, so the SDK ignores the component when scanning a world or avatar for incompatible scripts. Editor-side world validation excludes `IEditorOnly` components from illegal-component removal, while the client removes all non-whitelisted components. An `IEditorOnly` helper never reaches runtime.
+`VRC.SDKBase.IEditorOnly` is a marker interface with no members (verified against SDK 3.10.3). The [official build-pipeline callbacks and interfaces docs](https://creators.vrchat.com/sdk/build-pipeline-callbacks-and-interfaces/) state that implementing it marks a script as editor-only for SDK validation, so the SDK ignores the component when scanning a world or avatar for incompatible scripts. Non-whitelisted components do not function in the VRChat client (see the [world component whitelist](https://creators.vrchat.com/worlds/whitelisted-world-components/)), so the helper has no runtime effect either way — `IEditorOnly` is about passing SDK validation cleanly and declaring intent.
 
 ```csharp
 using UnityEngine;
 using VRC.SDKBase;
 
-// Setup-only helper: SDK validation ignores it and it never ships with the world
+// Setup-only helper: SDK validation ignores it and it does not run in the client
 public class LightProbeSetupHelper : MonoBehaviour, IEditorOnly
 {
     public float spacing = 2.0f;
@@ -328,6 +328,7 @@ public class LightProbeSetupHelper : MonoBehaviour, IEditorOnly
     private void GenerateProbes()
     {
         // Place light probes from spacing / targetArea
+        // (a real implementation uses UnityEditor APIs — hence the directive)
     }
 #endif
 }
@@ -340,8 +341,8 @@ Two key rules:
 
 ### IEditorOnly vs the EditorOnly Tag
 
-| | `IEditorOnly` interface | `EditorOnly` tag |
-|---|---|---|
+| Aspect | `IEditorOnly` interface | `EditorOnly` tag |
+|--------|-------------------------|------------------|
 | Granularity | Single component | Entire GameObject (with its children) |
 | Mechanism | VRChat SDK validation treats the component as editor-only | Unity standard: tagged GameObjects are excluded from builds |
 | Runtime components on the same GameObject | Keep working | Removed together with the GameObject |
@@ -378,7 +379,7 @@ public class TeleporterController : UdonSharpBehaviour
 ```
 
 ```csharp
-// TeleporterSetupHelper.cs — editor-only setup component, never ships
+// TeleporterSetupHelper.cs — editor-only setup component, ignored by SDK validation
 using UnityEngine;
 using VRC.SDKBase;
 

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -303,6 +303,181 @@ public class MyToolWindow : EditorWindow
 #endif
 ```
 
+## Editor-Only Setup Components (IEditorOnly)
+
+### The Problem
+
+In-scene setup tooling such as light-probe placers, multi-component wiring helpers, and prefab configurators is editor-only by nature. A plain `MonoBehaviour` in a world scene is not on the world component whitelist, so SDK validation reports it as an incompatible script. It would never execute in the VRChat client anyway, because only Udon programs run in worlds. Creators need a supported way to keep these helpers in the scene without validation complaints.
+
+### The IEditorOnly Marker Interface
+
+`VRC.SDKBase.IEditorOnly` is a marker interface with no members (verified against SDK 3.10.3). The [official build-pipeline callbacks and interfaces docs](https://creators.vrchat.com/sdk/build-pipeline-callbacks-and-interfaces/) state that implementing it marks a script as editor-only for SDK validation, so the SDK ignores the component when scanning a world or avatar for incompatible scripts. Editor-side world validation excludes `IEditorOnly` components from illegal-component removal, while the client removes all non-whitelisted components. An `IEditorOnly` helper never reaches runtime.
+
+```csharp
+using UnityEngine;
+using VRC.SDKBase;
+
+// Setup-only helper: SDK validation ignores it and it never ships with the world
+public class LightProbeSetupHelper : MonoBehaviour, IEditorOnly
+{
+    public float spacing = 2.0f;
+    public Bounds targetArea;
+
+#if UNITY_EDITOR
+    [ContextMenu("Generate Probes")]
+    private void GenerateProbes()
+    {
+        // Place light probes from spacing / targetArea
+    }
+#endif
+}
+```
+
+Two key rules:
+
+1. The script must live in a runtime assembly. A component cannot come from an `Editor` folder, so any use of `UnityEditor` APIs inside it must be wrapped in `#if UNITY_EDITOR`; otherwise platform builds fail to compile. Attributes such as `[ContextMenu]`, `[Header]`, `[Range]`, and `[Tooltip]` are `UnityEngine` types and need no directive.
+2. `UdonSharpBehaviour` cannot implement interfaces (see [constraints.md](constraints.md)), so `IEditorOnly` is exclusively for plain `MonoBehaviour` helpers. That is exactly the niche it fills: editor tooling that UdonSharp cannot express.
+
+### IEditorOnly vs the EditorOnly Tag
+
+| | `IEditorOnly` interface | `EditorOnly` tag |
+|---|---|---|
+| Granularity | Single component | Entire GameObject (with its children) |
+| Mechanism | VRChat SDK validation treats the component as editor-only | Unity standard: tagged GameObjects are excluded from builds |
+| Runtime components on the same GameObject | Keep working | Removed together with the GameObject |
+| Typical use | Setup helper attached next to runtime components | Dev-only objects (test rigs, reference geometry, measurement guides) |
+
+Use the tag when the whole object is development-only; use the interface when only the tooling component is.
+
+### Setup Helper Pattern: One-Click Udon Configuration
+
+An `IEditorOnly` helper can expose a small set of designer-facing fields, then a custom inspector or `[ContextMenu]` method applies them to one or more `UdonSharpBehaviour` components through the editor APIs covered in [Proxy System](#proxy-system): `Undo.RecordObject`, field assignment, `UdonSharpEditorUtility.CopyProxyToUdon`, then `EditorUtility.SetDirty` or scene dirty marking. Prefab users get explicit, simplified configuration in one place and one button instead of hand-editing serialized fields across several Udon components. Missing references can be surfaced before upload via an inspector help box.
+
+The pattern splits across two files: the runtime `UdonSharpBehaviour` in its own file (the class name must match the file name, paired with its program asset — see [UdonSharpProgramAsset Auto-Generation](#udonsharpprogramasset-auto-generation)), and the editor-only helper with its custom inspector in another.
+
+```csharp
+// TeleporterController.cs — runtime behaviour, ships with the world
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+public class TeleporterController : UdonSharpBehaviour
+{
+    public Transform exit;
+
+    public override void Interact()
+    {
+        if (exit == null || Networking.LocalPlayer == null)
+        {
+            return;
+        }
+
+        Networking.LocalPlayer.TeleportTo(exit.position, exit.rotation);
+    }
+}
+```
+
+```csharp
+// TeleporterSetupHelper.cs — editor-only setup component, never ships
+using UnityEngine;
+using VRC.SDKBase;
+
+#if UNITY_EDITOR
+using UdonSharpEditor;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+#endif
+
+public class TeleporterSetupHelper : MonoBehaviour, IEditorOnly
+{
+    public Transform entrance;
+    public Transform exit;
+    public TeleporterController controller;
+
+    private void OnDrawGizmosSelected()
+    {
+        if (entrance == null || exit == null)
+        {
+            return;
+        }
+
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawLine(entrance.position, exit.position);
+        Gizmos.DrawWireSphere(entrance.position, 0.25f);
+
+        Gizmos.color = Color.green;
+        Gizmos.DrawWireSphere(exit.position, 0.25f);
+    }
+}
+
+#if UNITY_EDITOR
+[CustomEditor(typeof(TeleporterSetupHelper))]
+public class TeleporterSetupHelperEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+        DrawPropertiesExcluding(serializedObject, "m_Script");
+        serializedObject.ApplyModifiedProperties();
+
+        TeleporterSetupHelper helper = (TeleporterSetupHelper)target;
+        bool missingReferences =
+            helper.entrance == null ||
+            helper.exit == null ||
+            helper.controller == null;
+
+        if (missingReferences)
+        {
+            EditorGUILayout.HelpBox(
+                "Assign entrance, exit, and controller before applying setup.",
+                MessageType.Warning
+            );
+        }
+
+        using (new EditorGUI.DisabledScope(missingReferences))
+        {
+            if (GUILayout.Button("Apply Setup"))
+            {
+                ApplySetup(helper);
+            }
+        }
+    }
+
+    private static void ApplySetup(TeleporterSetupHelper helper)
+    {
+        TeleporterController controller = helper.controller;
+
+        // Move the interactable to the entrance, then wire the destination
+        Undo.RecordObject(controller.transform, "Apply Teleporter Setup");
+        controller.transform.SetPositionAndRotation(
+            helper.entrance.position, helper.entrance.rotation);
+
+        Undo.RecordObject(controller, "Apply Teleporter Setup");
+        controller.exit = helper.exit;
+
+        UdonSharpEditorUtility.CopyProxyToUdon(controller);
+        EditorUtility.SetDirty(controller);
+
+        if (!Application.isPlaying)
+        {
+            EditorSceneManager.MarkSceneDirty(controller.gameObject.scene);
+        }
+    }
+}
+#endif
+```
+
+This inspector is for the plain helper, not for a `UdonSharpBehaviour`, so it does not call `UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader`. Plain `#if UNITY_EDITOR` is also sufficient in the helper file: `!COMPILER_UDONSHARP` guards code against the UdonSharp compile pass (see [Preprocessor Directives](#preprocessor-directives)) and only matters in files containing an `UdonSharpBehaviour`.
+
+### Choosing the Right Mechanism
+
+| Goal | Use |
+|------|-----|
+| Editor-only methods, gizmos, or validation on a U# script itself | `#if UNITY_EDITOR && !COMPILER_UDONSHARP` blocks (see [Preprocessor Directives](#preprocessor-directives)) |
+| Friendly inspector for a single UdonSharpBehaviour | Custom inspector with `DrawDefaultUdonSharpBehaviourHeader` (see [Custom Inspectors](#custom-inspectors)) |
+| Scene-wide or multi-component setup tooling living in the scene | Plain `MonoBehaviour` + `IEditorOnly` (+ custom inspector) |
+| Exclude an entire dev-only GameObject from upload | `EditorOnly` tag |
+
 ## Property Drawers
 
 ```csharp


### PR DESCRIPTION
## Summary

Adds an "Editor-Only Setup Components (IEditorOnly)" section to `references/editor-scripting.md` and wires it into the skill's discovery routes. Closes #236.

- `VRC.SDKBase.IEditorOnly` marker interface: SDK validation ignores implementing components when scanning a world/avatar for incompatible scripts (per the [official build pipeline docs](https://creators.vrchat.com/sdk/build-pipeline-callbacks-and-interfaces/))
- Comparison table: `IEditorOnly` interface (component granularity) vs the `EditorOnly` tag (GameObject granularity)
- Constraint interaction: `UdonSharpBehaviour` cannot implement interfaces, so the pattern is exclusively for plain `MonoBehaviour` helpers; `#if UNITY_EDITOR` is required around UnityEditor API usage because the helper lives in a runtime assembly
- Setup helper pattern: a two-file worked example (`TeleporterController` UdonSharpBehaviour + `TeleporterSetupHelper` with a custom inspector) that gives prefab users explicit one-click configuration through the documented proxy APIs (`Undo.RecordObject` → assign → `CopyProxyToUdon` → `SetDirty`), with a HelpBox guard for missing references and placement gizmos
- "Choosing the Right Mechanism" decision table routing between `#if` blocks, U# custom inspectors, `IEditorOnly` helpers, and the `EditorOnly` tag
- Discovery routes: SKILL.md task-routing row + reference-index keywords (`IEditorOnly`, `EditorOnly tag`, `setup helper`, `custom inspector`, `ContextMenu`, ...) and a CHEATSHEET reference-index row

## Verification

- `VRC.SDKBase.IEditorOnly` confirmed in SDK 3.10.3 `VRCSDKBase.dll` via the local SDK-search workspace (`strings VRCSDKBase.dll | grep IEditorOnly`); .NET metadata shows a public interface with no members
- Behavioral statements are scoped to official documentation only ([build pipeline callbacks and interfaces](https://creators.vrchat.com/sdk/build-pipeline-callbacks-and-interfaces/), [whitelisted world components](https://creators.vrchat.com/worlds/whitelisted-world-components/)); no strip-timing or bundle-size claims
- All code examples checked against UdonSharp constraints (one behaviour per file with matching name, no interface implementation on `UdonSharpBehaviour`, proxy sync ordering consistent with the existing Proxy System / Custom Inspectors sections)
- skill-judge score re-evaluated after the change: 119/120 (A+), unchanged from baseline
- `editorconfig-checker` clean on touched files; internal anchors and relative links verified

## Out of scope (follow-up issues)

- #237 — world-sdk-3 coverage of the component whitelist and `EditorOnly` tag
- #238 — build pipeline callback interfaces (`IVRCSDKBuildRequestedCallback`, `IPreprocessCallbackBehaviour`, scene pre/postprocess callbacks)