### PR TITLE
fix(skills/udon-sharp): correct broken networking examples and persistence contradictions

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
@@ -150,11 +150,11 @@ public class MapData : UdonSharpBehaviour
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class MapData : UdonSharpBehaviour
 {
-    // Manual sync budget: ~280KB = 286,720 bytes
+    // Manual sync data limit: 280,496 bytes
     // byte[] uses 1 byte/element vs int[] at 4 bytes/element
     // 256 x 256 as byte = 65,536 bytes — well within budget
     private const int MapSize = 256;
-    private const int MaxSyncBytes = 280 * 1024; // 286,720 bytes
+    private const int MaxSyncBytes = 280_000; // safely under the 280,496-byte Manual sync limit
 
     [UdonSynced] private byte[] tiles = new byte[MapSize * MapSize];
 
@@ -173,7 +173,7 @@ public class MapData : UdonSharpBehaviour
     }
 
     // For very large maps: chunk into multiple behaviours or use delta sync
-    // See: Delta Sync section above
+    // See: Delta Sync (Send Only Changes) in networking-bandwidth.md
 }
 ```
 

--- a/skills/unity-vrc-udon-sharp/references/networking-bandwidth.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-bandwidth.md
@@ -283,7 +283,7 @@ VRChat's transmission bandwidth is approximately **11KB/sec**. Large synced data
 Pack multiple small values into fewer variables to reduce sync overhead.
 See [Bit Packing](#bit-packing) above for the complete bit-count reference table and pack/unpack examples.
 
-Quick example — 40 color IDs (0-7, 3 bits each) into 15 bytes:
+Quick example — 40 color IDs (0-7, 3 bits each) into 15 bytes, with a guarded final two-byte read:
 
 ```csharp
 // 40 colors x 3 bits = 120 bits = 15 bytes (160 bytes from int[40] -> 93% reduction)
@@ -293,7 +293,8 @@ private byte GetColor(int index)
 {
     int byteIdx = (index * 3) / 8;
     int bitOffset = (index * 3) % 8;
-    int raw = packedColors[byteIdx] | (packedColors[byteIdx + 1] << 8);
+    int hi = (byteIdx + 1 < packedColors.Length) ? packedColors[byteIdx + 1] : 0;
+    int raw = packedColors[byteIdx] | (hi << 8);
     return (byte)((raw >> bitOffset) & 0x07);
 }
 ```

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -788,7 +788,7 @@ public void HighFrequencyEvent(float value) { }
 public void RareBroadcast(string message) { }
 ```
 
-**Note**: Events exceeding the rate limit are queued on the local client until the limit allows them to be sent; sustained overload can still drop them server-side. Rate limiting is applied **per event per behaviour**. Default is **5 calls/sec**, configurable up to **100 calls/sec** per event per behaviour.
+**Note**: Events exceeding the rate limit are queued on the local client until the limit allows them to be sent. The server silently drops events only in one documented case: players in the same instance running different world versions whose rate limits disagree. Rate limiting is applied **per event per behaviour**. Default is **5 calls/sec**, configurable up to **100 calls/sec** per event per behaviour.
 
 ### Types Usable as Parameters
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -543,13 +543,13 @@ public override void OnPlayerLeft(VRCPlayerApi player)
 `OnOwnershipRequest` allows the current owner to **accept or reject** ownership transfer requests:
 
 ```csharp
-private bool _isProcessingCriticalAction = false;
+[UdonSynced] private bool _isProcessingCriticalAction = false; // Shared gate: requester and owner must evaluate identical state.
 
 public override bool OnOwnershipRequest(
     VRCPlayerApi requestingPlayer,
     VRCPlayerApi requestedOwner)
 {
-    // Reject ownership transfers during critical game logic
+    // Reject ownership transfers during critical game logic using synced state
     if (_isProcessingCriticalAction)
     {
         Debug.Log($"Rejected ownership request from {requestingPlayer.displayName} " +
@@ -769,10 +769,10 @@ public class NetworkCallableExample : UdonSharpBehaviour
 
 ### Rate Limiting
 
-`[NetworkCallable]` accepts an optional integer parameter that controls the maximum call rate (in calls per second) allowed for that method per behaviour instance. This value also acts as the network cost/priority indicator — higher values consume more network budget and are scheduled at higher priority.
+`[NetworkCallable]` accepts an optional integer parameter that controls the maximum call rate (in calls per second) allowed for that event per behaviour instance. This value also acts as the network cost/priority indicator — higher values consume more network budget and are scheduled at higher priority.
 
 ```csharp
