### PR TITLE
fix(skills/world-sdk): resolve cross-file contradictions and repair the references table

### DIFF
--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -71,7 +71,7 @@ Demo:       All players at Spawns[0]
 ├── Collider (IsTrigger recommended)
 ├── Rigidbody
 ├── VRC_Pickup
-│   ├── Auto Hold: Yes/No/AutoDetect
+│   ├── Auto Hold: Yes/No (v1.1; AutoDetect is v1.0-only)
 │   ├── Pickupable: true
 │   └── Allow Theft: true
 └── VRC_ObjectSync (for sync)
@@ -172,7 +172,7 @@ Physics.Raycast(origin, dir, out hit, distance, playerMask);
 |------|-----|-------|
 | FPS Target | 45+ VR, 60+ Desktop | 72 |
 | Mirrors | 1 (default OFF) | 0-1 |
-| Video Players | 2 | 1 |
+| Video Players | 1-2 recommended | 1 recommended |
 | Realtime Lights | 0-1 | 0 |
 | Polygons | 500K-1M | 50K-100K |
 | Materials | No limit | 25 or less |
@@ -194,7 +194,7 @@ Physics.Raycast(origin, dir, out hit, distance, playerMask);
 □ Light baking complete
 □ Realtime lights ≤ 1
 □ Mirror default OFF
-□ Video players ≤ 2
+□ Video players kept to 1-2 (recommended)
 □ Static Batching enabled
 □ Occlusion Culling configured
 □ LOD configured
@@ -250,7 +250,7 @@ Do NOT place:
 
 | Property | Default | Range |
 |----------|---------|-------|
-| Gain | 0 dB | -24 ~ +24 |
+| Gain | 10 dB | 0-24 dB |
 | Near | 0 m | Attenuation start |
 | Far | 40 m | Attenuation end |
 | Volumetric Radius | 0 m | Source spread |

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -45,9 +45,10 @@
 ### Spawn Order
 
 ```text
+First:      Always the first spawn
 Sequential: 0 → 1 → 2 → 0 → 1 (in order)
 Random:     Random selection
-Demo:       All players at Spawns[0]
+Demo:       Spawn point = center of room scale
 ```
 
 ---
@@ -93,7 +94,7 @@ OnPickupUseUp()      // Trigger released
 └── VRC_Station
     ├── Player Mobility: Mobile/Immobilize
     ├── Disable Station Exit: false
