### PR TITLE
fix(skills): scope the camera dolly scripting surface to documented APIs

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -1233,7 +1233,7 @@ public class DollyController : UdonSharpBehaviour
 ### Limitations
 
 - The API applies the animation to the **local player only**. To trigger it for all players, use `SendCustomNetworkEvent(NetworkEventTarget.All, nameof(PlayDolly))`.
-- No properties of the animation, paths, or points are readable or writable from UdonSharp at runtime.
+- `Import()` is the only scripting entry point on the official page; runtime reads or writes of animation, path, or point parameters from UdonSharp are not documented — treat anything beyond `Import()` as unverified.
 - There is no event callback when the animation completes.
 - No ClientSim preview; Build and Test is required to see the animation.
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -124,9 +124,9 @@ None that affect standard UdonSharp worlds. The `GetComponent<T>` behavior chang
 
 #### Camera Dolly Udon API (SDK 3.9.0+)
 
-SDK 3.9.0 added a Udon-accessible Camera Dolly system. Camera dolly tracks can be authored in the scene and controlled at runtime from UdonSharp, enabling cinematic camera movement sequences.
+SDK 3.9.0 added the Camera Dolly system. Animations are authored in the scene (VRC Camera Dolly Animation / Path / Point components) and applied to the local player's camera from UdonSharp.
 
-Key usage pattern: create a Camera Dolly track in the scene, assign a `VRCCameraDolly` reference in your UdonBehaviour, then call the track control methods.
+Key usage pattern: author the dolly animation in the scene, assign a `VRCCameraDollyAnimation` reference in your UdonBehaviour, then call `Import()` to apply it — the only documented scripting entry point (see api.md).
 
 #### Auto Hold Mode Simplification for Pickups (SDK 3.9.0+)
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -569,97 +569,55 @@ Displays avatars and allows switching.
 
 ## VRC_CameraDolly
 
-Moves the player's camera along a defined spline path (SDK 3.9+). Typically used for cinematic intros, tutorials, and guided tours.
+Plays a camera animation along defined paths on the local player's VRChat user camera (SDK 3.9+). Typically used for cinematic intros, tutorials, and guided tours.
 
-### Setup
+### Components
 
 ```text
-[Dolly Track Root]
-├── VRC_CameraDolly
-│   ├── Path (SplineContainer or CinemachinePath reference)
-│   ├── Duration (float, seconds for a full traversal)
-│   └── Loop (bool)
-└── UdonController (UdonSharpBehaviour)
+GameObject (VRC Camera Dolly Animation)
+├── GameObject (VRC Camera Dolly Path)
+│   ├── GameObject (VRC Camera Dolly Point)
+│   └── GameObject (VRC Camera Dolly Point)
+└── GameObject (VRC Camera Dolly Path)
 ```
 
-### VRC_CameraDolly Udon API
+Animation-level parameters (Path Type, Loop Type, Capture Type, Focus Mode, Anchor Mode, ...) and per-point parameters (Zoom, Duration, Speed, Focal Distance, ...) are configured in the Inspector — see the official VRC_CameraDolly page for the full list.
 
-```csharp
-VRCCameraDolly dolly = (VRCCameraDolly)GetComponent(typeof(VRCCameraDolly));
+### Scripting
 
-// Start playback from position 0
-dolly.Play();
-
-// Stop playback and release camera control
-dolly.Stop();
-
-// Pause at the current position
-dolly.Pause();
-
-// Resume from paused position
-dolly.Resume();
-
-// Jump to a normalized position along the path (0.0 = start, 1.0 = end)
-dolly.SetPosition(float normalizedT);
-
-// Get current normalized position
-float t = dolly.GetPosition();
-
-// Set playback speed multiplier (1.0 = normal, 2.0 = double speed, -1.0 = reverse)
-dolly.SetSpeed(float speedMultiplier);
-
-// Check if currently playing
-bool isPlaying = dolly.IsPlaying;
-
-// Check if looping is enabled
-bool loops = dolly.Loop;
-```
-
-### Udon Control Example
+`VRCCameraDollyAnimation.Import()` applies the defined settings and animation to the local player's VRC user camera. It is the only documented scripting entry point; runtime reads or writes of the parameters from Udon are not documented.
 
 ```csharp
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.Components;
 
-public class DollyController : UdonSharpBehaviour
+public class DollyTrigger : UdonSharpBehaviour
 {
-    [SerializeField] private VRCCameraDolly dolly;
+    [SerializeField] private VRCCameraDollyAnimation dollyAnimation;
 
-    // Call from UI button or trigger
     public override void Interact()
     {
-        if (dolly.IsPlaying)
-        {
-            dolly.Stop();
-        }
-        else
-        {
-            dolly.SetPosition(0f);
-            dolly.Play();
-        }
-    }
-
-    // Jump to midpoint on demand
-    public void JumpToMid()
-    {
-        dolly.SetPosition(0.5f);
+        if (!Utilities.IsValid(dollyAnimation)) return;
+        dollyAnimation.Import();
     }
 }
 ```
 