-// Default: 5 calls/sec per behaviour (no argument)
+// Default: 5 calls/sec per event per behaviour (no argument)
 [NetworkCallable]
 public void NormalEvent(int value) { }
 
@@ -785,7 +785,7 @@ public void HighFrequencyEvent(float value) { }
 public void RareBroadcast(string message) { }
 ```
 
-**Note**: Events exceeding the rate limit are dropped. Rate limiting is applied **per event per behaviour**. Default is **5 calls/sec**, configurable up to **100 calls/sec** per behaviour.
+**Note**: Events exceeding the rate limit are dropped. Rate limiting is applied **per event per behaviour**. Default is **5 calls/sec**, configurable up to **100 calls/sec** per event per behaviour.
 
 ### Types Usable as Parameters
 
@@ -918,34 +918,28 @@ private void ProcessData()
 
 ### Workaround: Targeting Specific Players
 
-Since direct player targeting is not available, use synced variables:
+Since direct player targeting is not available, include the target player's ID as a `[NetworkCallable]` parameter and let each receiver filter locally:
 
 ```csharp
-[UdonSynced] private int targetPlayerId;
-[UdonSynced] private string message;
-
 public void SendMessageToPlayer(VRCPlayerApi player, string msg)
 {
-    if (!Networking.IsOwner(gameObject))
-    {
-        Networking.SetOwner(Networking.LocalPlayer, gameObject);
-    }
-
-    targetPlayerId = player.playerId;
-    message = msg;
-    RequestSerialization();
-
-    SendCustomNetworkEvent(NetworkEventTarget.All, "CheckMessage");
+    SendCustomNetworkEvent(
+        NetworkEventTarget.All,
+        nameof(CheckMessage),
+        player.playerId,
+        msg
+    );
 }
 
-public void CheckMessage()
+[NetworkCallable]
+public void CheckMessage(int targetPlayerId, string message)
 {
-    if (Networking.LocalPlayer.playerId == targetPlayerId)
-    {
-        ProcessMessage(message);
-    }
+    if (Networking.LocalPlayer.playerId != targetPlayerId) return;
+    ProcessMessage(message);
 }
 ```
+
+Passing both the target and payload as event parameters avoids the synced-variable/event ordering race described above. For pre-3.8.1 SDKs, use synced variables and react in `OnDeserialization`/`FieldChangeCallback`, not in a paired network event.
 
 ## Data Limits
 
@@ -997,7 +991,7 @@ void Update()
 
 ## Object Pooling
 
-Dynamic instantiation is not network-supported in VRChat. Use object pooling with pre-placed GameObjects.
+Avoid instantiating networked objects mid-game. Use object pooling — pre-placed GameObjects or a pool built once in `Start()` (see patterns-networking.md).
 
 For full implementations, see:
 - Simple pool: [patterns-networking.md](patterns-networking.md#object-pooling)
@@ -1012,7 +1006,7 @@ public override void OnPlayerJoined(VRCPlayerApi player)
 
     Debug.Log($"{player.displayName} joined");
 
-    // Sync state for new player if we're owner
+    // Late joiners receive current synced values automatically; this owner refresh is defensive only.
     if (Networking.IsOwner(gameObject))
     {
         RequestSerialization();
@@ -1079,14 +1073,19 @@ public void OnInteract()
 ### Synced Timer
 
 ```csharp
-[UdonSynced] private float gameStartTime;
+[UdonSynced] private double gameStartTime;
 [UdonSynced] private bool gameRunning;
 
 public void StartGame()
 {
-    if (!Networking.IsMaster) return;
+    if (!Networking.IsOwner(gameObject))
+    {
+        Networking.SetOwner(Networking.LocalPlayer, gameObject);
+    }
 
-    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    if (!Networking.IsOwner(gameObject)) return;
+
+    gameStartTime = Networking.GetServerTimeInSeconds();
     gameRunning = true;
     RequestSerialization();
 }
@@ -1095,7 +1094,7 @@ void Update()
 {
     if (!gameRunning) return;
 
-    float elapsed = (float)Networking.GetServerTimeInSeconds() - gameStartTime;
+    double elapsed = Networking.GetServerTimeInSeconds() - gameStartTime;
     timerDisplay.text = elapsed.ToString("F1");
 }
 ```

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -544,6 +544,9 @@ public override void OnPlayerLeft(VRCPlayerApi player)
 
 ```csharp
 [UdonSynced] private bool _isProcessingCriticalAction = false; // Shared gate: requester and owner must evaluate identical state.
