### PR TITLE
fix(skills/udon-sharp): align pattern and media references with documented APIs

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -1,8 +1,8 @@
 # VRChat Dynamics for Worlds Reference
 
-Comprehensive guide to PhysBones, Contacts, and VRC Constraints in VRChat worlds (SDK 3.10.0+).
+Comprehensive guide to PhysBones, Contacts, and VRC Constraints in VRChat worlds (SDK 3.10.0 - 3.10.3).
 
-**Supported SDK Versions**: 3.10.0+ (2025 onward)
+**Supported SDK Versions**: 3.10.0 - 3.10.3
 
 ## Overview
 
@@ -679,7 +679,7 @@ public class ConstraintSourceSwapper : UdonSharpBehaviour
 ```
 
 **Notes**:
-- `VRCConstraintSource` is a **struct** — always construct a new instance and assign it; do not attempt to mutate the value returned by `GetSource()` in place (see [struct mutation caveat](../rules/udonsharp-constraints.md#struct-mutation)).
+- `VRCConstraintSource` is a **struct** — always construct a new instance and assign it; do not attempt to mutate the value returned by `GetSource()` in place (see [struct mutation caveat](../rules/udonsharp-constraints.md#3-struct-mutation)).
 - Remove sources from the **highest index downward** when removing multiple at once, to avoid index shifting mid-loop.
 - `SetSourceWeight(index, weight)` is a shorthand for read-modify-write with `GetSource` / `SetSource`; both approaches are equivalent.
 

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -301,7 +301,11 @@ public class DoubleBufferImageDisplay : UdonSharpBehaviour
 
     public override void OnImageLoadSuccess(IVRCImageDownload result)
     {
-        if (_isFading) return; // Ignore if a fade is already running
+        if (_isFading)
+        {
+            Destroy(result.Result); // Do not leak an abandoned texture while a fade is already running
+            return;
+        }
 
         Texture2D newTexture = result.Result;
 
@@ -923,6 +927,6 @@ public class StaggeredImageLoader : UdonSharpBehaviour
 
 - [web-loading.md](web-loading.md) — `VRCImageDownloader` API overview, rate limits, trusted URL list, and basic pattern
 - [api.md](api.md) — Quick reference for `VRCUrl`, `TextureInfo`, `IVRCImageDownload` properties
-- [troubleshooting.md](troubleshooting.md) — Web loading error table and HTTP error code reference
+- [troubleshooting.md](troubleshooting.md) — General UdonSharp compile, runtime, networking, persistence, and performance troubleshooting
 - [patterns-performance.md](patterns-performance.md) — Update Handler Pattern (disable per-frame polling when not needed)
 - [web-loading-advanced.md](web-loading-advanced.md) - Advanced data loading via StringDownloader with Base64 textures

--- a/skills/unity-vrc-udon-sharp/references/patterns-ui.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-ui.md
@@ -130,7 +130,7 @@ public class AvatarScaleUI : UdonSharpBehaviour
 > **Key notes:**
 > - `GetTrackingData(Head).position.y` returns the world-space Y of the player's head, which correlates with avatar scale.
 > - Clamp the scale factor to avoid UI becoming invisible (tiny avatars) or enormous (giant avatars).
-> - Call `ApplyScale()` from an external trigger (e.g., avatar change event or a periodic timer) since there is no built-in "avatar changed" callback in UdonSharp.
+> - Call `ApplyScale()` from `OnAvatarEyeHeightChanged(VRCPlayerApi, float)` or `OnAvatarChanged(VRCPlayerApi)`; `player.GetAvatarEyeHeightAsMeters()` is the direct avatar scale source when you do not need the head-Y heuristic.
 
 ---
 
@@ -138,12 +138,14 @@ public class AvatarScaleUI : UdonSharpBehaviour
 
 When players change their camera FOV (e.g., through VRChat camera zoom settings), world-space
 UI panels can drift out of view. This pattern adjusts the Canvas offset using trigonometric
-FOV calculations and hooks `OnVRCCameraSettingsChanged()` for live updates.
+FOV calculations and hooks `OnVRCCameraSettingsChanged(VRCCameraSettings cameraSettings)`
+for live updates (SDK 3.8.1+).
 
 ```csharp
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.Rendering;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class FovResponsiveUI : UdonSharpBehaviour
@@ -174,7 +176,7 @@ public class FovResponsiveUI : UdonSharpBehaviour
     /// <summary>
     /// Called by VRChat when camera settings (FOV, near/far plane) change.
     /// </summary>
-    public override void OnVRCCameraSettingsChanged()
+    public override void OnVRCCameraSettingsChanged(VRCCameraSettings cameraSettings)
     {
         RecalculatePosition();
     }
@@ -188,11 +190,8 @@ public class FovResponsiveUI : UdonSharpBehaviour
         if (_isVR) return;
 
         float currentFov = 60.0f;
-        Camera screenCam = VRCCameraSettings.ScreenCamera;
-        if (screenCam != null)
-        {
-            currentFov = screenCam.fieldOfView;
-        }
+        VRCCameraSettings screenCam = VRCCameraSettings.ScreenCamera;
+        currentFov = screenCam.FieldOfView;
 
         // Compute viewport-relative scale factor
         float refTan = Mathf.Tan((referenceFov / 2.0f) * Mathf.Deg2Rad);