-### Ownership and Network Notes
+> **Editor step**: before entering Play mode or building, select the `VRC Camera Dolly Animation` object and click **Collect Paths & Points**; repeat whenever child paths or points change.
+
+### Notes
 
 ```text
-- VRC_CameraDolly only affects the local player's camera.
-- Play/Stop calls are local — no network sync is built in.
-- To sync a cinematic across all players, call Play() via
-  SendCustomNetworkEvent(NetworkEventTarget.All, nameof(StartDolly)).
-- Only one dolly can be active per player at a time.
-  Calling Play() on a second dolly automatically stops the first.
+- The animation applies to the local player's camera only.
+- To trigger it for everyone, route the call through
+  SendCustomNetworkEvent(NetworkEventTarget.All, ...).
+- No ClientSim preview — use Build and Test to see the animation.
 ```
 
----
+For the full scripting reference, see the udon-sharp skill's
+[`api.md` Camera Dolly section](../../unity-vrc-udon-sharp/references/api.md).
 
 ## VRCCameraSettings API
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -569,7 +569,7 @@ Displays avatars and allows switching.
 
 ## VRC_CameraDolly
 
-Plays a camera animation along defined paths on the local player's VRChat user camera (SDK 3.9+). Typically used for cinematic intros, tutorials, and guided tours.
+Applies a camera animation along defined paths to the local player's VRChat user camera (SDK 3.9+). Typically used for cinematic intros, tutorials, and guided tours.
 
 ### Components
 
@@ -617,7 +617,9 @@ public class DollyTrigger : UdonSharpBehaviour
 ```
 
 For the full scripting reference, see the udon-sharp skill's
-[`api.md` Camera Dolly section](../../unity-vrc-udon-sharp/references/api.md).
+[`api.md` Camera Dolly section](../../unity-vrc-udon-sharp/references/api.md#vrc-camera-dolly-api-sdk-390).
+
+---
 
 ## VRCCameraSettings API
 


### PR DESCRIPTION
Closes #253

## Summary

The world skill's VRC_CameraDolly section asserted a scripting API (`Play/Stop/Pause/Resume/SetPosition/GetPosition/SetSpeed/IsPlaying/Loop` on a `VRC_CameraDolly` component) and a behavioral contract ("Only one dolly can be active per player") with no source. Enumerating the SDK 3.10.3 Udon wrapper modules shows none of those symbols exist on any dolly type — the actual exposed surface is `VRCCameraDollyAnimation.Import()` plus get/set accessors for the Inspector parameters (AnchorMode, FocusMode, CaptureType, PathType, LoopType, Paths, Points). The official VRC_CameraDolly page documents `Import()` as the way to apply the animation and lists the parameters as Inspector configuration, without documenting runtime access.

## Changes

- **world-sdk components.md**: the VRC_CameraDolly section is rewritten on the verified surface — real component hierarchy (Animation/Path/Point), Inspector parameters with a pointer to the official list, `Import()` as the only documented scripting entry point, the Collect Paths & Points editor step, local-only and ClientSim notes, and a cross-skill link to api.md's fuller section. The fabricated API block, control example, and the invented one-active-dolly contract are gone.
- **udon-sharp api.md**: the limitation bullet "No properties of the animation, paths, or points are readable or writable from UdonSharp at runtime" was an absolute negative contradicted by the exposed accessors; it now states the docs-scoped fact — `Import()` is the only documented entry point and runtime parameter access is undocumented/unverified.

Per the repo's content policy, the binary-only accessors are treated as discovery signals and are not documented as usable APIs.

## Verification

- Full wrapper-symbol enumeration of VRC.Udon.VRCWrapperModules.dll for all dolly types (SDK 3.10.3)
- Official VRC_CameraDolly page re-fetched for the documented surface and parameter list
- editorconfig-checker clean; section heading/TOC anchor preserved