-    └── Entry/Exit Transform
+    └── Station Enter/Exit Player Location
 ```
 
 **Udon:**

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -36,7 +36,7 @@
 | Property | Description | Default |
 |----------|-------------|---------|
 | Spawns | Array of spawn points | Descriptor position |
-| Spawn Order | Sequential/Random/Demo | Sequential |
+| Spawn Order | First/Sequential/Random/Demo | Sequential |
 | Respawn Height | Respawn Y coordinate | -100 |
 | Reference Camera | Camera settings reference | None |
 | Maximum Capacity | Max player count | - |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -120,8 +120,8 @@ Quest required? → Yes
 | 3.7.4  | **Persistence API** (PlayerData/PlayerObject)                                  | ✅             |
 | 3.7.6  | **Multi-platform Build & Publish** (simultaneous PC + Android builds)          | ✅             |
 | 3.8.0  | PhysBone dependency sorting, **Force Kinematic On Remote**, Drone API          | ✅             |
-| 3.8.1  | **[NetworkCallable]** events with parameters, `Others`/`Self` targets          | ✅             |
-| 3.9.0  | **Camera Dolly API**, Auto Hold simplification, VRCCameraSettings              | ✅             |
+| 3.8.1  | **[NetworkCallable]** events with parameters, `Others`/`Self` targets, VRCCameraSettings | ✅ |
+| 3.9.0  | **Camera Dolly API**, Auto Hold simplification, VRCCameraSettings additions (CullingMask, GetCurrentCamera) | ✅ |
 | 3.10.0 | **Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints)                 | ✅             |
 | 3.10.1 | Bug fixes and stability improvements                                           | ✅             |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅             |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -50,7 +50,7 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile with post-processing disabled |
 | 6 | Place more than 2 active video players simultaneously | Each player adds significant decoding overhead; running >2 simultaneously is a common cause of frame drops and audio issues in practice | Disable extra players at scene start; activate only the currently playing one |
 | 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use VRC Constraints (SDK 3.10.0+, world-supported) or Animator-driven transforms, and remove cloth from Quest meshes |
-| 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
+| 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — commonly on the order of 3-5× draw call overhead in practice, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
 | 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
 | 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit (PC) / 5-10 (Quest) as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
 | 11 | Add VRC_UIShape to a Screen Space or Overlay Canvas | VRC_UIShape requires World Space Canvas; other modes throw a runtime Unity error in VRChat — the UI renders visually but is not interactive, with no visible error to the world builder | Set Canvas > Render Mode to World Space before adding VRC_UIShape |
@@ -296,9 +296,7 @@ Exactly **one** is required in every VRChat world.
 | GPU-bound | Draw calls, overdraw, shader complexity | [performance.md](references/performance.md#optimization-workflow) §Optimization-Workflow |
 | Memory | VRAM usage, texture size, mesh count | [performance.md](references/performance.md#optimization-workflow) §Optimization-Workflow |
 
-**MANDATORY READ**: Load [performance.md](references/performance.md) before optimizing — measure first, then target the largest bottleneck.
-
-**MANDATORY READ** [`references/performance.md`](references/performance.md) and [`references/lighting.md`](references/lighting.md) for Quest optimization.
+**MANDATORY READ**: Load [performance.md](references/performance.md) before optimizing — measure first, then target the largest bottleneck — and [`references/lighting.md`](references/lighting.md) for Quest optimization.
 **Do NOT Load**: `references/audio-video.md`, `references/upload.md`.
 
 ---

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -44,7 +44,7 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | # | NEVER do this | Why it hurts | Use instead |
 |---|---------------|-------------|-------------|
 | 1 | Enable Mirror by default (active on world join) | Renders the entire scene twice — immediate FPS halving, catastrophic on Quest | Default Mirror OFF; add UdonSharp toggle or player-triggered activation |
-| 2 | Use realtime directional lights with real-time shadows | Quest has no hardware shadow acceleration; each shadow caster costs 10-30 FPS | Baked lightmaps + light probes; set lights to Baked or Mixed mode |
+| 2 | Use realtime directional lights with real-time shadows | Quest has no hardware shadow acceleration; shadow casters commonly cost on the order of 10-30 FPS in practice (varies by scene) | Baked lightmaps + light probes; set lights to Baked or Mixed mode |
 | 3 | Set Respawn Height at or above the world floor | Player respawns → falls → respawns again → infinite loop; players cannot recover | Set to an unreachable depth (e.g., floor at Y=0 → Respawn at Y=-100) |
 | 4 | Skip "Setup Layers for VRChat" on a new project | Layer collision matrix is wrong by default — players walk through walls, Pickups clip floors | Run VRChat SDK > Builder > "Setup Layers for VRChat" before placing any colliders |
 | 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile with post-processing disabled |
@@ -150,7 +150,8 @@ Exactly **one** is required in every VRChat world.
 | Property                        | Type        | Description                     | Default           |
 | ------------------------------- | ----------- | ------------------------------- | ------------------ |
 | **Spawns**                      | Transform[] | Array of spawn points           | Descriptor position |
-| **Spawn Order**                 | enum        | Sequential/Random/Demo (Demo: all players to Spawns[0]) | Sequential |
+| **Spawn Order**                 | enum        | First/Sequential/Random/Demo (First: always the first spawn; Demo: spawn point is the center of room scale) | Sequential |
+| **Spawn Orientation**           | enum        | Default/Align Player With Spawn Point/Align Room With Spawn Point | Default |
 | **Respawn Height**              | float       | Respawn height (Y axis)         | -100               |
 | **Object Behaviour At Respawn** | enum        | Respawn/Destroy                 | Respawn            |
 | **Reference Camera**            | Camera      | Player camera settings reference | None              |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -49,7 +49,7 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | 4 | Skip "Setup Layers for VRChat" on a new project | Layer collision matrix is wrong by default — players walk through walls, Pickups clip floors | Run VRChat SDK > Builder > "Setup Layers for VRChat" before placing any colliders |
 | 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile with post-processing disabled |
 | 6 | Place more than 2 active video players simultaneously | Each player adds significant decoding overhead; running >2 simultaneously is a common cause of frame drops and audio issues in practice | Disable extra players at scene start; activate only the currently playing one |
-| 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use Animator-driven transforms (no constraints) or remove cloth from Quest meshes |
+| 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use VRC Constraints (SDK 3.10.0+, world-supported) or Animator-driven transforms, and remove cloth from Quest meshes |
 | 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
 | 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
 | 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit (PC) / 5-10 (Quest) as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
@@ -330,7 +330,7 @@ Exactly **one** is required in every VRChat world.
 
 | Property              | Description           | Default            |
 | --------------------- | --------------------- | ------------------ |
-| Gain                  | Volume (dB)           | 0 (World: +10)    |
+| Gain                  | Volume boost (0-24 dB) | 10 dB (world default) |
 | Near                  | Attenuation start     | 0m                 |
 | Far                   | Attenuation end       | 40m                |
 | Volumetric Radius     | Source spread          | 0m                 |
@@ -435,9 +435,9 @@ Starter templates for common SDK component patterns. Each template compiles with
 | ------------------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
 | `references/components.md`      | All component details, component whitelist, editor-only exclusion (EditorOnly tag / IEditorOnly) | 800+          |
 | `references/layers.md`          | Layers & collision                                                                               | 300+          |
-| `references/performance.md`     | Performance optimization                                                                         | 500+          |
+| `references/performance.md`     | Performance optimization                                                                         | 700+          |
 | `references/lighting.md`        | Lighting settings                                                                                | 400+          |
-| `references/audio-video.md`     | Audio & video                                                                                    | 400+          |
+| `references/audio-video.md`     | Audio & video                                                                                    | 600+          |
 | `references/upload.md`          | Upload procedure                                                                                 | 300+          |
 | `references/troubleshooting.md` | Troubleshooting guide                                                                            | 500+          |
 | `CHEATSHEET.md`                 | Quick reference                                                                                  | 200+          |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -27,10 +27,10 @@ metadata:
 | ------------------------------------------ | -------------------------- | ------------------------------- |
 | [Scene Setup](#scene-setup)                | VRC_SceneDescriptor, Spawn | This file                       |
 | [Components](#components)                  | Pickup, Station, Mirror    | `references/components.md`      |
-| [Layers & Collision](#layers-collision)   | Layers, Collision Matrix   | `references/layers.md`          |
+| [Layers & Collision](#layers--collision)  | Layers, Collision Matrix   | `references/layers.md`          |
 | [Performance](#performance)                | Optimization guide         | `references/performance.md`     |
 | [Lighting](#lighting)                      | Lighting settings          | `references/lighting.md`        |
-| [Audio & Video](#audio-video)             | Audio, Video players       | `references/audio-video.md`     |
+| [Audio & Video](#audio--video)            | Audio, Video players       | `references/audio-video.md`     |
 | [World Upload](#world-upload)              | Upload workflow            | `references/upload.md`          |
 | [Troubleshooting](#troubleshooting)        | Problem solving            | `references/troubleshooting.md` |
 | [Cheatsheet](CHEATSHEET.md)               | Quick reference            | `CHEATSHEET.md`                 |
@@ -47,12 +47,12 @@ These cause silent world failures, performance disasters, or Quest incompatibili
 | 2 | Use realtime directional lights with real-time shadows | Quest has no hardware shadow acceleration; each shadow caster costs 10-30 FPS | Baked lightmaps + light probes; set lights to Baked or Mixed mode |
 | 3 | Set Respawn Height at or above the world floor | Player respawns → falls → respawns again → infinite loop; players cannot recover | Set to an unreachable depth (e.g., floor at Y=0 → Respawn at Y=-100) |
 | 4 | Skip "Setup Layers for VRChat" on a new project | Layer collision matrix is wrong by default — players walk through walls, Pickups clip floors | Run VRChat SDK > Builder > "Setup Layers for VRChat" before placing any colliders |
-| 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile or guard assets with `#if UNITY_ANDROID` |
+| 5 | Enable Post-Processing without Quest build profile | Post-Processing is silently disabled at runtime on Quest but VRAM is still allocated | Use separate Android build profile with post-processing disabled |
 | 6 | Place more than 2 active video players simultaneously | Each player adds significant decoding overhead; running >2 simultaneously is a common cause of frame drops and audio issues in practice | Disable extra players at scene start; activate only the currently playing one |
 | 7 | Use Unity Constraints or Cloth on Quest | Both are disabled silently at runtime on Quest — animations freeze, cloth hangs in place | Use Animator-driven transforms (no constraints) or remove cloth from Quest meshes |
 | 8 | Upload without completing a lightmap bake | Realtime GI calculates at runtime — 3-5× draw call overhead, unacceptable on Quest | Always bake lights before upload; Progressive GPU lightmapper is fastest |
 | 9 | Place player walkable surfaces on Default layer (0) | Collision matrix is wrong by default — avatar physics collision is unreliable; players may clip through geometry | Use Environment (layer 11) for all walkable geometry, walls, and floors |