@@ -214,7 +213,7 @@ public class FovResponsiveUI : UdonSharpBehaviour
 ```
 
 > **Key notes:**
-> - `OnVRCCameraSettingsChanged()` fires whenever the player adjusts camera zoom or near/far clip planes.
+> - `VRCCameraSettings` and `OnVRCCameraSettingsChanged(VRCCameraSettings cameraSettings)` require SDK 3.8.1+ and fire whenever the player adjusts camera zoom or near/far clip planes.
 > - VR headsets have a fixed FOV; this adjustment is only meaningful on desktop.
 > - The tangent ratio preserves the apparent angular size of the UI panel regardless of FOV.
 
@@ -230,6 +229,7 @@ UI layout at runtime based on platform and input mode.
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.Rendering;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class PlatformAdaptiveUI : UdonSharpBehaviour
@@ -278,10 +278,10 @@ public class PlatformAdaptiveUI : UdonSharpBehaviour
 
     private void ApplyAspectLayout()
     {
-        Camera screenCam = VRCCameraSettings.ScreenCamera;
-        if (screenCam == null) return;
+        VRCCameraSettings screenCam = VRCCameraSettings.ScreenCamera;
+        if (screenCam.PixelHeight <= 0) return;
 
-        float aspect = screenCam.aspect;
+        float aspect = (float)screenCam.PixelWidth / screenCam.PixelHeight;
         bool isLandscape = aspect >= 1.0f;
 
         if (landscapeSidebar != null) landscapeSidebar.SetActive(isLandscape);
@@ -293,7 +293,7 @@ public class PlatformAdaptiveUI : UdonSharpBehaviour
 > **Key notes:**
 > - `#if UNITY_ANDROID || UNITY_IOS` is evaluated at **compile time**, producing separate builds for PC and Quest with no runtime overhead.
 > - `IsUserInVR()` detects VR headsets at runtime — a PC user can be in either Desktop or VR mode.
-> - `VRCCameraSettings.ScreenCamera.aspect` returns the current viewport aspect ratio, useful for detecting portrait-mode streaming or unusual resolutions.
+> - `VRCCameraSettings.ScreenCamera` exposes `PixelWidth` and `PixelHeight`; compute aspect as `(float)PixelWidth / PixelHeight` after checking `PixelHeight > 0`.
 
 ---
 
@@ -301,7 +301,7 @@ public class PlatformAdaptiveUI : UdonSharpBehaviour
 
 Many worlds need a live player list for teleportation, team assignment, or voting.
 This pattern enumerates all players, creates a button for each, refreshes on join/leave,
