### PR TITLE
fix(skills/udon-sharp): correct event and API reference errors

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -143,6 +143,15 @@ string value = player.GetPlayerTag(string tagName);
 player.ClearPlayerTags();
 ```
 
+### Language Methods
+
+```csharp
+string language = VRCPlayerApi.GetCurrentLanguage(); // local user's selected language, RFC 5646: en, ja, zh-CN
+string[] languages = VRCPlayerApi.GetAvailableLanguages(); // selectable languages
+```
+
+These are local-user getters, not per-remote-player reads.
+
 ### PlayerObject Methods
 
 ```csharp
@@ -606,7 +615,7 @@ For details on the Web Loading API, see `references/web-loading.md`.
 - Rate limit: **Once every 5 seconds** (for String/Image each)
 - Max image resolution: **2048 x 2048**
 - Trusted URLs: Domain allowlist restrictions apply
-- Memory management: Must release with `IVRCImageDownload.Dispose()`
+- Memory management: `IVRCImageDownload.Dispose()` releases the download wrapper, not the GPU texture — destroy the assigned `Texture2D` (see `image-loading-vram.md`)
 
 ```csharp
 // String Loading (VRC.SDK3.StringLoading)
@@ -628,6 +637,8 @@ using VRC.Udon.Common.Interfaces;
 
 NetworkEventTarget.All    // Send to all players including self
 NetworkEventTarget.Owner  // Send to object owner only
+NetworkEventTarget.Others // Send to all players except self (SDK 3.8.1+)
+NetworkEventTarget.Self   // Send to local player only (SDK 3.8.1+)
 ```
 
 ### TrackingDataType
@@ -835,7 +846,7 @@ public class PersistentScore : UdonSharpBehaviour
 }
 ```
 
-## VRCCameraSettings API (SDK 3.9.0+)
+## VRCCameraSettings API (SDK 3.8.1+; CullingMask and GetCurrentCamera added in 3.9.0)
 
 Read-only access to VRChat's built-in camera parameters. Provides two static instances and an event callback when settings change.
 
@@ -1201,6 +1212,7 @@ dollyAnimation.Import();
 ```csharp
 using UdonSharp;
 using UnityEngine;