-| 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
+| 10 | Use very high lightmap resolution for large areas without profiling | Texture memory can spike significantly at high resolutions; a common cause of OOM crashes on mobile headsets | Start at 10-20 texels/unit (PC) / 5-10 (Quest) as a practical guideline; profile VRAM and adjust — official guidance says "keep lightmap resolution low" for Quest |
 | 11 | Add VRC_UIShape to a Screen Space or Overlay Canvas | VRC_UIShape requires World Space Canvas; other modes throw a runtime Unity error in VRChat — the UI renders visually but is not interactive, with no visible error to the world builder | Set Canvas > Render Mode to World Space before adding VRC_UIShape |
 
 ## Reference Loading Guide
@@ -202,7 +202,7 @@ Exactly **one** is required in every VRChat world.
 ## Components
 
 **MANDATORY READ** [`references/components.md`](references/components.md) (~800 lines) before configuring any VRC component below. Load in full — dependency requirements and Udon event hooks are distributed throughout.
-**Do NOT Load**: `references/audio-video.md`, `references/lighting.md`.
+**Do NOT Load**: `references/audio-video.md` (unless the task involves audio/video components), `references/lighting.md`.
 
 | Component                  | Required Elements        | Purpose                        | SDK  |
 | -------------------------- | ------------------------ | ------------------------------ | ---- |