+// The owner sets this flag and calls RequestSerialization() around the critical action.
+// A synced gate still has a propagation window — a requester can read a stale value
+// until the owner's write deserializes — so keep gated sections short.
 
 public override bool OnOwnershipRequest(
     VRCPlayerApi requestingPlayer,
@@ -785,7 +788,7 @@ public void HighFrequencyEvent(float value) { }
 public void RareBroadcast(string message) { }
 ```
 
-**Note**: Events exceeding the rate limit are dropped. Rate limiting is applied **per event per behaviour**. Default is **5 calls/sec**, configurable up to **100 calls/sec** per event per behaviour.
+**Note**: Events exceeding the rate limit are queued on the local client until the limit allows them to be sent; sustained overload can still drop them server-side. Rate limiting is applied **per event per behaviour**. Default is **5 calls/sec**, configurable up to **100 calls/sec** per event per behaviour.
 
 ### Types Usable as Parameters
 
@@ -991,7 +994,7 @@ void Update()
 
 ## Object Pooling
 
-Avoid instantiating networked objects mid-game. Use object pooling — pre-placed GameObjects or a pool built once in `Start()` (see patterns-networking.md).
+Runtime-instantiated objects are never network-synced (`VRCInstantiate` results are local-only). Use object pooling — pre-placed GameObjects for synced objects, or a pool built once in `Start()` for local-only objects (see patterns-networking.md).
 
 For full implementations, see:
 - Simple pool: [patterns-networking.md](patterns-networking.md#object-pooling)
@@ -1130,7 +1133,7 @@ public void StartGame()
 {
     if (!Networking.IsMaster) return;  // Fragile: master may leave mid-check
 
-    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    gameStartTime = Networking.GetServerTimeInSeconds();
     gameRunning = true;
     RequestSerialization();
 }
@@ -1146,7 +1149,7 @@ public void StartGame()
 {
     if (!Networking.IsOwner(gameObject)) return;  // Stable: exactly one owner
 
-    gameStartTime = (float)Networking.GetServerTimeInSeconds();
+    gameStartTime = Networking.GetServerTimeInSeconds();
     gameRunning = true;
     RequestSerialization();
 }

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -231,7 +231,7 @@ public class DamageReceiver : UdonSharpBehaviour
 ### Chat System
 
 ```csharp
-[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+[UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class ChatSystem : UdonSharpBehaviour
 {
     public TextMeshProUGUI chatLog;
@@ -507,9 +507,12 @@ public class GrabbableRope : UdonSharpBehaviour
     public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
     {
         Networking.SetOwner(info.player, gameObject);
-        isGrabbed = true;
-        grabberId = info.player.playerId;
-        RequestSerialization();
+        if (info.player.isLocal)
+        {
+            isGrabbed = true;
+            grabberId = info.player.playerId;
+            RequestSerialization();
+        }
 
         grabSound.Play();
     }
@@ -722,15 +725,15 @@ The wiring for capacity-limited or master-approved variants follows the [Master-
 
 ### Solution
 
-Use an integer generation counter. Each new schedule increments the counter and captures the current value. The callback checks whether the counter has advanced; if so, a newer schedule exists and this invocation is a no-op.
+Use a pending callback counter. Each new schedule increments the counter. Each callback decrements it; if callbacks are still pending, a newer input arrived and this invocation is a no-op.
 
 ```csharp
 public class DebouncedSearch : UdonSharpBehaviour
 {
     [SerializeField] private float debounceDelay = 0.5f;
 
-    // Monotonically increasing; each new schedule captures the current value.
-    private int _scheduleGeneration = 0;
+    // Number of delayed callbacks still waiting to run.
+    private int _pendingCount = 0;
 
     /// <summary>
     /// Call this whenever input changes. Only the callback scheduled after the
@@ -738,23 +741,17 @@ public class DebouncedSearch : UdonSharpBehaviour
     /// </summary>
     public void OnInputChanged()
     {
-        _scheduleGeneration++;
-        // Pass the current generation as a serialized field so the callback can read it.
-        // UdonSharp does not support lambda captures, so store in a member variable.
-        _pendingGeneration = _scheduleGeneration;
+        _pendingCount++;
         SendCustomEventDelayedSeconds(nameof(ExecuteSearch), debounceDelay);
     }
 
-    // Captured generation for the most recently scheduled callback.
-    private int _pendingGeneration = 0;
-
     public void ExecuteSearch()
     {
-        // If _scheduleGeneration has moved past _pendingGeneration, a newer
-        // schedule supersedes this one — bail out.
-        if (_scheduleGeneration != _pendingGeneration) return;
+        _pendingCount--;
+        // If another delayed callback is still pending, a newer input supersedes this one.
+        if (_pendingCount > 0) return;
 
-        // Safe to execute: this is the most recent scheduled callback.
+        // Safe to execute: this is the last pending callback.
         PerformSearch();
     }
 
@@ -766,7 +763,7 @@ public class DebouncedSearch : UdonSharpBehaviour
 }
 ```
 
-> **Note:** This pattern ensures only the *last* scheduled event executes. It does not prevent intermediate callbacks from running their guard check — it only makes them return immediately.
+> **Note:** Every scheduled callback still runs its guard and decrements the counter. Only the final callback sees no newer pending work and executes the search.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -519,9 +519,14 @@ public class GrabbableRope : UdonSharpBehaviour
 
     public override void OnPhysBoneRelease(PhysBoneReleaseInfo info)
     {
-        isGrabbed = false;
-        grabberId = -1;
-        RequestSerialization();
+        // PhysBoneReleaseInfo carries no player field; the grabber owns the
+        // object after the grab, so gate the synced writes on ownership.
+        if (Networking.IsOwner(gameObject))
+        {
+            isGrabbed = false;
+            grabberId = -1;
+            RequestSerialization();
+        }
 
         releaseSound.Play();
     }
@@ -747,9 +752,12 @@ public class DebouncedSearch : UdonSharpBehaviour
 
     public void ExecuteSearch()
     {
+        // Public only because Udon event targets must be — do not call this
+        // directly; stray calls would drive the pending counter negative.
         _pendingCount--;
         // If another delayed callback is still pending, a newer input supersedes this one.
         if (_pendingCount > 0) return;
+        _pendingCount = 0; // Floor against stray external calls
 
         // Safe to execute: this is the last pending callback.
         PerformSearch();

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -31,7 +31,8 @@ Does another player need to see this value?
           │                 └─ Yes ─→ PlayerObject (synced UdonBehaviour per player)
           │
           └─ Shared ─────── Does a late joiner need to see the current value?
-                            ├─ No ──→ SendCustomNetworkEvent (fire-and-forget, no payload)
+                            ├─ No ──→ SendCustomNetworkEvent (fire-and-forget, no payload;
+                            │          or up to 8 parameters with [NetworkCallable], SDK 3.8.1+)
                             └─ Yes ─→ [UdonSynced] variable (Continuous or Manual)
 ```
 
@@ -41,9 +42,9 @@ Does another player need to see this value?
 |-------|-------|----------|----------|-------------|
 | **Non-synced field** | Self only | Until scene reload | Unlimited | UI state, timers, cooldown flags |
 | **[UdonSynced]** | All players in instance | Instance lifetime (late joiners receive current value) | ~200 B continuous / ~280KB (280,496 bytes) manual per behaviour | Shared game state, scores, toggles |
-| **SendCustomNetworkEvent** | All players in instance | Instant (no persistence, late joiners miss it) | Event name only (no payload) | Sound effects, particle triggers, one-shot notifications |
+| **SendCustomNetworkEvent** | All players in instance | Instant (no persistence, late joiners miss it) | Event name only, or up to 8 parameters with `[NetworkCallable]` (SDK 3.8.1+) | Sound effects, particle triggers, one-shot notifications |
 | **PlayerData** | Per player, readable by all | Cross-session (permanent until deleted) | 100 KB per player per world | Settings, unlocks, high scores |
-| **PlayerObject** | Per player, synced behaviour | Instance lifetime (+ cross-session if `VRCEnablePersistence` is on) | One UdonBehaviour per player | Complex per-player state with frequent updates |
+| **PlayerObject** | Per player, synced behaviour | Instance lifetime (+ cross-session if `VRCEnablePersistence` is on) | Multiple UdonBehaviours per prefab (combined toward the 100 KB limit) | Complex per-player state with frequent updates |
 
 ### Common Mistakes
 
@@ -183,13 +184,13 @@ PlayerObject is a more powerful system for per-player state management. When a p
 
 ### Required Components
 
-All three components must be on the same root GameObject of your prefab:
+These components live on the same root GameObject of your prefab; `VRCEnablePersistence` is only required when the data must persist:
 
 | Component | Purpose |
 |-----------|---------|
 | `VRCPlayerObject` | Marks the prefab as a per-player object; triggers auto-instantiation |
 | `UdonBehaviour` | Holds `[UdonSynced]` variables and logic |
-| `VRCEnablePersistence` | Opts the UdonBehaviour's synced data into cloud persistence |
+| `VRCEnablePersistence` | Optional: opts the UdonBehaviour's synced data into cloud persistence |
 
 > Note: `VRCEnablePersistence` must be placed on the **same GameObject** as each `UdonBehaviour` whose data you want persisted. A PlayerObject prefab with no `VRCEnablePersistence` still instantiates per-player but does not persist data.
 
@@ -198,7 +199,7 @@ All three components must be on the same root GameObject of your prefab:
 1. Create a prefab in your project
 2. Add `VRC Player Object` component to the root of the prefab
 3. Add your `UdonSharpBehaviour` script as an `UdonBehaviour` component
-4. Add `VRC Enable Persistence` component to the same root GameObject
+4. If data must persist, add `VRC Enable Persistence` component to the same root GameObject
 5. Place **one instance** of the prefab in the scene — VRChat handles instantiation for all players automatically
 
 ### OnPlayerRestored on PlayerObjects
@@ -371,21 +372,21 @@ public class PlayerBadge : UdonSharpBehaviour
 
 ## Persistence Storage Information API (SDK 3.10.0+)
 
-Since SDK 3.10.0, VRChat exposes methods to query how much persistence storage each player is using. This applies to **both** PlayerData and PlayerObject data combined.
+Since SDK 3.10.0, VRChat exposes methods to query how much PlayerData persistence storage each player is using. PlayerObject has a separate 100 KB per-player quota.
 
 ### API Methods
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `player.GetPlayerDataStorageUsage()` | `int` (bytes) | Current persistence bytes used by this player |
-| `player.GetPlayerDataStorageLimit()` | `int` (bytes) | Maximum bytes allowed (typically 102400 = 100 KB) |
+| `player.GetPlayerDataStorageUsage()` | `int` (bytes) | Current PlayerData bytes used by this player |
+| `player.GetPlayerDataStorageLimit()` | `int` (bytes) | Maximum PlayerData bytes allowed (typically 102400 = 100 KB) |
 | `player.RequestStorageUsageUpdate()` | `void` | Requests a fresh usage value from the server |
 
 ### OnPersistenceUsageUpdated Event
 
 `OnPersistenceUsageUpdated` fires on the local player's UdonBehaviours when updated storage
 usage data is available (e.g., after a `RequestStorageUsageUpdate()` call or after a write).
-The event signature takes the player whose usage changed.
+The event is parameterless; query `Networking.LocalPlayer` for the updated usage.
 
 ### Storage Monitoring Example
 
@@ -472,7 +473,6 @@ public class StorageMonitor : UdonSharpBehaviour
 | Limit | Value |
 |-------|-------|
 | Total per player per world | 100 KB |
-| String max length | ~50 characters |
 | Key name max length | 128 characters |
 
 ### PlayerObject Limits
@@ -480,7 +480,6 @@ public class StorageMonitor : UdonSharpBehaviour
 | Limit | Value |
 |-------|-------|
 | Total per player per world | 100 KB |
-| Per UdonBehaviour with VRC Enable Persistence | 108 bytes per variable type |
 
 ### Bandwidth Considerations
 

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -44,7 +44,7 @@ Does another player need to see this value?
 | **[UdonSynced]** | All players in instance | Instance lifetime (late joiners receive current value) | ~200 B continuous / ~280KB (280,496 bytes) manual per behaviour | Shared game state, scores, toggles |
 | **SendCustomNetworkEvent** | All players in instance | Instant (no persistence, late joiners miss it) | Event name only, or up to 8 parameters with `[NetworkCallable]` (SDK 3.8.1+) | Sound effects, particle triggers, one-shot notifications |
 | **PlayerData** | Per player, readable by all | Cross-session (permanent until deleted) | 100 KB per player per world | Settings, unlocks, high scores |
-| **PlayerObject** | Per player, synced behaviour | Instance lifetime (+ cross-session if `VRCEnablePersistence` is on) | Multiple UdonBehaviours per prefab (combined toward the 100 KB limit) | Complex per-player state with frequent updates |
+| **PlayerObject** | Per player, synced behaviour | Instance lifetime (+ cross-session if `VRCEnablePersistence` is on) | Multiple UdonBehaviours per PlayerObject — their persisted data counts toward the per-player 100 KB total | Complex per-player state with frequent updates |
 
 ### Common Mistakes
 

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -184,7 +184,7 @@ PlayerObject is a more powerful system for per-player state management. When a p
 
 ### Required Components
 
-These components live on the same root GameObject of your prefab; `VRCEnablePersistence` is only required when the data must persist:
+`VRCPlayerObject` sits on the prefab root; the `UdonBehaviour` and (when persisting) `VRCEnablePersistence` sit together on the same GameObject, root or child. `VRCEnablePersistence` is only required when the data must persist:
 
 | Component | Purpose |
 |-----------|---------|
@@ -199,7 +199,7 @@ These components live on the same root GameObject of your prefab; `VRCEnablePers
 1. Create a prefab in your project
 2. Add `VRC Player Object` component to the root of the prefab
 3. Add your `UdonSharpBehaviour` script as an `UdonBehaviour` component
-4. If data must persist, add `VRC Enable Persistence` component to the same root GameObject
+4. If data must persist, add `VRC Enable Persistence` component to the same GameObject as the UdonBehaviour
 5. Place **one instance** of the prefab in the scene — VRChat handles instantiation for all players automatically
 
 ### OnPlayerRestored on PlayerObjects


### PR DESCRIPTION
Closes #244

## Summary

Fixes the networking/persistence cluster defects from the self-consistency audit: example code an agent would copy verbatim no longer contradicts the doctrine stated around it, and persistence.md no longer disagrees with itself.

## Changes

**Broken examples fixed**
- Delayed Event Debounce: replaced the inert generation guard (always-equal comparison) with a pending-callback counter; only the last scheduled callback executes
- Sync Buffer Overflow "correct" example: `MaxSyncBytes` now sits under the documented 280,496-byte Manual limit (was 286,720)
- 40-color bit unpack: guarded the two-byte read window (indices 38–39 read past the 15-byte array)
- Targeting Specific Players: rewritten on `[NetworkCallable]` parameters, removing the synced-variable/event ordering race the same file flags as critical; pre-3.8.1 route noted
- OnOwnershipRequest: the verdict gate is now a synced field so requester and owner evaluate identical state
- Synced Timer: owner-centric ownership flow instead of the fragile IsMaster shape; `double` server time per the file's own optimization tip
- GrabbableRope: synced writes after `SetOwner(info.player, …)` now run only on the grabber's client (NEVER #12)
- ChatSystem: `BehaviourSyncMode.None` → `NoVariableSync` — UdonSharp's source documents that `None` also disables `SendCustomNetworkEvent`, so the example could not work as written

**persistence.md contradictions resolved (officially verified)**
- PlayerData and PlayerObject quotas are separate per the official persistence page ("100 KB of PlayerData and 100 KB of PlayerObject data per player"); removed the "combined" claim
- Removed undocumented limits ("String max length ~50 characters", "108 bytes per variable type") — the former contradicted the file's own Data Aging pattern
- `OnPersistenceUsageUpdated` is parameterless (matches the example and events.md)
- PlayerObject capacity: multiple UdonBehaviours per prefab; `VRCEnablePersistence` marked optional-for-persistence, matching the note below the table
- Decision tree/matrix now mention `[NetworkCallable]` payloads (SDK 3.8.1+)

**Alignment**
- Object pooling wording reconciled with SimplePool's Start()-time construction
- Dead "Delta Sync section above" pointer now names networking-bandwidth.md
- Late-joiner auto-delivery noted on the OnPlayerJoined defensive refresh
- NetworkCallable rate-limit scope unified to per event per behaviour

## Verification

- All factual changes resolved against official docs (persistence quotas, late-joiner delivery, OnPreSerialization guidance) or SDK 3.10.3 UdonSharp source (`BehaviourSyncMode` semantics, `OnPersistenceUsageUpdated()` signature) before editing
- editorconfig-checker clean on changed files; no heading/anchor changes