-and dispatches click callbacks using button name parsing.
+and dispatches click callbacks through a parameterless per-button handler.
 
 ```csharp
 using UdonSharp;
@@ -318,8 +318,10 @@ public class DynamicPlayerList : UdonSharpBehaviour
     [SerializeField] private GameObject buttonTemplate;
 
     [Header("Configuration")]
-    [Tooltip("Prefix for button names used to identify player ID")]
+    [Tooltip("Prefix for generated button names")]
     [SerializeField] private string buttonPrefix = "PlayerBtn_";
+
+    [HideInInspector] public int selectedIndex = -1; // Written by ButtonHandler before OnPlayerButtonClicked
 
     private GameObject[] _activeButtons = new GameObject[0];
 
@@ -368,8 +370,16 @@ public class DynamicPlayerList : UdonSharpBehaviour
             btn.transform.SetParent(listParent, false);
             btn.SetActive(true);
 
-            // Encode player ID in button name for callback dispatch
+            // Name the clone for hierarchy/debugging
             btn.name = buttonPrefix + players[i].playerId.ToString();
+
+            ButtonHandler handler = btn.GetComponent<ButtonHandler>();
+            if (Utilities.IsValid(handler))
+            {
+                handler.buttonIndex = players[i].playerId;
+                handler.targetScript = this;
+                handler.methodName = nameof(OnPlayerButtonClicked);
+            }
 
             // Set display text
             TextMeshProUGUI label = btn.GetComponentInChildren<TextMeshProUGUI>();
@@ -383,34 +393,12 @@ public class DynamicPlayerList : UdonSharpBehaviour
     }
 
     /// <summary>
-    /// Called by each button's OnClick UnityEvent. The button passes
-    /// its own GameObject name so we can extract the player ID.
+    /// Called by ButtonHandler after it writes selectedIndex.
     /// </summary>
-    public void OnPlayerButtonClicked(string buttonName)
+    public void OnPlayerButtonClicked()
     {
-        if (buttonName == null) return;
-
-        // Parse player ID from button name
-        string idStr = buttonName.Replace(buttonPrefix, "");
-        int playerId = -1;
-
-        // Manual int parse (no int.TryParse in older Udon runtimes)
-        bool valid = true;
-        int result = 0;
-        for (int i = 0; i < idStr.Length; i++)
-        {
-            char c = idStr[i];
-            if (c < '0' || c > '9')
-            {
-                valid = false;
-                break;
-            }
-            result = result * 10 + (c - '0');
-        }
-        if (valid && idStr.Length > 0)
-        {
-            playerId = result;
-        }
+        int playerId = selectedIndex;
+        selectedIndex = -1;
 
         if (playerId < 0) return;
 
@@ -431,7 +419,7 @@ public class DynamicPlayerList : UdonSharpBehaviour
 
 > **Key notes:**
 > - `Object.Instantiate()` works in UdonSharp for scene objects. The template button must exist in the scene (not an asset prefab).
-> - Player IDs are encoded in the button `name` field and parsed back on click — this avoids needing per-button UdonBehaviours.
+> - Add the `ButtonHandler` component from `patterns-core.md` to the template button. Wire the Button's OnClick to `SendCustomEvent("OnClick")` on that handler; it writes `selectedIndex` before calling `OnPlayerButtonClicked`.
 > - Always check `IsValid()` before using a `VRCPlayerApi` reference, as players may leave between list refresh and click.
 > - For large player counts (80+), consider recycling buttons instead of Destroy/Instantiate every refresh.
 
@@ -498,7 +486,7 @@ public class ScrollInputAdapter : UdonSharpBehaviour
 
     private float GetVRScrollDelta()
     {
-        // InputLookVertical maps to the right-hand thumbstick Y axis
+        // Oculus_CrossPlatform_SecondaryThumbstickVertical maps to the right-hand thumbstick Y axis
         float axis = Input.GetAxis("Oculus_CrossPlatform_SecondaryThumbstickVertical");
 
         // Apply dead zone
@@ -744,6 +732,9 @@ public class UISettingsStore : UdonSharpBehaviour
     [Header("UI References")]
     [SerializeField] private Slider volumeSlider;
 
+    [Header("PlayerObject Lookup")]
+    [SerializeField] private UISettingsStore referenceStore;
+
     private bool _initialized = false;
     private VRCPlayerApi _localPlayer;
 
@@ -794,10 +785,16 @@ public class UISettingsStore : UdonSharpBehaviour
     /// <summary>
     /// Look up another player's settings store from their PlayerObjects.
     /// </summary>
-    public static UISettingsStore FindForPlayer(VRCPlayerApi player)
+    public UISettingsStore FindForPlayer(VRCPlayerApi player)
     {
-        // Returns the UISettingsStore component from the given player's PlayerObjects
-        return Networking.FindComponentInPlayerObjects<UISettingsStore>(player);
+        if (player == null) return null;
+        if (!player.IsValid()) return null;
+        if (!Utilities.IsValid(referenceStore)) return null;
+
+        Component found = player.FindComponentInPlayerObjects(referenceStore);
+        if (!Utilities.IsValid(found)) return null;
+
+        return (UISettingsStore)found;
     }
 
     /// <summary>
@@ -817,9 +814,10 @@ public class UISettingsStore : UdonSharpBehaviour
 
 > **Key notes:**
 > - PlayerObject instances are created per-player by VRChat. The component on the PlayerObject prefab becomes a per-player data store.
+> - Add `VRCEnablePersistence` to the same GameObject as this `UISettingsStore`; without it the PlayerObject instantiates but its synced fields do not persist (see `persistence.md`).
 > - The `-1` sentinel pattern lets you distinguish "player never set this" from "player explicitly chose value 0."
 > - `OnPlayerRestored()` fires after the player's persistent data is loaded. Apply saved state here, not in `Start()`.
-> - `Networking.FindComponentInPlayerObjects<T>(player)` retrieves another player's PlayerObject component, useful for displaying their preferences.
+> - Assign `referenceStore` to the UISettingsStore component on the PlayerObject prefab. `player.FindComponentInPlayerObjects(referenceStore)` returns the matching component for that player and must be cast and validity-checked.
 
 ---
 
@@ -1593,6 +1591,7 @@ public class AppManager : UdonSharpBehaviour
     // ownership-transfer code path only.
     // -2 = no pending operation, -1 = pending close, >= 0 = pending open index
     private int _pendingOpenIndex = -2;
+    [HideInInspector] public int selectedIndex = -1; // Written by ButtonHandler before OnIconButtonClicked
 
     /// <summary>
     /// Synced property: when the synced value changes, trigger a transition.
@@ -1682,6 +1681,14 @@ public class AppManager : UdonSharpBehaviour
             iconObj.SetActive(true);
             iconObj.name = "AppIcon_" + i.ToString();
 
+            ButtonHandler handler = iconObj.GetComponent<ButtonHandler>();
+            if (Utilities.IsValid(handler))
+            {
+                handler.buttonIndex = i;
+                handler.targetScript = this;
+                handler.methodName = nameof(OnIconButtonClicked);
+            }
+
             // Set icon texture if a RawImage is present on the template
             RawImage rawImage =
                 iconObj.GetComponentInChildren<RawImage>();
@@ -1701,8 +1708,7 @@ public class AppManager : UdonSharpBehaviour
     }
 
     /// <summary>
-    /// Open an app by index. Call from icon button OnClick events.
-    /// The button name must contain the index (e.g., "AppIcon_2").
+    /// Open an app by index. Call from icon button handlers.
     /// </summary>
     public void OpenApp(int appIndex)
     {
@@ -1758,36 +1764,13 @@ public class AppManager : UdonSharpBehaviour
     }
 
     /// <summary>
-    /// Called by icon buttons. Parse the button name to extract the app index.
-    /// Button name format: "AppIcon_N" where N is the app index.
+    /// Called by ButtonHandler after it writes selectedIndex.
     /// </summary>
-    public void OnIconButtonClicked(string buttonName)
+    public void OnIconButtonClicked()
     {
-        if (buttonName == null) return;
-
-        string prefix = "AppIcon_";
-        if (buttonName.Length <= prefix.Length) return;
-
-        string idxStr = buttonName.Substring(prefix.Length);
-
-        // Manual int parse
-        int result = 0;
-        bool valid = true;
-        for (int i = 0; i < idxStr.Length; i++)
-        {
-            char c = idxStr[i];
-            if (c < '0' || c > '9')
-            {
-                valid = false;
-                break;
-            }
-            result = result * 10 + (c - '0');
-        }
-
-        if (valid && idxStr.Length > 0)
-        {
-            OpenApp(result);
-        }
+        int appIndex = selectedIndex;
+        selectedIndex = -1;
+        OpenApp(appIndex);
     }
 
     private void BeginTransition(int targetIndex)
@@ -1945,7 +1928,7 @@ public class AppManager : UdonSharpBehaviour
 > - The `[FieldChangeCallback]` attribute on `SyncedAppIndex` ensures the property setter runs on all clients when the synced value changes, triggering the transition on remote players.
 > - App discovery iterates `appsParent` children at `Start()`. Adding or removing apps at runtime is not supported — all apps must be present in the scene hierarchy at load time.
 > - Pickup events (`OnPickup`, `OnDrop`, `OnPickupUseDown`, `OnPickupUseUp`) are forwarded from the manager to the active app via `SendCustomEvent`, allowing each app to respond to device interactions independently.
-> - Icon buttons are instantiated from a scene template at startup. Wire each button's OnClick to call `OnIconButtonClicked` with the button's name.
+> - Icon buttons are instantiated from a scene template at startup. Add `ButtonHandler` from `patterns-core.md` to the template and wire each Button's OnClick to `SendCustomEvent("OnClick")` on that handler; the handler writes `selectedIndex` before calling `OnIconButtonClicked`.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-ui.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-ui.md
@@ -130,7 +130,7 @@ public class AvatarScaleUI : UdonSharpBehaviour
 > **Key notes:**
 > - `GetTrackingData(Head).position.y` returns the world-space Y of the player's head, which correlates with avatar scale.
 > - Clamp the scale factor to avoid UI becoming invisible (tiny avatars) or enormous (giant avatars).
-> - Call `ApplyScale()` from `OnAvatarEyeHeightChanged(VRCPlayerApi, float)` or `OnAvatarChanged(VRCPlayerApi)`; `player.GetAvatarEyeHeightAsMeters()` is the direct avatar scale source when you do not need the head-Y heuristic.
+> - Call `ApplyScale()` from `OnAvatarEyeHeightChanged(VRCPlayerApi, float)` or `OnAvatarChanged(VRCPlayerApi)` — both fire for every player, so early-return unless `player.isLocal`. `player.GetAvatarEyeHeightAsMeters()` is the direct avatar scale source when you do not need the head-Y heuristic.
 
 ---
 
@@ -189,9 +189,8 @@ public class FovResponsiveUI : UdonSharpBehaviour
         // Apply distance adjustment only on desktop.
         if (_isVR) return;
 
-        float currentFov = 60.0f;
         VRCCameraSettings screenCam = VRCCameraSettings.ScreenCamera;
-        currentFov = screenCam.FieldOfView;
+        float currentFov = screenCam.FieldOfView;
 
         // Compute viewport-relative scale factor
         float refTan = Mathf.Tan((referenceFov / 2.0f) * Mathf.Deg2Rad);

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -418,8 +418,8 @@ public class DataProcessor : UdonSharpBehaviour
         ResultData    = output;
 
         // Notify mediator via string event.
-        // String literal used instead of nameof(ProcessMediator.OnResultReady) because
-        // UdonSharp's nameof support for cross-class members is unreliable at runtime.
+        // SendCustomEvent dispatches by method-name string; the literal spells
+        // out the cross-behaviour contract at the call site.
         _mediator.SendCustomEvent("OnResultReady");
     }
 }
@@ -585,8 +585,8 @@ public class RetryController : UdonSharpBehaviour
 
         // The callback fires on the helper; destroying _pendingTimer before
         // retryDelay seconds cancels it without any pending-counter bookkeeping.
-        // String literal used instead of nameof(CancellableTimer._Fire) because
-        // UdonSharp's nameof support for cross-class members is unreliable at runtime.
+        // SendCustomEvent dispatches by method-name string; the literal spells
+        // out the cross-behaviour contract at the call site.
         timer.SendCustomEventDelayedSeconds("_Fire", _retryDelay);
     }
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -562,7 +562,7 @@ using UnityEngine;
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class RetryController : UdonSharpBehaviour
 {
-    [SerializeField] private GameObject _timerPrefab; // Prefab with CancellableTimer attached
+    [SerializeField] private GameObject _timerTemplate; // Disabled scene GameObject with CancellableTimer attached
     [SerializeField] private float      _retryDelay = 5f;
 
     private GameObject _pendingTimer;
@@ -574,17 +574,20 @@ public class RetryController : UdonSharpBehaviour
     {
         CancelPendingRetry();
 
-        if (_timerPrefab == null) { Debug.LogError("[RetryController] Timer prefab not assigned"); return; }
+        if (_timerTemplate == null) { Debug.LogError("[RetryController] Timer template not assigned"); return; }
 
-        _pendingTimer = VRCInstantiate(_timerPrefab);
+        _pendingTimer = Object.Instantiate(_timerTemplate);
         CancellableTimer timer = _pendingTimer.GetComponent<CancellableTimer>();
         if (timer == null) { Debug.LogError("[RetryController] CancellableTimer component missing"); Destroy(_pendingTimer); _pendingTimer = null; return; }
         timer.CallbackTarget = this;
         timer.CallbackMethod = nameof(OnRetryFired);
+        _pendingTimer.SetActive(true);
 
         // The callback fires on the helper; destroying _pendingTimer before
         // retryDelay seconds cancels it without any generation-counter bookkeeping.
-        timer.SendCustomEventDelayedSeconds(nameof(CancellableTimer._Fire), _retryDelay);
+        // String literal used instead of nameof(CancellableTimer._Fire) because
+        // UdonSharp's nameof support for cross-class members is unreliable at runtime.
+        timer.SendCustomEventDelayedSeconds("_Fire", _retryDelay);
     }
 
     /// <summary>

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -506,13 +506,13 @@ public class MyResultHandler : ProcessCallbackBase
 
 ### Problem
 
-`SendCustomEventDelayedSeconds` has no cancellation API. Once scheduled, the callback will fire even if the caller's state has changed and the event is no longer wanted. The generation-counter debounce (see [Delayed Event Debounce in patterns-networking.md](patterns-networking.md)) handles "soft cancel" — it lets the callback fire but makes it a no-op. That is sufficient for debounce cases but not for situations where the callback absolutely must not execute: side effects inside the callback (audio playback, network requests, object destruction) will still run through the guard check even if they then return early.
+`SendCustomEventDelayedSeconds` has no cancellation API. Once scheduled, the callback will fire even if the caller's state has changed and the event is no longer wanted. The pending-callback-counter debounce (see [Delayed Event Debounce in patterns-networking.md](patterns-networking.md)) handles "soft cancel" — it lets the callback fire but makes it a no-op. That is sufficient for debounce cases but not for situations where the callback absolutely must not execute: side effects inside the callback (audio playback, network requests, object destruction) will still run through the guard check even if they then return early.
 
 ### Solution
 
 Instantiate a helper `GameObject` that carries a tiny `UdonSharpBehaviour`. Schedule `SendCustomEventDelayedSeconds` on the helper itself. To cancel, call `Destroy(helperGameObject)` before the delay expires — the destroyed behaviour never executes its scheduled callback.
 
-**Trade-off:** Allocates a `GameObject` per timer instance. Use the generation-counter pattern for high-frequency debounce; use this pattern only when the callback truly must not fire.
+**Trade-off:** Allocates a `GameObject` per timer instance. Use the pending-callback-counter pattern for high-frequency debounce; use this pattern only when the callback truly must not fire.
 
 **When to use:**
 - Retry timers that must be cancelled when the user changes their action before the retry fires
@@ -584,7 +584,7 @@ public class RetryController : UdonSharpBehaviour
         _pendingTimer.SetActive(true);
 
         // The callback fires on the helper; destroying _pendingTimer before
-        // retryDelay seconds cancels it without any generation-counter bookkeeping.
+        // retryDelay seconds cancels it without any pending-counter bookkeeping.
         // String literal used instead of nameof(CancellableTimer._Fire) because
         // UdonSharp's nameof support for cross-class members is unreliable at runtime.
         timer.SendCustomEventDelayedSeconds("_Fire", _retryDelay);

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -493,6 +493,10 @@ public class AVProTextureStabilizer : UdonSharpBehaviour
 | `PlayerError` | Decoder / codec mismatch | Retry N times; then try alternate player |
 | `Unknown` | Unclassified failure | Retry once; give up on second failure |
 
+On AVPro players, a too-frequent `PlayURL` can surface as `VideoError.RateLimited`
+through `OnVideoError`. Some request paths can also drop too-frequent requests without
+a callback; space requests more than 5 seconds apart instead of relying on the error.
+
 ### Retry Logic
 
 ```text