@@ -273,7 +273,7 @@ Exactly **one** is required in every VRChat world.
 | Item                | Recommended           | Reason                        |
 | ------------------- | --------------------- | ----------------------------- |
 | Mirrors             | 1, default OFF        | Renders the entire scene 2x   |
-| Video players       | Max 2                 | Decoding overhead             |
+| Video players       | 1-2 recommended       | Decoding overhead; no documented hard limit |
 | Realtime lights     | 0-1                   | Dynamic shadows are expensive  |
 | Lightmaps           | **Required**          | Performance foundation         |
 
@@ -309,7 +309,7 @@ Exactly **one** is required in every VRChat world.
 ```text
 ✅ Recommended settings:
 ├── Lightmapper: Progressive GPU
-├── Lightmap Resolution: 10-20 texels/unit
+├── Lightmap Resolution: 10-20 texels/unit (PC) / 5-10 (Quest)
 ├── Light Mode: Baked or Mixed
 └── Light Probes: Place along player paths
 
@@ -346,6 +346,7 @@ Exactly **one** is required in every VRChat world.
 | Quest support      | ✅    | ✅          |
 
 **MANDATORY READ** [`references/audio-video.md`](references/audio-video.md) for VRC_SpatialAudioSource or video player configuration.
+**Optional**: `references/components.md` when wiring audio/video components.
 **Do NOT Load**: `references/lighting.md`, `references/performance.md`.
 
 ---
@@ -402,7 +403,7 @@ Identify the symptom category and jump to the reference section:
 | Player walks through walls / floor | Layer setup not run; geometry not on Environment (11) | [troubleshooting.md §Layer & Collision](references/troubleshooting.md#layer--collision-issues) |
 | Can't grab / Pickup not working | Missing Collider, Rigidbody, or VRC_Pickup component | [troubleshooting.md §Component](references/troubleshooting.md#component-issues) |
 | Object not syncing / snaps back | Missing VRC_ObjectSync or ownership not transferred | [troubleshooting.md §Networking](references/troubleshooting.md#networking-issues) |
-| Can't sit / clips through Station | Missing Collider; Station Collision Transform needs adjustment | [troubleshooting.md §Component](references/troubleshooting.md#component-issues) |
+| Can't sit / clips through Station | Missing Collider; Station Enter Player Location needs adjustment | [troubleshooting.md §Component](references/troubleshooting.md#component-issues) |
 | Mirror not reflecting | Layers mask missing Player/PlayerLocal/MirrorReflection | [troubleshooting.md §Component](references/troubleshooting.md#component-issues) |
 | Build / Upload fails | Missing SceneDescriptor, script errors, layer warnings | [troubleshooting.md §Build](references/troubleshooting.md#build--upload-issues) |
 | Performance issues | Mirror ON, realtime lights, uncooked lightmaps | [performance.md](references/performance.md) |
@@ -431,9 +432,9 @@ Starter templates for common SDK component patterns. Each template compiles with
 ## References
 
 | File                            | Content                                                                                          | Approx. Lines |
-| ------------------------------- | ----------------------------------------------------------------------------------------------- -| ------------- |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
 | `references/components.md`      | All component details, component whitelist, editor-only exclusion (EditorOnly tag / IEditorOnly) | 800+          |
-| `references/layers.md`          | Layers & collision                                                                               | 400+          |
+| `references/layers.md`          | Layers & collision                                                                               | 300+          |
 | `references/performance.md`     | Performance optimization                                                                         | 500+          |
 | `references/lighting.md`        | Lighting settings                                                                                | 400+          |
 | `references/audio-video.md`     | Audio & video                                                                                    | 400+          |

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
@@ -18,7 +18,7 @@ using VRC.Udon; // Kept for consistency with other UdonSharp templates; not dire
 /// Sync mode note:
 ///   BehaviourSyncMode.Manual is used so that synced variables (if you add any) are
 ///   serialised on demand via RequestSerialization. If you add VRC_ObjectSync and have
-///   no UdonSynced variables, you can safely switch to BehaviourSyncMode.None instead.
+///   no UdonSynced variables, switch to BehaviourSyncMode.NoVariableSync (None would also disable SendCustomNetworkEvent, breaking the use-effect broadcast below).
 ///
 /// Ownership note:
 ///   VRC_ObjectSync automatically transfers ownership to the grabbing player on pickup.

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -122,7 +122,7 @@ AudioSource:
 └── Volume: 1.0
 
 VRC_SpatialAudioSource:
-├── Gain: 12 dB (above the 10 dB default)
+├── Gain: 10 dB (default — official guidance keeps Gain at default; Volumetric Radius below provides the area size)
 ├── Near: 5 m
 ├── Far: 50 m
 ├── Volumetric Radius: 10 m

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -122,7 +122,7 @@ AudioSource:
 └── Volume: 1.0
 
 VRC_SpatialAudioSource:
-├── Gain: +6 dB (louder)
+├── Gain: 12 dB (above the 10 dB default)
 ├── Near: 5 m
 ├── Far: 50 m
 ├── Volumetric Radius: 10 m

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -48,7 +48,7 @@ VRC_SpatialAudioSource is added alongside a Unity AudioSource.
 
 | Property | Type | Description | Default |
 |----------|------|-------------|---------|
-| **Gain** | float (dB) | Volume adjustment (-24 ~ +24) | 0 dB |
+| **Gain** | float (dB) | Volume adjustment (0-24 dB) | 10 dB |
 | **Near** | float (m) | Attenuation start distance | 0 m |
 | **Far** | float (m) | Attenuation end distance (0=infinite) | 40 m |
 | **Volumetric Radius** | float (m) | Source spread | 0 m |
@@ -92,7 +92,7 @@ AudioSource:
 └── Volume: 0.5
 
 VRC_SpatialAudioSource:
-├── Gain: 0 dB
+├── Gain: 10 dB (default)
 ├── Enable Spatialization: false
 └── (Near/Far ignored in 2D mode)
 ```
