### PR TITLE
docs(skills/world-sdk): document component whitelist and editor-only exclusion

### DIFF
--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -430,13 +430,13 @@ Starter templates for common SDK component patterns. Each template compiles with
 
 ## References
 
-| File                            | Content                   | Approx. Lines |
-| ------------------------------- | ------------------------- | ------------- |
-| `references/components.md`      | All component details     | 800+          |
-| `references/layers.md`          | Layers & collision        | 400+          |
-| `references/performance.md`     | Performance optimization  | 500+          |
-| `references/lighting.md`        | Lighting settings         | 400+          |
-| `references/audio-video.md`     | Audio & video             | 400+          |
-| `references/upload.md`          | Upload procedure          | 300+          |
-| `references/troubleshooting.md` | Troubleshooting guide     | 500+          |
-| `CHEATSHEET.md`                 | Quick reference           | 200+          |
+| File                            | Content                                                                                         | Approx. Lines |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
+| `references/components.md`      | All component details, component whitelist, editor-only exclusion (EditorOnly tag / IEditorOnly) | 800+          |
+| `references/layers.md`          | Layers & collision                                                                              | 400+          |
+| `references/performance.md`     | Performance optimization                                                                        | 500+          |
+| `references/lighting.md`        | Lighting settings                                                                               | 400+          |
+| `references/audio-video.md`     | Audio & video                                                                                   | 400+          |
+| `references/upload.md`          | Upload procedure                                                                                | 300+          |
+| `references/troubleshooting.md` | Troubleshooting guide                                                                           | 500+          |
+| `CHEATSHEET.md`                 | Quick reference                                                                                 | 200+          |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -430,13 +430,13 @@ Starter templates for common SDK component patterns. Each template compiles with
 
 ## References
 
-| File                            | Content                                                                                         | Approx. Lines |
-| ------------------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
+| File                            | Content                                                                                          | Approx. Lines |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- -| ------------- |
 | `references/components.md`      | All component details, component whitelist, editor-only exclusion (EditorOnly tag / IEditorOnly) | 800+          |
-| `references/layers.md`          | Layers & collision                                                                              | 400+          |
-| `references/performance.md`     | Performance optimization                                                                        | 500+          |
-| `references/lighting.md`        | Lighting settings                                                                               | 400+          |
-| `references/audio-video.md`     | Audio & video                                                                                   | 400+          |
-| `references/upload.md`          | Upload procedure                                                                                | 300+          |
-| `references/troubleshooting.md` | Troubleshooting guide                                                                           | 500+          |
-| `CHEATSHEET.md`                 | Quick reference                                                                                 | 200+          |
+| `references/layers.md`          | Layers & collision                                                                               | 400+          |
+| `references/performance.md`     | Performance optimization                                                                         | 500+          |
+| `references/lighting.md`        | Lighting settings                                                                                | 400+          |
+| `references/audio-video.md`     | Audio & video                                                                                    | 400+          |
+| `references/upload.md`          | Upload procedure                                                                                 | 300+          |
+| `references/troubleshooting.md` | Troubleshooting guide                                                                            | 500+          |
+| `CHEATSHEET.md`                 | Quick reference                                                                                  | 200+          |

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -708,7 +708,10 @@ Some avatar-side features fire rays or cast queries into the world and react to 
 
 ## Allowed Unity Components
 