+using VRC.SDKBase;
 
 public class DollyController : UdonSharpBehaviour
 {

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -1213,6 +1213,7 @@ dollyAnimation.Import();
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.Components;
 
 public class DollyController : UdonSharpBehaviour
 {

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -799,7 +799,7 @@ PlayerData.DeleteKey(Networking.LocalPlayer, "oldKey");
 | `SetInt` / `TryGetInt` | `int` | 4 bytes |
 | `SetFloat` / `TryGetFloat` | `float` | 4 bytes |
 | `SetDouble` / `TryGetDouble` | `double` | 8 bytes |
-| `SetString` / `TryGetString` | `string` | ~50 chars |
+| `SetString` / `TryGetString` | `string` | No documented per-string cap — bounded by the 100 KB total |
 | `SetBytes` / `TryGetBytes` | `byte[]` | ~100KB total |
 | `SetVector3` / `TryGetVector3` | `Vector3` | 12 bytes |
 | `SetQuaternion` / `TryGetQuaternion` | `Quaternion` | 16 bytes |
@@ -811,7 +811,6 @@ PlayerData.DeleteKey(Networking.LocalPlayer, "oldKey");
 |------|------|
 | PlayerData per player per world | 100 KB |
 | PlayerObject per player per world | 100 KB |
-| Single UdonBehaviour with VRC Enable Persistence | 108 bytes per variable type |
 
 ### Usage Pattern
 

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -762,7 +762,7 @@ Note: `ExecuteInEditMode` can cause issues with UdonSharp. Use with caution.
 
 - [api.md](api.md) - VRChat API reference including types used in editor scripts
 - [constraints.md](constraints.md) - C# feature constraints that affect editor-time validation
-- [patterns-performance.md](patterns-performance.md) - DefaultExecutionOrder and performance patterns
+- [patterns-performance.md](patterns-performance.md) - Event dispatch cost tiers and performance patterns
 
 ## UdonSharpProgramAsset Auto-Generation
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -10,7 +10,7 @@ UdonSharp events include those that **require override** and those that **do not
 
 ### override Required (VRChat/Udon-Specific Events)
 
-`OnPlayerJoined`, `OnPlayerLeft`, `OnPlayerRespawn`, `OnMasterTransferred`, `OnPlayerSuspendChanged`, `OnAvatarChanged`, `OnAvatarEyeHeightChanged`, `OnLanguageChanged`, `OnVRCPlusMassGift`, `OnDeserialization`, `OnPreSerialization`, `OnPostSerialization`, `OnOwnershipTransferred`, `OnOwnershipRequest`, `Interact`, `OnPickup`, `OnDrop`, `OnPickupUseDown`, `OnPickupUseUp`, `OnPlayerTriggerEnter/Stay/Exit`, `OnPlayerCollisionEnter/Stay/Exit`, `OnPlayerParticleCollision`, `OnControllerColliderHitPlayer`, `OnStationEntered/Exited`, `OnPlayerRestored`, `OnPersistenceUsageUpdated`, `OnPlayerDataStorageExceeded/Warning`, `OnPlayerObjectStorageExceeded/Warning`, `OnContactEnter/Stay/Exit`, `OnPhysBoneGrab/Release`, `OnPhysBoneColliderEnter/Stay/Exit`, `OnPhysBonePosed`, `OnPhysBoneUnPosed`, `OnDroneTriggerEnter/Stay/Exit`, `InputJump`, `InputUse`, `InputGrab`, `InputDrop`, `InputMoveHorizontal/Vertical`, `InputLookHorizontal/Vertical`, `OnInputMethodChanged`, `MidiNoteOn/Off`, `MidiControlChange`, `OnVideo*`, `OnStringLoad*`, `OnImageLoad*`, `OnSpawn`, `OnVRCQualitySettingsChanged`, `OnVRCCameraSettingsChanged`, `OnScreenUpdate`, `OnAsyncGpuReadbackComplete`, `OnPurchaseConfirmed`, `OnPurchaseConfirmedMultiple`, `OnPurchaseExpired`, `OnPurchasesLoaded`, `OnListAvailableProducts`, `OnListProductOwners`, `OnListPurchases`, `OnProductEvent`
+`PostLateUpdate`, `OnPlayerJoined`, `OnPlayerLeft`, `OnPlayerRespawn`, `OnMasterTransferred`, `OnPlayerSuspendChanged`, `OnAvatarChanged`, `OnAvatarEyeHeightChanged`, `OnLanguageChanged`, `OnVRCPlusMassGift`, `OnDeserialization`, `OnPreSerialization`, `OnPostSerialization`, `OnOwnershipTransferred`, `OnOwnershipRequest`, `Interact`, `OnPickup`, `OnDrop`, `OnPickupUseDown`, `OnPickupUseUp`, `OnPlayerTriggerEnter/Stay/Exit`, `OnPlayerCollisionEnter/Stay/Exit`, `OnPlayerParticleCollision`, `OnControllerColliderHitPlayer`, `OnStationEntered/Exited`, `OnPlayerRestored`, `OnPlayerDataUpdated`, `OnPersistenceUsageUpdated`, `OnPlayerDataStorageExceeded/Warning`, `OnPlayerObjectStorageExceeded/Warning`, `OnContactEnter/Stay/Exit`, `OnPhysBoneGrab/Release`, `OnPhysBoneColliderEnter/Stay/Exit`, `OnPhysBonePosed`, `OnPhysBoneUnPosed`, `OnDroneTriggerEnter/Stay/Exit`, `InputJump`, `InputUse`, `InputGrab`, `InputDrop`, `InputMoveHorizontal/Vertical`, `InputLookHorizontal/Vertical`, `OnInputMethodChanged`, `MidiNoteOn/Off`, `MidiControlChange`, `OnVideo*`, `OnStringLoad*`, `OnImageLoad*`, `OnSpawn`, `OnVRCQualitySettingsChanged`, `OnVRCCameraSettingsChanged`, `OnScreenUpdate`, `OnAsyncGpuReadbackComplete`, `OnPurchaseConfirmed`, `OnPurchaseConfirmedMultiple`, `OnPurchaseExpired`, `OnPurchasesLoaded`, `OnListAvailableProducts`, `OnListProductOwners`, `OnListPurchases`, `OnProductEvent`
 
 ### override Not Required (Standard Unity Callbacks)
 
@@ -634,9 +634,12 @@ Called on GameObjects spawned from a VRCObjectPool.
 |-------|-------------|
 | `void OnSpawn()` | This object is spawned from a VRCObjectPool |
 
+> **Note**: `OnSpawn` is deprecated per the official docs — use `OnEnable` to react to an object being activated by the pool.
+
 ```csharp
 public override void OnSpawn()
 {
+    // OnSpawn is deprecated; prefer OnEnable for activation from the pool.
     // Initialize state when this pooled object becomes active
     _isActive = true;
     _spawnTime = Time.time;
@@ -649,7 +652,7 @@ public override void OnSpawn()
 
 ## Settings & Rendering Events
 
-Called when VRChat settings or rendering state changes. These events require SDK 3.10.0+.
+Called when VRChat settings or rendering state changes. The camera/quality settings events require SDK 3.8.1+ (additional camera members in 3.9.0).
 
 | Event | When Called |
 |-------|-------------|
@@ -791,10 +794,12 @@ The Unity/VRChat per-frame execution order (steady state, every frame):
 
 ### Initialization Guarantee
 
-`OnEnable` and `Start` are guaranteed to run **before any other event** fires on the behaviour, and they run with **no gap between them** on the initial activation. This means:
+`OnEnable` and `Start` normally run before other event callbacks on the behaviour, and they run with **no gap between them** on the initial activation. This means:
 
-- You can safely access component references set up in `Start()` from any event handler.
-- No VRChat event (player join, deserialization, etc.) will interrupt `OnEnable`/`Start`.
+- You can safely access component references set up in `Start()` from ordinary event handlers.
+- No ordinary VRChat event (player join, deserialization, etc.) will interrupt `OnEnable`/`Start`.
+
+> **Exception**: A `[FieldChangeCallback]` setter can run during initial deserialization before `Start()` returns — see the edge case below.
 
 ---
 
@@ -807,7 +812,7 @@ _onEnable → _start
     ↓
 OnPlayerJoined(self)          ← fires for yourself
     ↓
-OnMasterChanged               ← master transferred from nobody to you
+OnMasterTransferred           ← master transferred from nobody to you
 ```
 
 - You are immediately both Master and Owner of scene objects.
@@ -838,10 +843,10 @@ OnDeserialization             ← receives synced variable state from owner
 If the current owner calls `RequestSerialization()` at or very close to the time a late joiner's `OnPlayerJoined` fires (for example, in their own `OnPlayerJoined` handler), the following race condition can occur on the **late joiner's client**:
 
 1. Synced variable value arrives and changes.
-2. `OnVariableChanged` fires for the changed variable.
+2. The `[FieldChangeCallback]` property setter runs for the changed field.
 3. `OnDeserialization` fires immediately after.
 
-In this specific edge case (most likely when the late joiner is the **first instance** on its client), `OnVariableChanged` can fire **before** `Start()` has returned. Guard against this with an initialization flag (see pattern below).
+In this specific edge case (most likely when the late joiner is the **first instance** on its client), the `[FieldChangeCallback]` setter can run **before** `Start()` has returned. Guard against this with an initialization flag (see pattern below).
 
 ---
 
@@ -887,11 +892,24 @@ public override void OnDeserialization()
 
 #### Initialization Flag Guard
 
-Use a `_isInitialized` flag to ensure setup code runs exactly once after the first `OnDeserialization`, and to guard against `OnVariableChanged` firing before `Start()` completes:
+Use a `_isInitialized` flag to ensure setup code runs exactly once after the first `OnDeserialization`, and to guard against a `[FieldChangeCallback]` setter running before `Start()` completes:
 
 ```csharp
-[UdonSynced] private int _syncedScore;
+[UdonSynced, FieldChangeCallback(nameof(Value))]
+private int _syncedValue;
+
 private bool _isInitialized;
+
+public int Value
+{
+    get => _syncedValue;
+    set
+    {
+        _syncedValue = value;
+        if (!_isInitialized) return;
+        UpdateDisplay();
+    }
+}
 
 void Start()
 {
@@ -905,13 +923,6 @@ public override void OnDeserialization()
         _isInitialized = true;
         InitializeFromSyncedState();
     }
-    UpdateDisplay();
-}
-
-// OnVariableChanged can fire before Start() in edge cases — guard with the flag
-public override void OnVariableChanged()
-{
-    if (!_isInitialized) return;
     UpdateDisplay();
 }
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -844,7 +844,7 @@ If the current owner calls `RequestSerialization()` at or very close to the time
 
 1. Synced variable value arrives and changes.
 2. The `[FieldChangeCallback]` property setter runs for the changed field.
-3. `OnDeserialization` fires immediately after.
+3. `OnDeserialization` follows.
 
 In this specific edge case (most likely when the late joiner is the **first instance** on its client), the `[FieldChangeCallback]` setter can run **before** `Start()` has returned. Guard against this with an initialization flag (see pattern below).
 
@@ -892,13 +892,14 @@ public override void OnDeserialization()
 
 #### Initialization Flag Guard
 
-Use a `_isInitialized` flag to ensure setup code runs exactly once after the first `OnDeserialization`, and to guard against a `[FieldChangeCallback]` setter running before `Start()` completes:
+Use a pair of flags: `_isInitialized` suppresses `[FieldChangeCallback]` side effects until `Start()` completes, and `_hasReceivedState` runs one-time setup exactly once after the first `OnDeserialization`:
 
 ```csharp
 [UdonSynced, FieldChangeCallback(nameof(Value))]
 private int _syncedValue;
 
-private bool _isInitialized;
+private bool _isInitialized;    // true once Start() has completed
+private bool _hasReceivedState; // true after the first OnDeserialization
 
 public int Value
 {
@@ -906,6 +907,8 @@ public int Value
     set
     {
         _syncedValue = value;
+        // Suppress side effects until Start() completes — the setter can run
+        // during initial deserialization, before Start() returns.
         if (!_isInitialized) return;
         UpdateDisplay();
     }
@@ -913,14 +916,17 @@ public int Value
 
 void Start()
 {
-    _isInitialized = false;
+    // Render defaults here: on the instance creator's client,
+    // OnDeserialization never fires on initial load.
+    UpdateDisplay();
+    _isInitialized = true;
 }
 
 public override void OnDeserialization()
 {
-    if (!_isInitialized)
+    if (!_hasReceivedState)
     {
-        _isInitialized = true;
+        _hasReceivedState = true;
         InitializeFromSyncedState();
     }
     UpdateDisplay();
@@ -928,7 +934,6 @@ public override void OnDeserialization()
 
 private void InitializeFromSyncedState()
 {
-    UpdateDisplay();
     // Perform any one-time setup that depends on synced variables
 }
 ```

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -844,7 +844,9 @@ If the current owner calls `RequestSerialization()` at or very close to the time
 
 1. Synced variable value arrives and changes.
 2. The `[FieldChangeCallback]` property setter runs for the changed field.
-3. `OnDeserialization` follows.
+3. `OnDeserialization` follows. The pre-`Start()` window applies only to the
+   `[FieldChangeCallback]` setter — `OnDeserialization` itself dispatches between
+   frames, after `Start()`, per the Initialization Guarantee above.
 
 In this specific edge case (most likely when the late joiner is the **first instance** on its client), the `[FieldChangeCallback]` setter can run **before** `Start()` has returned. Guard against this with an initialization flag (see pattern below).
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -37,7 +37,7 @@ MyScript s = GetComponent<MyScript>();
 public class BaseGimmick : UdonSharpBehaviour { }
 public class DerivedGimmick : BaseGimmick { }
 
-BaseGimmick base = GetComponent<BaseGimmick>();     // finds DerivedGimmick too
+BaseGimmick baseGimmick = GetComponent<BaseGimmick>(); // finds DerivedGimmick too
 DerivedGimmick derived = GetComponent<DerivedGimmick>();
 BaseGimmick[] all = GetComponents<BaseGimmick>();   // plural form also works
 ```
@@ -141,9 +141,9 @@ The `Auto Hold` field on `VRC_Pickup` was simplified. The old three-value enum (
 
 Worlds upgrading from 3.8 should audit all `VRC_Pickup` components and confirm the auto hold setting is intentional, since `AutoDetect` no longer exists as a fallback.
 
-#### VRCCameraSettings API (SDK 3.9.0+)
+#### VRCCameraSettings API (SDK 3.8.1+; CullingMask and GetCurrentCamera added in 3.9.0)
 
-Read-only access to the player's active camera properties. Namespace: `VRC.SDK3.Rendering`.
+Read-only access to the player's active camera properties. Introduced in SDK 3.8.1; SDK 3.9.0 added `CullingMask` and `VRCCameraSettings.GetCurrentCamera`. Namespace: `VRC.SDK3.Rendering`.
 
 ```csharp
 using VRC.SDK3.Rendering;

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -255,7 +255,7 @@ VRC Constraint types: `VRCPositionConstraint`, `VRCRotationConstraint`, `VRCScal
 
 #### Persistence Storage Information API (SDK 3.10.0+)
 
-New `VRCPlayerApi` methods to query how much persistence storage (PlayerData + PlayerObject combined) a player is consuming.
+New `VRCPlayerApi` methods to query how much PlayerData persistence storage a player is consuming (PlayerObject data has a separate 100 KB per-player quota).
 
 ```csharp
 int used  = player.GetPlayerDataStorageUsage(); // bytes

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1555,7 +1555,7 @@ var myScript = other.GetComponent<MyScript>();
 
 ```
 
-On SDK 3.8+, `GetComponent<MyScript>()` works for `UdonSharpBehaviour` subclasses (including inherited types — see sdk-migration.md). Fetching `UdonBehaviour` itself returns the first `UdonBehaviour` regardless of program type.
+On SDK 3.8+, `GetComponent<MyScript>()` works for `UdonSharpBehaviour` subclasses (including inherited types — see [sdk-migration.md](sdk-migration.md)). Fetching `UdonBehaviour` itself returns the first `UdonBehaviour` regardless of program type.
 
 **Solution (Runtime, pre-SDK 3.8):**
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -496,6 +496,8 @@ private void DoAction()
 
 **Solution:**
 
+Read synced state in `OnDeserialization`; it fires after the joining client receives current values. `Start()` may run before the first deserialization, so do not read synced variables there.
+
 ```csharp
 
 public override void OnPlayerJoined(VRCPlayerApi player)
@@ -507,10 +509,8 @@ public override void OnPlayerJoined(VRCPlayerApi player)
     }
 }
 
-// Or use Start() for initial state
-void Start()
+public override void OnDeserialization()
 {
-    // This runs after OnDeserialization for late joiners
     ApplyState();
 }
 
@@ -597,11 +597,11 @@ public void HighFrequencyEvent(float value) { }
 private float lastSendTime;
 private const float SEND_INTERVAL = 0.1f;
 
-public void SendIfReady(int value)
+public void SendIfReady(float value)
 {
     if (Time.time - lastSendTime < SEND_INTERVAL) return;
     lastSendTime = Time.time;
-    SendCustomNetworkEvent(NetworkEventTarget.All, nameof(MyEvent), value);
+    SendCustomNetworkEvent(NetworkEventTarget.All, nameof(HighFrequencyEvent), value);
 }
 
 ```
@@ -1546,21 +1546,23 @@ void Start()
 
 ### GetComponent Returns Proxy Instead of UdonSharpBehaviour
 
-**Problem:**
+**Problem (SDK 3.7 and older):**
 
 ```csharp
 
-// Returns UdonBehaviour, not your type
+// Older SDKs could return a proxy/incorrect type for UdonSharpBehaviour subclasses
 var myScript = other.GetComponent<MyScript>();
 
 ```
 
-**Solution (Runtime):**
+On SDK 3.8+, `GetComponent<MyScript>()` works for direct `UdonSharpBehaviour` subclasses. Fetching `UdonBehaviour` itself returns the first `UdonBehaviour` regardless of program type.
+
+**Solution (Runtime, pre-SDK 3.8):**
 
 ```csharp
 
-// Cast works at runtime in VRChat
-var myScript = (MyScript)other.GetComponent(typeof(UdonBehaviour));
+// Fetch by your script type, then cast through object
+var myScript = (MyScript)(object)other.GetComponent(typeof(MyScript));
 
 ```
 
@@ -1568,10 +1570,10 @@ var myScript = (MyScript)other.GetComponent(typeof(UdonBehaviour));
 
 ```csharp
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
 var myScript = other.GetUdonSharpComponent<MyScript>();
 #else
-var myScript = (MyScript)other.GetComponent(typeof(UdonBehaviour));
+var myScript = (MyScript)(object)other.GetComponent(typeof(MyScript));
 #endif
 
 ```

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -496,7 +496,7 @@ private void DoAction()
 
 **Solution:**
 
-Read synced state in `OnDeserialization`; it fires after the joining client receives current values. `Start()` may run before the first deserialization, so do not read synced variables there.
+Read synced state in `OnDeserialization`; it fires after the joining client receives current values. `Start()` runs before the first deserialization, so do not read synced variables there.
 
 ```csharp
 
@@ -1555,7 +1555,7 @@ var myScript = other.GetComponent<MyScript>();
 
 ```
 
-On SDK 3.8+, `GetComponent<MyScript>()` works for direct `UdonSharpBehaviour` subclasses. Fetching `UdonBehaviour` itself returns the first `UdonBehaviour` regardless of program type.
+On SDK 3.8+, `GetComponent<MyScript>()` works for `UdonSharpBehaviour` subclasses (including inherited types — see sdk-migration.md). Fetching `UdonBehaviour` itself returns the first `UdonBehaviour` regardless of program type.
 
 **Solution (Runtime, pre-SDK 3.8):**
 


### PR DESCRIPTION
Closes #243

## Summary

Fixes the event/API documentation cluster found by the self-consistency audit. Every signature and version statement below was verified against SDK 3.10.3 (UdonSharpBehaviour.cs / DLL metadata) or official release notes before editing.

## Changes

**events.md**
- Initialization Flag Guard no longer overrides a nonexistent `OnVariableChanged()` — rewritten on the `[FieldChangeCallback]` property setter, with the surrounding edge-case prose updated to match
- "Initialization Guarantee" now carries the qualifier for the FieldChangeCallback-before-Start edge case the same file documents
- Execution-order diagram: `OnMasterChanged` → `OnMasterTransferred` (the real virtual)
- Object Pool Events: deprecation note for `OnSpawn` per the official docs ("use OnEnable")
- Camera/quality settings events: SDK gate corrected from 3.10.0+ to 3.8.1+ (3.9.0 only added members)
- `PostLateUpdate` and `OnPlayerDataUpdated` added to the override-required list (both verified virtuals)

**api.md**
- `NetworkEventTarget`: added the missing `Others` / `Self` members (DLL enum: All, Owner, Others, Self; added in 3.8.1)
- VRCCameraSettings section: introduced in SDK 3.8.1 per release-3-8-1 notes ("Includes 2 new events…"); 3.9.0 additions noted
- Image loading: `Dispose()` releases the wrapper, not the GPU texture (aligned with image-loading-vram.md)
- DollyController example: added the missing `using VRC.SDKBase;`
- Added a brief documented entry for `VRCPlayerApi.GetCurrentLanguage()` / `GetAvailableLanguages()` (official players page; local-user getters)

**troubleshooting.md**
- Late-joiner fix no longer claims `Start()` runs after `OnDeserialization` — the snippet now reads synced state in `OnDeserialization`, matching events.md and the official event order
- Generic `GetComponent<T>` section qualified to pre-3.8 SDKs; the legacy recipe now fetches by script type (the `UdonBehaviour`-typed fetch returns the first behaviour regardless of program type)
- Editor branch uses the full `#if UNITY_EDITOR && !COMPILER_UDONSHARP` guard
- Throttle snippet sends a defined event with matching parameter types

**sdk-migration.md** — `base` reserved-keyword variable renamed; VRCCameraSettings version statement corrected

**editor-scripting.md** — See Also entry describes patterns-performance.md accurately (DefaultExecutionOrder lives in this file)

## Verification

- UdonSharpBehaviour.cs (SDK 3.10.3) checked for every event signature touched; NetworkEventTarget read from VRC.Udon.Common.dll metadata
- Release notes 3.8.1/3.9.0 checked for the VRCCameraSettings timeline; official network-components page for the OnSpawn deprecation
- No heading/anchor breakage (in-repo links grepped); editorconfig-checker clean