@@ -106,7 +106,7 @@ AudioSource:
 └── Volume: 1.0
 
 VRC_SpatialAudioSource:
-├── Gain: 0 dB
+├── Gain: 10 dB (default)
 ├── Near: 1 m
 ├── Far: 15 m
 ├── Volumetric Radius: 0
@@ -522,7 +522,7 @@ Ambient sounds (looping):
 
 Video players per world:
 ├── Recommended: 1-2
-└── Maximum: No strict limit (performance dependent)
+└── Maximum: not documented — performance-bound in practice
 
 Simultaneous playback:
 ├── Avoid simultaneous playback
@@ -617,7 +617,7 @@ Debug.Log($"Video playing: {videoPlayer.IsPlaying}");
 ### VRC_SpatialAudioSource Defaults
 
 ```text
-Gain: 0 dB (World: +10 dB)
+Gain: 10 dB (world audio source default)
 Near: 0 m
 Far: 40 m
 Volumetric Radius: 0 m

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -119,7 +119,7 @@ Allows players to grab objects.
 | Exact Grip | Transform | Exact grip position | null |
 | Exact Gun | Transform | Exact gun position | null |
 | Proximity | float | Pickup distance | 2.0 |
-| **Auto Hold** | enum | Yes/No/AutoDetect | No |
+| **Auto Hold** | enum | Yes/No (v1.1; AutoDetect is v1.0-only) | No |
 
 ### Auto Hold (SDK 3.9+)
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -178,6 +178,8 @@ public class PickupHandler : UdonSharpBehaviour
 }
 ```
 