@@ -624,12 +628,14 @@ public class VideoErrorHandler : UdonSharpBehaviour
 
 | Synced variable | Type | Purpose |
 |-----------------|------|---------|
-| `_queueUrls` | `VRCUrl[]` | Ordered list of URLs |
-| `_queuePlayerTypes` | `byte[]` | Player type per entry (0 = Unity, 1 = AVPro) |
+| `_queueUrl0` ... `_queueUrl7` | `VRCUrl` fields | Fixed-capacity ordered URL slots |
+| `_queuePlayerTypes` | `byte[]` | Player type per slot (0 = Unity, 1 = AVPro) |
 | `_queueHead` | `int` | Index of the currently playing entry |
+| `_queueCount` | `int` | Number of occupied queue slots |
 
 The queue is FIFO: `_queueHead` advances on each video end. Add appends to the logical
-tail; the owner compacts the array only when removing mid-queue entries.
+tail. `VRCUrl[]` cannot be synced, so the URL slots use the individual-field workaround
+from [constraints.md](constraints.md#vrcurl-array-sync-workaround).
 
 ### Repeat Modes
 
@@ -659,9 +665,20 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
     [SerializeField] private BaseVRCVideoPlayer _unityPlayer;
     [SerializeField] private BaseVRCVideoPlayer _avProPlayer;
 
-    [UdonSynced] private VRCUrl[] _queueUrls        = new VRCUrl[0];
-    [UdonSynced] private byte[]   _queuePlayerTypes = new byte[0];
+    private const int QueueCapacity = 8;
+
+    // VRCUrl[] cannot be [UdonSynced]; see constraints.md "VRCUrl Array Sync Workaround".
+    [UdonSynced] private VRCUrl _queueUrl0 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl1 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl2 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl3 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl4 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl5 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl6 = VRCUrl.Empty;
+    [UdonSynced] private VRCUrl _queueUrl7 = VRCUrl.Empty;
+    [UdonSynced] private byte[] _queuePlayerTypes = new byte[QueueCapacity];
     [UdonSynced] private int      _queueHead        = 0;
+    [UdonSynced] private int      _queueCount       = 0;
     [UdonSynced] private byte     _repeatMode       = RepeatNone;
 
     // Owner-only: add a URL to the end of the queue
@@ -669,20 +686,12 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
     {
         if (!Networking.IsOwner(gameObject)) return;
 
-        int len = _queueUrls.Length;
-        VRCUrl[] newUrls  = new VRCUrl[len + 1];
-        byte[]   newTypes = new byte[len + 1];
+        int len = _queueCount;
+        if (len >= QueueCapacity) return;
 
-        for (int i = 0; i < len; i++)
-        {
-            newUrls[i]  = _queueUrls[i];
-            newTypes[i] = _queuePlayerTypes[i];
-        }
-        newUrls[len]  = url;
-        newTypes[len] = playerType;
-
-        _queueUrls        = newUrls;
-        _queuePlayerTypes = newTypes;
+        SetQueueUrl(len, url);
+        _queuePlayerTypes[len] = playerType;
+        _queueCount = len + 1;
         RequestSerialization();
 
         // Start playback if queue was empty
@@ -702,7 +711,7 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
 
         int nextIndex = _queueHead + 1;
 
-        if (nextIndex >= _queueUrls.Length)
+        if (nextIndex >= _queueCount)
         {
             if (_repeatMode == RepeatAll)
             {
@@ -711,7 +720,7 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
             else
             {
                 // RepeatNone: queue exhausted
-                _queueHead = _queueUrls.Length;
+                _queueHead = _queueCount;
                 RequestSerialization();
                 return;
             }
@@ -731,17 +740,17 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
         if (!Networking.IsOwner(gameObject)) return;
 
         int start = _queueHead + 1;
-        int end   = _queueUrls.Length - 1;
+        int end   = _queueCount - 1;
 
         for (int i = end; i > start; i--)
         {
             int j = Random.Range(start, i + 1);
 
-            VRCUrl tempUrl  = _queueUrls[i];
+            VRCUrl tempUrl  = GetQueueUrl(i);
             byte   tempType = _queuePlayerTypes[i];
-            _queueUrls[i]        = _queueUrls[j];
+            SetQueueUrl(i, GetQueueUrl(j));
             _queuePlayerTypes[i] = _queuePlayerTypes[j];
-            _queueUrls[j]        = tempUrl;
+            SetQueueUrl(j, tempUrl);
             _queuePlayerTypes[j] = tempType;
         }
 
@@ -757,13 +766,44 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
 
     private void PlayCurrentEntry()
     {
-        if (_queueHead < 0 || _queueHead >= _queueUrls.Length) return;
+        if (_queueHead < 0 || _queueHead >= _queueCount) return;
 
-        VRCUrl url        = _queueUrls[_queueHead];
+        VRCUrl url        = GetQueueUrl(_queueHead);
         byte   playerType = _queuePlayerTypes[_queueHead];
 
         BaseVRCVideoPlayer player = (playerType == 1) ? _avProPlayer : _unityPlayer;
         player.PlayURL(url);
+    }
+
+    private void SetQueueUrl(int index, VRCUrl url)
+    {
+        switch (index)
+        {
+            case 0: _queueUrl0 = url; break;
+            case 1: _queueUrl1 = url; break;
+            case 2: _queueUrl2 = url; break;
+            case 3: _queueUrl3 = url; break;
+            case 4: _queueUrl4 = url; break;
+            case 5: _queueUrl5 = url; break;
+            case 6: _queueUrl6 = url; break;
+            case 7: _queueUrl7 = url; break;
+        }
+    }
+
+    private VRCUrl GetQueueUrl(int index)
+    {
+        switch (index)
+        {
+            case 0: return _queueUrl0;
+            case 1: return _queueUrl1;
+            case 2: return _queueUrl2;
+            case 3: return _queueUrl3;
+            case 4: return _queueUrl4;
+            case 5: return _queueUrl5;
+            case 6: return _queueUrl6;
+            case 7: return _queueUrl7;
+            default: return VRCUrl.Empty;
+        }
     }
 
     public override void OnVideoEnd()

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -833,6 +833,18 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
 
     public override void OnVideoEnd()
     {
+        // RepeatOne (and a single-entry RepeatAll wrap) changes no synced state,
+        // so non-owners replay locally; _repeatMode and _queueCount are synced.
+        if (!Networking.IsOwner(gameObject))
+        {
+            if (_repeatMode == RepeatOne ||
+                (_repeatMode == RepeatAll && _queueCount == 1))
+            {
+                PlayCurrentEntry();
+            }
+            return;
+        }
+
         AdvanceQueue();
     }
 }

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -38,6 +38,7 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
+using VRC.SDK3.Video.Components.Base;
 using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
@@ -210,6 +211,7 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
+using VRC.SDK3.Video.Components.Base;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class PlaybackTimeSynchronizer : UdonSharpBehaviour
@@ -333,6 +335,7 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
+using VRC.SDK3.Video.Components.Base;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class LateJoinerVideoSync : UdonSharpBehaviour
@@ -494,8 +497,9 @@ public class AVProTextureStabilizer : UdonSharpBehaviour
 | `Unknown` | Unclassified failure | Retry once; give up on second failure |
 
 On AVPro players, a too-frequent `PlayURL` can surface as `VideoError.RateLimited`
-through `OnVideoError`. Some request paths can also drop too-frequent requests without
-a callback; space requests more than 5 seconds apart instead of relying on the error.
+through `OnVideoError`. Requests can also be dropped without any callback (see the
+rate-limit dispatcher discussion in patterns-performance.md); space requests more than
+5 seconds apart instead of relying on the error.
 
 ### Retry Logic
 
@@ -517,6 +521,7 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
+using VRC.SDK3.Video.Components.Base;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class VideoErrorHandler : UdonSharpBehaviour
@@ -653,6 +658,7 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
+using VRC.SDK3.Video.Components.Base;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class SyncedPlaylistManager : UdonSharpBehaviour
@@ -719,8 +725,9 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
             }
             else
             {
-                // RepeatNone: queue exhausted
-                _queueHead = _queueCount;
+                // RepeatNone: queue exhausted — reset so future adds start fresh
+                _queueHead = 0;
+                _queueCount = 0;
                 RequestSerialization();
                 return;
             }
@@ -764,8 +771,26 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
         RequestSerialization();
     }
 
+    // PlayURL does not propagate to remote clients, so non-owners and late
+    // joiners start playback from the synced queue state on deserialization.
+    private int _lastSeenHead  = -1;
+    private int _lastSeenCount = 0;
+
+    public override void OnDeserialization()
+    {
+        bool headChanged    = _queueHead != _lastSeenHead;
+        bool queueRestarted = _lastSeenCount == 0 && _queueCount > 0;
+        _lastSeenCount = _queueCount;
+        // Appends behind the playing entry change neither condition,
+        // so they do not restart playback mid-entry.
+        if (!headChanged && !queueRestarted) return;
+        PlayCurrentEntry();
+    }
+
     private void PlayCurrentEntry()
     {
+        _lastSeenHead  = _queueHead;
+        _lastSeenCount = _queueCount;
         if (_queueHead < 0 || _queueHead >= _queueCount) return;
 
         VRCUrl url        = GetQueueUrl(_queueHead);
@@ -840,6 +865,7 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
+using VRC.SDK3.Video.Components.Base;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class PlatformUrlSelector : UdonSharpBehaviour

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -633,14 +633,15 @@ public class VideoErrorHandler : UdonSharpBehaviour
 
 | Synced variable | Type | Purpose |
 |-----------------|------|---------|
-| `_queueUrl0` ... `_queueUrl7` | `VRCUrl` fields | Fixed-capacity ordered URL slots |
+| `_queueUrls` | `VRCUrl[]` | Fixed-capacity ordered URL slots |
 | `_queuePlayerTypes` | `byte[]` | Player type per slot (0 = Unity, 1 = AVPro) |
 | `_queueHead` | `int` | Index of the currently playing entry |
 | `_queueCount` | `int` | Number of occupied queue slots |
 
 The queue is FIFO: `_queueHead` advances on each video end. Add appends to the logical
-tail. `VRCUrl[]` cannot be synced, so the URL slots use the individual-field workaround
-from [constraints.md](constraints.md#vrcurl-array-sync-workaround).
+tail. `VRCUrl[]` syncs like other arrays (see [constraints.md](constraints.md#synced-vrcurl-lists));
+both arrays are fixed-capacity and must be initialized — an uninitialized synced array
+prevents the behaviour from syncing.
 
 ### Repeat Modes
 
@@ -673,16 +674,10 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
 
     private const int QueueCapacity = 8;
 
-    // VRCUrl[] cannot be [UdonSynced]; see constraints.md "VRCUrl Array Sync Workaround".
-    [UdonSynced] private VRCUrl _queueUrl0 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl1 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl2 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl3 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl4 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl5 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl6 = VRCUrl.Empty;
-    [UdonSynced] private VRCUrl _queueUrl7 = VRCUrl.Empty;
-    [UdonSynced] private byte[] _queuePlayerTypes = new byte[QueueCapacity];
+    // VRCUrl[] syncs like other arrays (VRChat 2021.3.2+); initialize synced
+    // arrays — an uninitialized synced array prevents the behaviour from syncing.
+    [UdonSynced] private VRCUrl[] _queueUrls       = new VRCUrl[QueueCapacity];
+    [UdonSynced] private byte[]   _queuePlayerTypes = new byte[QueueCapacity];
     [UdonSynced] private int      _queueHead        = 0;
     [UdonSynced] private int      _queueCount       = 0;
     [UdonSynced] private byte     _repeatMode       = RepeatNone;
@@ -695,7 +690,7 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
         int len = _queueCount;
         if (len >= QueueCapacity) return;
 
-        SetQueueUrl(len, url);
+        _queueUrls[len]        = url;
         _queuePlayerTypes[len] = playerType;
         _queueCount = len + 1;
         RequestSerialization();
@@ -753,11 +748,11 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
         {
             int j = Random.Range(start, i + 1);
 
-            VRCUrl tempUrl  = GetQueueUrl(i);
+            VRCUrl tempUrl  = _queueUrls[i];
             byte   tempType = _queuePlayerTypes[i];
-            SetQueueUrl(i, GetQueueUrl(j));
+            _queueUrls[i]        = _queueUrls[j];
             _queuePlayerTypes[i] = _queuePlayerTypes[j];
-            SetQueueUrl(j, tempUrl);
+            _queueUrls[j]        = tempUrl;
             _queuePlayerTypes[j] = tempType;
         }
 
@@ -793,42 +788,11 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
         _lastSeenCount = _queueCount;
         if (_queueHead < 0 || _queueHead >= _queueCount) return;
 
-        VRCUrl url        = GetQueueUrl(_queueHead);
+        VRCUrl url        = _queueUrls[_queueHead];
         byte   playerType = _queuePlayerTypes[_queueHead];
 
         BaseVRCVideoPlayer player = (playerType == 1) ? _avProPlayer : _unityPlayer;
         player.PlayURL(url);
-    }
-
-    private void SetQueueUrl(int index, VRCUrl url)
-    {
-        switch (index)
-        {
-            case 0: _queueUrl0 = url; break;
-            case 1: _queueUrl1 = url; break;
-            case 2: _queueUrl2 = url; break;
-            case 3: _queueUrl3 = url; break;
-            case 4: _queueUrl4 = url; break;
-            case 5: _queueUrl5 = url; break;
-            case 6: _queueUrl6 = url; break;
-            case 7: _queueUrl7 = url; break;
-        }
-    }
-
-    private VRCUrl GetQueueUrl(int index)
-    {
-        switch (index)
-        {
-            case 0: return _queueUrl0;
-            case 1: return _queueUrl1;
-            case 2: return _queueUrl2;
-            case 3: return _queueUrl3;
-            case 4: return _queueUrl4;
-            case 5: return _queueUrl5;
-            case 6: return _queueUrl6;
-            case 7: return _queueUrl7;
-            default: return VRCUrl.Empty;
-        }
     }
 
     public override void OnVideoEnd()

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -678,6 +678,16 @@ public class SyncedPlaylistManager : UdonSharpBehaviour
     // arrays — an uninitialized synced array prevents the behaviour from syncing.
     [UdonSynced] private VRCUrl[] _queueUrls       = new VRCUrl[QueueCapacity];
     [UdonSynced] private byte[]   _queuePlayerTypes = new byte[QueueCapacity];
+
+    void Start()
+    {
+        // Fill every slot so no null VRCUrl element is ever serialized;
+        // late joiners get these overwritten by the first deserialization.
+        for (int i = 0; i < QueueCapacity; i++)
+        {
+            if (_queueUrls[i] == null) _queueUrls[i] = VRCUrl.Empty;
+        }
+    }
     [UdonSynced] private int      _queueHead        = 0;
     [UdonSynced] private int      _queueCount       = 0;
     [UdonSynced] private byte     _repeatMode       = RepeatNone;

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -19,7 +19,7 @@ become bottlenecks in resource-heavy worlds:
 |---|---|---|
 | Rate limit | 1 image per 5 seconds, **shared across the entire scene** | 10 images = 50+ seconds to load |
 | Resolution cap | 2048 × 2048 maximum | Server must pre-resize, or download is rejected |
-| Trusted domain list | Separate, shorter list from string loading | Limits hosting options |
+| Trusted domain list | Separate list from string loading | Limits hosting options |
 | Images per request | 1 | No way to batch a thumbnail strip into one download |
 | Format | PNG / JPG / GIF only | Cannot use GPU-compressed formats (DXT, ETC2) directly |
 
@@ -883,7 +883,7 @@ public class PackedResourceLoader : UdonSharpBehaviour
 | Index file parses but `TryGetAddress` always returns false | Resource ID string case mismatch between JSON and `_slotResourceIds` inspector values | Ensure exact string match; JSON keys are case-sensitive |
 | Pack parses but inner texture is blank | `innerIndex` out of range for the decoded `blocks` array | Log `blocks.Length` and `innerIdx`; confirm JSON `entries` array length matches the pack |
 | All downloads stall after one error | `_pendingUrlIndex` is not reset in `OnStringLoadError`; next callback is misrouted | Reset `_pendingUrlIndex = -1` and `_pendingSlotIndex = -1` in `OnStringLoadError` |
-| UI slots load slowly even with cache hits | `LoadNextSlot` delays 5.5 s between all slots, including cache hits | Skip the 5.5 s delay when dispatching `LoadNextSlot` for a cache hit; only delay when a network download is initiated |
+| UI slots load slowly even with cache hits | Your implementation delays `LoadNextSlot` even when serving from cache | Follow the example above: dispatch `LoadNextSlot` immediately on cache hits; only delay when a network download is initiated |
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -596,7 +596,7 @@ private void OnAllDownloadsComplete()
 | Want to download faster than every 5 seconds | Rate limiting | Not possible. Requests are only queued. Processing order is random |
 | Image events not received in UdonSharp | `udonBehaviour` parameter not specified | Explicitly pass `(IUdonEventReceiver)this` |
 | JSON numbers are not `int` | VRCJson specification | Cast with `(int)token.Double` |
-| Memory usage keeps growing | Old textures not Disposed | Release with `IVRCImageDownload.Dispose()` |
+| Memory usage keeps growing | Old textures not destroyed | Call `Destroy(oldTexture)` before replacing textures; `IVRCImageDownload.Dispose()` only releases the wrapper state |
 | Error inside JSON after successful parse | Lazy parsing specification | Check for false on `TryGetValue` for nested values |
 
 ---
@@ -615,6 +615,6 @@ private void OnAllDownloadsComplete()
 ## See Also
 
 - [api.md](api.md) - `VRCUrl`, `VRCStringDownloader`, and `VRCImageDownloader` API quick reference
-- [troubleshooting.md](troubleshooting.md) - Web loading error table and debugging tips
+- [troubleshooting.md](troubleshooting.md) - General UdonSharp compile, runtime, networking, persistence, and performance troubleshooting
 - [image-loading-vram.md](image-loading-vram.md) - Advanced VRAM management: Destroy vs Dispose, double-buffer fade, stock mode, mipmap bias
 - [web-loading-advanced.md](web-loading-advanced.md) - Advanced data loading: Base64 texture embedding, cross-platform compression, LRU cache


### PR DESCRIPTION
Closes #256
Closes #245

## Summary

patterns-ui.md asserted several API shapes that the skill's own api.md/events.md (DLL-verified) document differently — code generated from those patterns would not compile or silently fail. This aligns the pattern/media cluster with the documented surfaces.

## Changes

**patterns-ui.md**
- Patterns 5 and 12 no longer wire OnClick to a string-parameter method (Inspector wiring can only invoke SendCustomEvent); both now dispatch through the ButtonHandler component from patterns-core.md (`SetProgramVariable("selectedIndex", …)` + parameterless handler), and the hand-rolled digit parsers are gone — `int.TryParse` is exposed in the Udon wrapper (verified SDK 3.10.3)
- Camera pattern: `OnVRCCameraSettingsChanged(VRCCameraSettings cameraSettings)` signature, `VRCCameraSettings`-typed `ScreenCamera`, `FieldOfView`/`PixelWidth`/`PixelHeight` members, aspect computed from pixel dimensions, `VRC.SDK3.Rendering` using, and the 3.8.1+ gate
- PlayerObject lookup rewritten on the documented instance API (`player.FindComponentInPlayerObjects(reference)` + cast + `Utilities.IsValid`), replacing a fabricated generic static
- The "no built-in avatar changed callback" claim replaced with the real events (`OnAvatarEyeHeightChanged`/`OnAvatarChanged`) and `GetAvatarEyeHeightAsMeters()`
- Pattern 9 now instructs adding `VRCEnablePersistence` (without it the PlayerObject instantiates but does not persist)
- VR scroll comment matches the axis the code reads

**patterns-video.md**
- The synced playlist no longer declares `[UdonSynced] VRCUrl[]` (not syncable per constraints.md); it uses the individual-field workaround with fixed capacity and switch accessors, with the queue logic updated to match
- Rate-limit failure modes reconciled: RateLimited can surface via OnVideoError on AVPro, and some paths drop without a callback — spacing requests >5 s is the safe pattern

**patterns-utilities.md** — timer helper now clones a disabled scene template via `Object.Instantiate` (matching the scene-template doctrine) and uses a string literal for the cross-class event name with the same justification comment used earlier in the file

**image-loading-vram.md** — the double-buffer fade guard destroys the incoming texture instead of abandoning it (the file's own anti-pattern)

**web-loading.md / web-loading-advanced.md** — troubleshooting rows and See Also entries no longer point at content that doesn't exist (Dispose-only advice, phantom troubleshooting tables, wrong trusted-list comparison, advice to "fix" code the example already handles)

**dynamics.md** — struct-mutation anchor fixed (`#3-struct-mutation`); version header capped at 3.10.3 like sibling files

## Verification

- Every API shape checked against UdonSharpBehaviour.cs / DLL metadata (SDK 3.10.3) or the official players page; ButtonHandler contract verified against patterns-core.md
- editorconfig-checker clean; heading anchors preserved