-Unity standard components available in VRChat.
+VRChat worlds run only whitelisted components. The authoritative list is the official
+[whitelisted world components](https://creators.vrchat.com/worlds/whitelisted-world-components/)
+page; per that page, components that are not in the list will not work. The Unity
+standard components below are the commonly used whitelisted subset.
 
 ### Physics
 
@@ -777,6 +780,27 @@ Unity standard components available in VRChat.
 ❌ Audio Sources on Avatar
 ❌ Unity Constraints (use VRC equivalents: VRCPositionConstraint, VRCRotationConstraint, VRCScaleConstraint, VRCParentConstraint, VRCAimConstraint, VRCLookAtConstraint)
 ```
+
+### Editor-Only Objects and Components
+
+For dev-only GameObjects such as test rigs, reference geometry, and measurement guides,
+assign the Unity `EditorOnly` tag. Unity excludes GameObjects with the `EditorOnly`
+tag in a Scene, including their child GameObjects, from builds.
+
+For editor-only components that must sit next to runtime components, such as setup-helper
+MonoBehaviours, implement the `VRC.SDKBase.IEditorOnly` marker interface. `IEditorOnly`
+has no members; VRChat SDK validation ignores `IEditorOnly` scripts when scanning the
+world for incompatible scripts.
+
+Use the `EditorOnly` tag when the whole GameObject and its children are dev-only. Use
+`IEditorOnly` when only one setup-helper component is editor-only and runtime components
+on the same GameObject should remain. For the full `IEditorOnly` pattern, `EditorOnly`
+comparison table, and worked setup-helper example, see
+[editor-scripting.md](../../unity-vrc-udon-sharp/references/editor-scripting.md).
+
+Custom MonoBehaviour scripts are not whitelisted and do not run in the client either way;
+the `EditorOnly` tag and `IEditorOnly` interface are about passing SDK validation cleanly
+and keeping dev-only content out of the upload intentionally.
 
 ## See Also
 

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -78,6 +78,14 @@ Common problems encountered during world development and their solutions.
 
 ```
 
+### "Unsupported component" warnings
+
+**Symptom**: SDK validation flags non-whitelisted scripts or components
+
+**Solution**: Remove them, tag dev-only objects `EditorOnly`, or mark setup-helper
+components with `IEditorOnly` — see
+[components.md](components.md#editor-only-objects-and-components).
+
 ---
 
 ## Scene Setup Issues

--- a/skills/unity-vrc-world-sdk-3/references/upload.md
+++ b/skills/unity-vrc-world-sdk-3/references/upload.md
@@ -133,6 +133,7 @@ Notes:
 | Layer setup required | Layers not configured | Click "Setup Layers" |
 | Build size too large | Build is too big | Reduce assets |
 | Script errors | Compilation errors | Fix scripts |
+| Unsupported component warnings | Non-whitelisted scripts or components in the scene | Remove them, tag dev-only objects `EditorOnly`, or mark setup-helper components with `IEditorOnly` (see [components.md](components.md#editor-only-objects-and-components)) |
 | Missing references | Reference errors | Fix references |
 
 ### Auto-Fix Feature


### PR DESCRIPTION
## Summary

Closes #237 (follow-up to #239). Adds the world-side facts around component whitelisting that the skill never stated:

- `components.md`: the "Allowed Unity Components" intro now states the whitelist policy explicitly, using the official wording — components not on the [whitelisted world components list](https://creators.vrchat.com/worlds/whitelisted-world-components/) "will not work"
- `components.md`: new "Editor-Only Objects and Components" subsection — `EditorOnly` tag for dev-only GameObjects (Unity-standard build exclusion, children included) vs `VRC.SDKBase.IEditorOnly` for component-granularity exclusion, with a cross-skill link to the full pattern in unity-vrc-udon-sharp `editor-scripting.md` (#239)
- `upload.md`: "Unsupported component warnings" row in the Common Validation Errors table pointing at both mechanisms
- `SKILL.md`: reference index row for components.md updated so the new coverage is discoverable

## Verification

- Behavioral statements scoped to official docs (whitelist page "will not work" wording; build pipeline page for `IEditorOnly`; Unity manual for `EditorOnly` tag semantics); no strip-timing or bundle-size claims
- Cross-skill relative link uses the same form as the existing one in `audio-video.md`
- Anchor `components.md#editor-only-objects-and-components` verified against the new heading
- `editorconfig-checker` clean on all three touched files