+On desktop, `OnPickupUseDown` and `OnPickupUseUp` require Auto Hold = Yes to fire.
+
 ### Network Sync
 
 ```csharp
@@ -456,7 +458,7 @@ Configures 3D spatial audio. Automatically added to AudioSource.
 
 | Property | Type | Description | Default | Range |
 |----------|------|-------------|---------|-------|
-| Gain | float | Additional volume | 0 dB | 0-24 dB |
+| Gain | float | Additional volume | 10 dB (world audio sources) | 0-24 dB |
 | Near | float | Attenuation start distance | 0 m | - |
 | Far | float | Attenuation end distance | 40 m | - |
 | Volumetric Radius | float | Source size | 0 m | < Far |
@@ -487,7 +489,7 @@ Configures 3D spatial audio. Automatically added to AudioSource.
 
 ```text
 ⚠️ AudioSource on avatars:
-- Gain limit: 10 dB
+- Avatar gain cap: 10 dB
 - Far limit: 40 m
 - Always add VRC_SpatialAudioSource
   (If not added, SDK auto-generates one, causing unexpected behavior)
@@ -771,9 +773,11 @@ standard components below are the commonly used whitelisted subset.
 
 ### Disabled on Quest/Android
 
+Entries marked "on Avatar" come from avatar-side limitations and are listed here for completeness; unmarked entries are world-relevant where applicable.
+
 ```text
 ❌ Dynamic Bones
-❌ Cloth (allowed in worlds, not on avatars)
+❌ Cloth — completely disabled on Android/Quest
 ❌ Physics on Avatar (Rigidbody, Collider, Joint)
 ❌ Cameras on Avatar
 ❌ Lights on Avatar

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -44,14 +44,18 @@ Full component reference for SDK 3.7.1 - 3.10.3.
 ### Spawn Order Details
 
 ```csharp
+// First: Always use the first spawn
+// Every player appears at Spawns[0]
+
 // Sequential: Spawn in order
 // Join order: Player1→Spawn0, Player2→Spawn1, Player3→Spawn2, Player4→Spawn0...
 
 // Random: Random selection
 // Different spawn point each time
 
-// Demo: All at the same location
-// All players appear at Spawns[0]
+// Demo: Room-scale alignment mode
+// The spawn point represents the center of the player's room scale —
+// standing a meter from your room-scale center spawns you a meter from the spawn
 ```
 
 ### Reference Camera Settings
@@ -206,8 +210,8 @@ Creates a location where players can sit.
 [Station GameObject]
 ├── Collider (Required - for Interact)
 └── VRC_Station
-    ├── Entry Transform (optional)
-    └── Exit Transform (optional)
+    ├── Station Enter Player Location (optional)
+    └── Station Exit Player Location (optional)
 ```
 
 ### All Properties

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -659,7 +659,7 @@ public class DollyController : UdonSharpBehaviour
 
 ## VRCCameraSettings API
 
-Retrieves camera information (SDK 3.9+).
+Retrieves camera information (SDK 3.8.1+; CullingMask and GetCurrentCamera added in 3.9.0).
 
 ### Properties
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -29,7 +29,7 @@ Full component reference for SDK 3.7.1 - 3.10.3.
 | Property | Type | Description | Default |
 |----------|------|-------------|---------|
 | Spawns | Transform[] | Array of spawn points | Descriptor position |
-| Spawn Order | SpawnOrder | Sequential/Random/Demo | Sequential |
+| Spawn Order | SpawnOrder | First/Sequential/Random/Demo | Sequential |
 | Respawn Height | float | Respawn Y coordinate | -100 |
 | Object Behaviour At Respawn | enum | Respawn/Destroy | Respawn |
 | Reference Camera | Camera | Camera settings reference | None |

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -80,7 +80,7 @@ Problem:
 - Simultaneous playback increases load
 
 Countermeasures:
-□ Maximum 2
+□ Keep to 1-2 players (recommended; no documented hard limit)
 □ Avoid simultaneous playback
 □ Provide a low-resolution option
 ```

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -453,7 +453,7 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 | Custom shaders | Supported with caution | Custom shaders are allowed for worlds; use mobile-compatible shaders to avoid GPU overload. Avatars are restricted to VRChat Mobile shaders. |
 | Post-processing effects | Not supported | Bloom, depth of field, color grading unavailable |
 | Real-time shadows | Not supported | Baked lighting only |
-| Video players | Work with some limitations | See audio-video.md (Quest URL resolution caveats) |
+| Video players | Work with some limitations | See audio-video.md (some URLs unsupported on Quest) |
 | Particle systems | Limited | Reduce count and complexity |
 
 ### Features Not Available on Quest

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -80,7 +80,7 @@ Problem:
 - Simultaneous playback increases load
 
 Countermeasures:
-□ Keep to 1-2 players (recommended; no documented hard limit)
+□ Keep to 1-2 players on PC, 1 on Quest (recommended; no documented hard limit)
 □ Avoid simultaneous playback
 □ Provide a low-resolution option
 ```

--- a/skills/unity-vrc-world-sdk-3/references/performance.md
+++ b/skills/unity-vrc-world-sdk-3/references/performance.md
@@ -355,7 +355,7 @@ public void SlowUpdate()
 □ Lights fully baked
 □ Realtime lights = 0
 □ No mirrors or minimal
-□ Video players ≤ 1
+□ Video players kept to 1 (recommended)
 □ No Post Processing
 ```
 
@@ -427,7 +427,7 @@ In-game checks:
 □ Light baking complete
 □ Realtime lights ≤ 1
 □ Mirror default OFF
-□ Video players ≤ 2
+□ Video players kept to 1-2 (recommended)
 □ Static Batching enabled
 □ Occlusion Culling configured
 □ LOD configured (large objects)
@@ -453,7 +453,7 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 | Custom shaders | Supported with caution | Custom shaders are allowed for worlds; use mobile-compatible shaders to avoid GPU overload. Avatars are restricted to VRChat Mobile shaders. |
 | Post-processing effects | Not supported | Bloom, depth of field, color grading unavailable |
 | Real-time shadows | Not supported | Baked lighting only |
-| Video player (AVPro) | Not supported | Use Unity Video Player component instead |
+| Video players | Work with some limitations | See audio-video.md (Quest URL resolution caveats) |
 | Particle systems | Limited | Reduce count and complexity |
 
 ### Features Not Available on Quest
@@ -462,7 +462,6 @@ Reference: https://creators.vrchat.com/platforms/android/quest-content-optimizat
 ⚠️ Custom shaders (worlds only: allowed with caution; avoid complex HLSL/ShaderLab features that stress the mobile GPU. Avatar shaders are restricted to VRChat Mobile shaders.)
 ❌ Post-processing stack (any effect)
 ❌ Real-time shadow casting and receiving
-❌ AVPro video player
 ❌ Screen-space ambient occlusion (SSAO)
 ❌ Screen-space reflections (SSR)
 ❌ Tessellation and geometry shaders
@@ -562,7 +561,7 @@ Additional steps:
 Mandatory: all lighting must be baked before uploading the Quest build.
 
 Recommended settings for Quest:
-├── Lightmapper:           Progressive CPU (stable) or GPU
+├── Lightmapper:           Progressive GPU (fast; fall back to CPU if GPU memory is insufficient)
 ├── Lightmap Resolution:   5–10 texels/unit (lower = smaller textures)
 ├── Lightmap Size:         1024×1024 max per map
 ├── Directional Mode:      Non-Directional  ← required for Quest
@@ -639,7 +638,7 @@ Verify all items below before uploading a Quest-compatible world build.
     - VRChat/Mobile/Toon Lit (if using VRChat shaders)
 □ No custom HLSL shaders or unsupported ShaderLab features
 □ GPU Instancing enabled on all materials applied to repeated objects
-□ Material count < 25 per scene section
+□ Material count < 25 unique materials per world
 □ No post-processing volumes or components in the scene
 ```
 
