### PR TITLE
feat(skills): improve routing determinism and complete reference indexes

### DIFF
--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -322,7 +322,7 @@ private void Log(string msg) {
 |-------|-----|
 | Sync not working | `SetOwner()` -> modify -> `RequestSerialization()` |
 | NullReference on player | Check `player != null && player.IsValid()` |
-| Method not found | Make method `public` and remove parameters |
+| Method not found (SendCustomEvent / network event target) | Make the target method public; plain network events take no parameters ([NetworkCallable] allows up to 8) |
 | FieldChangeCallback not firing | Use property setter even for local changes |
 | Cannot modify struct | `var v = struct; v.x = 1; struct = v;` |
 | Start() not called | Inactive object support: `OnEnable()` + `Initialize()` |
@@ -379,4 +379,19 @@ For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` arr
 | UI / Canvas patterns | [references/patterns-ui.md](references/patterns-ui.md) |
 | Video player patterns | [references/patterns-video.md](references/patterns-video.md) |
 | Custom inspectors, editor-only setup components (IEditorOnly) | [references/editor-scripting.md](references/editor-scripting.md) |
-
+| UdonSharp C# feature constraints and compiler behavior | [references/constraints.md](references/constraints.md) |
+| UdonSharp event overrides and Unity callback rules | [references/events.md](references/events.md) |
+| Common compile, runtime, networking, persistence, dynamics, editor, and performance issues | [references/troubleshooting.md](references/troubleshooting.md) |
+| Networking mistakes, data-loss causes, and advanced sync patterns | [references/networking-antipatterns.md](references/networking-antipatterns.md) |
+| Network bandwidth throttling, request serialization, bit packing, and owner-centric architecture | [references/networking-bandwidth.md](references/networking-bandwidth.md) |
+| Object pooling, synced game state, NetworkCallable, persistence, dynamics, and debouncing patterns | [references/patterns-networking.md](references/patterns-networking.md) |
+| Practical synced gimmick examples for local, event, and synced-variable patterns | [references/sync-examples.md](references/sync-examples.md) |
+| Persistent PlayerData and PlayerObject storage | [references/persistence.md](references/persistence.md) |
+| PhysBones, Contacts, and VRC Constraints in worlds | [references/dynamics.md](references/dynamics.md) |
+| Initialization, interaction, player detection, timer, audio, pickup, animation, UI, and teleportation patterns | [references/patterns-core.md](references/patterns-core.md) |
+| Cross-class call overhead, partial classes, update handlers, PostLateUpdate, spatial queries, and animator hashes | [references/patterns-performance.md](references/patterns-performance.md) |
+| Array helpers, event bus, GameObject relay communication, pseudo-struct double-cast, and callback patterns | [references/patterns-utilities.md](references/patterns-utilities.md) |
+| VRCImageDownloader GPU memory lifecycle, safe texture cleanup, fades, and staggering | [references/image-loading-vram.md](references/image-loading-vram.md) |
+| Advanced packed resource loading with VRCStringDownloader | [references/web-loading-advanced.md](references/web-loading-advanced.md) |
+| SDK upgrade steps, version-by-version changes, and migration checklists | [references/sdk-migration.md](references/sdk-migration.md) |
+| Preserving task-specific design intent across long or resumed work | [references/context-preservation.md](references/context-preservation.md) |

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -322,7 +322,7 @@ private void Log(string msg) {
 |-------|-----|
 | Sync not working | `SetOwner()` -> modify -> `RequestSerialization()` |
 | NullReference on player | Check `player != null && player.IsValid()` |
-| Method not found (SendCustomEvent / network event target) | Make the target method public; plain network events take no parameters ([NetworkCallable] allows up to 8) |
+| Method not found (SendCustomEvent / network event target) | Make the target method public and parameterless (pass data via `SetProgramVariable`); plain network events are also parameterless ([NetworkCallable] allows up to 8) |
 | FieldChangeCallback not firing | Use property setter even for local changes |
 | Cannot modify struct | `var v = struct; v.x = 1; struct = v;` |
 | Start() not called | Inactive object support: `OnEnable()` + `Initialize()` |
@@ -372,7 +372,7 @@ For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` arr
 
 | Topic | File |
 |-------|------|
-| Camera Dolly API, VRCObjectPool API | [references/api.md](references/api.md) |
+| Full VRChat API quick reference (VRCPlayerApi, networking, camera, persistence, data containers) | [references/api.md](references/api.md) |
 | Testing in Editor (ClientSim), multi-client debugging | [references/testing.md](references/testing.md) |
 | Networking ownership, sync modes, IsMaster migration | [references/networking.md](references/networking.md) |
 | Web / Image loading, VRCUrl constraints | [references/web-loading.md](references/web-loading.md) |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -124,9 +124,10 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
+| Migrating between SDK versions / fixing post-upgrade breakage | `sdk-migration.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 | Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
-| Creating new UdonSharp scripts | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
+| Setting up new script files (.cs/.asset wiring, program asset generation) | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
 | Building editor setup tools / placement UX (custom inspectors, scene wiring helpers, IEditorOnly) | `editor-scripting.md` | `constraints.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
 
 ## Pattern Selection Guide

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -124,7 +124,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
-| Migrating between SDK versions / fixing post-upgrade breakage | `sdk-migration.md` | `troubleshooting.md`, `networking.md` | `dynamics.md`, `web-loading.md` |
+| Migrating between SDK versions / fixing post-upgrade breakage | `sdk-migration.md` | `troubleshooting.md`, `networking.md`, `dynamics.md` | `web-loading.md`, `image-loading-vram.md` |
 | Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Setting up new script files (.cs/.asset wiring, program asset generation) | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -124,7 +124,7 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
 | Debugging ownership / sync conflicts | `networking.md`, `troubleshooting.md` | `networking-antipatterns.md` | `dynamics.md`, `web-loading.md` |
-| Migrating between SDK versions / fixing post-upgrade breakage | `sdk-migration.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
+| Migrating between SDK versions / fixing post-upgrade breakage | `sdk-migration.md` | `troubleshooting.md`, `networking.md` | `dynamics.md`, `web-loading.md` |
 | Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Setting up new script files (.cs/.asset wiring, program asset generation) | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -384,10 +384,10 @@ site:github.com/vrchat-community "issue keyword"
 |-------|------|
 | Performance targets, Quest optimization checklist | [references/performance.md](references/performance.md) |
 | Lightmap settings, Quest bake parameter reference | [references/lighting.md](references/lighting.md) |
-| Pickup + Rigidbody template | [assets/templates/VRC_Pickup_Rigidbody.cs](assets/templates/VRC_Pickup_Rigidbody.cs) |
-| Station (sit) template | [assets/templates/VRC_Station_Basic.cs](assets/templates/VRC_Station_Basic.cs) |
 | Full SDK 3.7.1-3.10.3 world component reference | [references/components.md](references/components.md) |
 | VRChat layer system, collision, and selective rendering reference | [references/layers.md](references/layers.md) |
 | Audio and video configuration, voice settings, Steam Audio, and video players | [references/audio-video.md](references/audio-video.md) |
 | Upload procedure, pre-upload checklist, validation, world settings, and post-upload steps | [references/upload.md](references/upload.md) |
 | Build/upload, scene setup, component, layer, performance, networking, and Quest troubleshooting | [references/troubleshooting.md](references/troubleshooting.md) |
+| Pickup + Rigidbody template | [assets/templates/VRC_Pickup_Rigidbody.cs](assets/templates/VRC_Pickup_Rigidbody.cs) |
+| Station (sit) template | [assets/templates/VRC_Station_Basic.cs](assets/templates/VRC_Station_Basic.cs) |

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -386,3 +386,8 @@ site:github.com/vrchat-community "issue keyword"
 | Lightmap settings, Quest bake parameter reference | [references/lighting.md](references/lighting.md) |
 | Pickup + Rigidbody template | [assets/templates/VRC_Pickup_Rigidbody.cs](assets/templates/VRC_Pickup_Rigidbody.cs) |
 | Station (sit) template | [assets/templates/VRC_Station_Basic.cs](assets/templates/VRC_Station_Basic.cs) |
+| Full SDK 3.7.1-3.10.3 world component reference | [references/components.md](references/components.md) |
+| VRChat layer system, collision, and selective rendering reference | [references/layers.md](references/layers.md) |
+| Audio and video configuration, voice settings, Steam Audio, and video players | [references/audio-video.md](references/audio-video.md) |
+| Upload procedure, pre-upload checklist, validation, world settings, and post-upload steps | [references/upload.md](references/upload.md) |
+| Build/upload, scene setup, component, layer, performance, networking, and Quest troubleshooting | [references/troubleshooting.md](references/troubleshooting.md) |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -65,7 +65,7 @@ Load only what the task requires.
 | Making objects grabbable (VRC_Pickup) | `components.md` | `layers.md` | `audio-video.md`, `lighting.md` | Pickup/Rigidbody requirements not in standard Unity docs |
 | Setting up seating (VRC_Station) | `components.md` | `layers.md` | `audio-video.md`, `performance.md` | Station collider + exit requirements are VRChat-specific |
 | Optimizing FPS for Quest | `performance.md`, `lighting.md` | `troubleshooting.md` | `audio-video.md`, `upload.md` | Quest limits differ from PC; bake requirements non-obvious |
-| Adding audio or video player | `audio-video.md`, `components.md` | `troubleshooting.md` | `lighting.md`, `performance.md` | AVPro vs Unity Video selection is VRChat-specific |
+| Adding audio or video player / voice zones (SetVoiceGain, Steam Audio) | `audio-video.md`, `components.md` | `troubleshooting.md` | `lighting.md`, `performance.md` | AVPro vs Unity Video selection is VRChat-specific |
 | Baking lights / lightmap setup | `lighting.md`, `performance.md` | — | `audio-video.md`, `layers.md` | Lightmap resolution and probe placement affect Quest VRAM |
 | World upload and publish | `upload.md` | `troubleshooting.md` | `audio-video.md`, `lighting.md` | Upload steps and validation order are fragile; easy to miss |
 | Debugging collision or layer issues | `layers.md`, `troubleshooting.md` | `components.md` | `audio-video.md`, `lighting.md` | VRChat collision matrix differs from Unity default |
@@ -217,6 +217,7 @@ Exactly **one** is required in every VRChat world.
 | **VRC_UIShape**            | Canvas (World Space)     | Unity UI interaction           | -    |
 | **VRC_AvatarPedestal**     | -                        | Avatar display/switch          | -    |
 | **VRC_CameraDolly**        | -                        | Camera dolly                   | 3.9+ |
+| **VRCCameraSettings**      | None (static API)        | Read camera info from Udon     | 3.8.1 |
 
 ### VRC_ObjectSync vs UdonSynced
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -217,7 +217,7 @@ Exactly **one** is required in every VRChat world.
 | **VRC_UIShape**            | Canvas (World Space)     | Unity UI interaction           | -    |
 | **VRC_AvatarPedestal**     | -                        | Avatar display/switch          | -    |
 | **VRC_CameraDolly**        | -                        | Camera dolly                   | 3.9+ |
-| **VRCCameraSettings**      | None (static API)        | Read camera info from Udon     | 3.8.1 |
+| **VRCCameraSettings**      | None (static API)        | Read camera info from Udon     | 3.8.1+ |
 
 ### VRC_ObjectSync vs UdonSynced
 


### PR DESCRIPTION
Closes #247

## Summary

Routing-layer usability improvements from the corpus audit — all additive or single-row changes, no content moves.

## Changes

**unity-vrc-udon-sharp**
- The two indistinguishable Loading Guide rows are now distinct: the editor-scripting row is relabeled "Setting up new script files (.cs/.asset wiring, program asset generation)", so an agent picking between it and "Writing new UdonSharp scripts (not sure if sync needed)" has a deterministic choice
- New Loading Guide row routes SDK migration / post-upgrade breakage to sdk-migration.md (previously reachable only via the References index)
- CHEATSHEET Reference Index extended from 7 to all 23 reference files (one line each, descriptions derived from each file's own intro)
- "Method not found" fix row now carries its SendCustomEvent context and the NetworkCallable exception, so it no longer reads as general method guidance contradicting the rules file's prefer-private advice

**unity-vrc-world-sdk-3**
- CHEATSHEET Reference Index extended from 2 to all 7 reference files
- The audio/video Loading Guide row now surfaces the voice-zone material (SetVoiceGain, Steam Audio) that was invisible from every routing surface
- Component router gains a VRCCameraSettings row (SDK 3.8.1, matching the dating corrected in #249)

## Verification

- Both indexes verified complete against `ls references/` (zero missing files)
- editorconfig-checker clean; no heading/anchor changes; existing rows untouched