@@ -668,7 +667,7 @@ Verify all items below before uploading a Quest-compatible world build.
 ### Platform-Specific Features
 
 ```text
-□ No AVPro video player components — replaced with Unity Video Player
+□ Video players configured for Quest (see audio-video.md)
 □ No post-processing components (Post Process Volume, etc.)
 □ No real-time shadow settings on any light
 □ No screen-space effects in any material or renderer

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -335,7 +335,7 @@ components with `IEditorOnly` — see
 1. Set mirror to default OFF
 2. Reduce/remove realtime lights
 3. Bake lights
-4. Check video player count (max 2)
+4. Check video player count (1-2 recommended)
 5. Reduce Draw Calls
 6. Reduce polygon count
 7. Lower texture resolution

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -234,7 +234,7 @@ components with `IEditorOnly` — see
 ```text
 
 1. If Disable Station Exit is true, set it to false
-2. Verify Exit Transform isn't inside an obstacle
+2. Verify Station Exit Player Location isn't inside an obstacle
 3. Implement forced exit in Udon
 
 ```

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -176,9 +176,9 @@ components with `IEditorOnly` — see
 
 ```text
 
-1. Check DisallowTheft on VRC_Pickup
-2. If DisallowTheft is true, the current holder owns it exclusively — a second grab is blocked
-3. Set DisallowTheft to false if shared grabbing is intended
+1. Check Allow Theft on VRC_Pickup
+2. If Allow Theft is disabled, the current holder owns it exclusively — a second grab is blocked
+3. Enable Allow Theft if shared grabbing is intended
 
 ```
 
@@ -219,9 +219,9 @@ components with `IEditorOnly` — see
 
 ```text
 
-1. Adjust the Station Collision Transform field in the VRC_Station Inspector
-2. Move the Station Collision Transform to an unobstructed position
-3. Ensure the Exit Transform is also clear of obstacles
+1. Adjust the Station Enter Player Location transform on the VRC_Station
+2. Move Station Enter Player Location to an unobstructed seated position
+3. Ensure Station Exit Player Location is also clear of obstacles
 
 ```
 


### PR DESCRIPTION
Closes #246

## Summary

Resolves the world-sdk-3 contradictions found by the self-consistency audit. Every contested fact was checked against official documentation before editing.

## Changes

**Docs-verified factual fixes**
- AVPro on Quest: performance.md claimed "Not supported — use Unity Video Player" in three places while audio-video.md/SKILL.md/CHEATSHEET marked Quest ✅. Official docs say link resolution now works on Android ("previous workarounds aren't needed") and that video players "work with some limitations" on Quest — performance.md now uses that scoped wording and routes to audio-video.md
- Cloth: removed the self-contradictory "(allowed in worlds, not on avatars)" parenthetical inside the Disabled-on-Quest list; official Quest limitations state "Cloth — Completely disabled on Android and Quest" (general components section). A scope note now separates the avatar-side entries in that list
- SpatialAudioSource Gain: unified to the official range 0-24 dB with the 10 dB world default ("By default, world audio sources get a 10dB boost") across components.md, audio-video.md, and CHEATSHEET; the avatar 10 dB cap is labeled as such
- Video player count: no official limit exists — "Max 2" hard-limit framing softened to recommendations everywhere (SKILL, CHEATSHEET, performance checklists, audio-video)
- VRC_Station: "Station Collision Transform" does not exist on the official component; troubleshooting and the SKILL quick-router now reference Station Enter/Exit Player Location
- Pickup theft: troubleshooting now uses the inspector name Allow Theft so cross-file grep against components.md works
- Auto Hold: CHEATSHEET carries the v1.1 Yes/No qualifier (AutoDetect is v1.0-only); components.md notes OnPickupUseDown/Up require Auto Hold = Yes on desktop (previously only stated in the bundled template)

**Internal consistency**
- Quest lightmap resolution: SKILL-level guidance now carries the PC/Quest split (10-20 / 5-10 texels per unit) matching lighting.md and performance.md
- Lightmapper recommendation unified on Progressive GPU with the CPU fallback noted
- Material budget scope unified to "< 25 unique materials per world"
- NEVER #5 no longer suggests `#if UNITY_ANDROID` for scene assets (not executable); the build-profile remedy stays
- audio-video.md load directives reconciled (Loading Guide row remains the source of truth)

**Mechanical repairs**
- References table delimiter row repaired (corrupted by a recent edit; the table did not render as GFM)
- TOC anchors `#layers--collision` / `#audio--video` fixed (double-hyphen anchors for "&" headings)
- layers.md size claim corrected (316 lines → "300+")

## Verification

- Official pages fetched 2026-06-11: video-players, quest-content-limitations, vrc_spatialaudiosource, vrc_station, whitelisted-world-components
- editorconfig-checker clean; heading anchors preserved (cross-file links re-checked)