### PR TITLE
Release v2.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.4.0"
+    "version": "2.5.0"
   },
   "plugins": [
     {

--- a/.claude/audit/sdk-coverage-ledger.md
+++ b/.claude/audit/sdk-coverage-ledger.md
@@ -60,3 +60,53 @@ confirmed **documented** and therefore skipped:
 Reversed during review: `GetPlayerObjectStorageLimit`/`Usage` were briefly flagged
 as undocumented by name-mismatch inference; the player-object page documents them.
 Inference is not a negative check — record `inconclusive`, never `undocumented`.
+
+## Audit: SDK 3.10.4
+
+Source release note: https://creators.vrchat.com/releases/release-3-10-4/
+
+Local package versions:
+
+- `com.vrchat.base` `3.10.4`
+- `com.vrchat.worlds` `3.10.4`
+
+Binary discovery command:
+
+```bash
+python3 .claude/audit/scripts/census.py \
+  --dll /home/natsuki/workspaces/agent-skills-vrc-udon/unity-project-for-sdk-search/TestProject/Packages/com.vrchat.worlds/Runtime/Udon/External/VRC.Udon.VRCWrapperModules.dll \
+  --out .claude/audit/.generated/census-3.10.4.json
+python3 .claude/audit/scripts/diff.py \
+  --census .claude/audit/.generated/census-3.10.4.json \
+  --out .claude/audit/.generated/diff-3.10.4.json
+python3 .claude/audit/scripts/refine.py \
+  --diff .claude/audit/.generated/diff-3.10.4.json
+```
+
+### Included / release-noted stable facts
+
+These are 3.10.4 release-note-backed authoring or Udon surfaces. Binary-backed
+rows list the local wrapper types found in `VRC.Udon.VRCWrapperModules.dll`;
+release-only rows are not treated as binary discoveries.
+
+| API / feature | release-note status | binary evidence | AI-relevance | status | notes |
+|---------------|---------------------|-----------------|--------------|--------|-------|
+| VRCTween / VRCTweenHandle | release-noted — 3.10.4 adds VRCTween, virtual tweens, cancelable delayed calls, UdonSharp and Graph compatibility; beta notes add `DelayedSetActive` and `TweenPitch` | `ExternVRCSDK3ComponentsVRCTween`: `DelayedCall`, `DelayedSetActive`, `KillAll`, `KillAllTweens`, `TweenAnchorPos`, `TweenColor`, `TweenFade`, `TweenFloat`, `TweenInt`, `TweenIntensity`, `TweenLocalPath`, `TweenLocalPosition`, `TweenLocalRotation`, `TweenPath`, `TweenPitch`, `TweenPosition`, `TweenRotation`, `TweenScale`, `TweenSizeDelta`, `TweenValue`, `TweenVector3`, `TweenVolume`; `ExternVRCSDK3ComponentsVRCTweenHandle`: `ChangeEndValue`, `Complete`, `Flip`, `From`, `Goto`, `Kill`, `OnComplete`, `OnRewind`, `Pause`, `Play`, `PlayBackwards`, `PlayForwards`, `Restart`, `SetDelay`, `SetDuration`, `SetEase`, `SetLoops`, `SetSpeedBased`, `SetUpdate`, plus state accessors | high — new animation API likely to be requested directly | `included` | Stable 3.10.4 fact. Do not infer DOTween parity beyond the documented/select exposed surface. |
+| Contacts: box shape / `size` / face proximity option | release-noted — contact senders and receivers can be box-shaped; width, height and depth are independently adjustable; proximity can use center distance or box-face distance | wrapper confirms `get_size`/`set_size` and existing shape/transform accessors on `ExternVRCSDK3DynamicsContactComponentsVRCContactReceiver` and `ExternVRCSDK3DynamicsContactComponentsVRCContactSender`; no separate `Use Face Proximity` Udon wrapper member surfaced in this DLL census | high — prevents agents from assuming sphere/capsule-only contacts | `included` | Treat `Use Face Proximity` as release-noted authoring behavior, not as a wrapper method. `CalculateProximity` / `UpdateCollisionTags` are related wrapper methods but are not new 3.10.4 inclusions; see related/gap rows below. |
+| World `VRCPhysBoneCollider` Udon access | release-noted — world PhysBone colliders are exposed to Udon and require `ApplyConfigurationChanges()` after property edits | `ExternVRCSDK3DynamicsPhysBoneComponentsVRCPhysBoneCollider`: `ApplyConfigurationChanges`, `get_height`/`set_height`, `get_position`/`set_position`, `get_radius`/`set_radius`, `get_rotation`/`set_rotation`, `get_shapeType`/`set_shapeType` | high — dynamic world collider edits need the apply call | `included` | Release note also mentions avatar global PhysBone colliders; this row is specifically the world Udon wrapper surface. |
+| Data Container capacity / `EnsureCapacity` | release-noted — `VRCDataList` and `VRCDataDictionary` can be constructed with custom capacity; `VRCDataDictionary` exposes `EnsureCapacity()` | `ExternVRCSDK3DataDataList`: `get_Capacity`, `set_Capacity`; `ExternVRCSDK3DataDataDictionary`: `EnsureCapacity` | medium-high — useful for performance-sensitive data structures and avoids confusing DataList capacity with Dictionary capacity | `included` | Constructor support is release-note-backed but not visible as a Udon wrapper method in this census. |
+
+### Related / gaps — not new 3.10.4 inclusions
+
+| API | methods | doc status (oracle) | AI-relevance | status | notes |
+|-----|---------|---------------------|--------------|--------|-------|
+| VRCContactReceiver / VRCContactSender related wrappers | `CalculateProximity`, `UpdateCollisionTags` | related wrapper confirmation, not a 3.10.4 new-feature fact | medium | `candidate` | Already listed under the 3.10.3 documented-skip review as Pickup / Contacts coverage. Keep separate from the 3.10.4 box-contact / size / face-proximity feature. |
+| Binary-only candidates carried forward from 3.10.3 | VRCPlayerApi Combat, VRCPlayerApi voice moderation, PlayerData `IsType`, Economy Store `OpenGroupListing`, Networking `GetEventDispatcher` | binary-only or lower-confidence reference gaps from the prior audit | varies | `candidate` | Remain candidates. The 3.10.4 release note does not promote them to release-noted stable facts. |
+
+### No-change / not adopted
+
+| Item | status | notes |
+|------|--------|-------|
+| Voice Audio Rework | `skip` | Not shipped in the audited release; do not add or reframe voice-audio guidance for this audit. |
+| Runtime Texture Compression | `skip` | No authoring wrapper surface found in the 3.10.4 wrapper DLL census; not adopted into skill coverage from this audit. |
+| World Preloading | `skip` | No authoring wrapper surface found in the 3.10.4 wrapper DLL census; not adopted into skill coverage from this audit. |

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.4.0"
+    version: "2.5.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.claude/skills/unity-vrc-skills-renovator/references/search-queries.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/search-queries.md
@@ -82,7 +82,7 @@ VRChat OnPlayerRestored event
 ```
 VRChat SDK PhysBones Contacts Udon API worlds
 VRChat SDK 3.10 dynamics worlds
-VRChat OnContactEnter OnPhysBoneGrab
+VRChat OnContactEnter OnPhysBoneGrabbed
 ```
 
 ### New System Namespaces

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 [English](README.md) | **日本語** | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -203,7 +203,8 @@ Q3: 継続的に変化しますか？（位置・回転など）
 | **3.10.0** | ワールド向けVRChat Dynamics（PhysBones、Contacts、VRC Constraints） | サポート済み |
 | **3.10.1** | バグ修正、安定性の向上 | サポート済み |
 | **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | サポート済み |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（アバター）、Mirror 描画タイミング修正 | 最新安定版 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（アバター）、Mirror 描画タイミング修正 | サポート済み |
+| **3.10.4** | VRCTween、Box形状のContacts、Global Avatar PhysBone Colliders、ワールドの`VRCPhysBoneCollider` Udonアクセス、DataList/DataDictionary容量API | 最新安定版 |
 
 > **注意**: SDK 3.9.0未満は2025年12月2日に非推奨となりました。新規ワールドのアップロードには3.9.0以上が必要です。
 
@@ -244,7 +245,7 @@ Q3: 継続的に変化しますか？（位置・回転など）
 - コンテンツは**「現状のまま」**提供されており、いかなる保証もありません。[LICENSE](LICENSE) をご確認ください。
 - これは個人プロジェクトです。**誤り、古くなった情報、または不完全な内容が含まれる可能性があります。** 常に[VRChat公式ドキュメント](https://creators.vrchat.com/)で確認してください。
 - このリポジトリが原因で生じた問題（ビルドエラー、アップロード拒否、予期しないワールドの動作など）について、作者は一切責任を負いません。
-- SDKカバレッジ（3.7.1〜3.10.3）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
+- SDKカバレッジ（3.7.1〜3.10.4）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
 
 ### AI支援による作成
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | **한국어**
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="에이전트 스킬" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="라이선스" />
@@ -203,7 +203,8 @@ Q3: 지속적으로 변하나요? (위치/회전)
 | **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | 지원 |
 | **3.10.1** | 버그 수정, 안정성 개선 | 지원 |
 | **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 지원 |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (아바타), Mirror 렌더 순서 수정 | 최신 안정 버전 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (아바타), Mirror 렌더 순서 수정 | 지원 |
+| **3.10.4** | VRCTween, Box형 Contacts, Global Avatar PhysBone Colliders, 월드 `VRCPhysBoneCollider` Udon 접근, DataList/DataDictionary 용량 API | 최신 안정 버전 |
 
 > **참고**: SDK 3.9.0 미만은 2025년 12월 2일에 지원이 종료되었습니다. 새로운 월드 업로드에는 3.9.0 이상이 필요합니다.
 
@@ -244,7 +245,7 @@ Q3: 지속적으로 변하나요? (위치/회전)
 - 콘텐츠는 어떠한 보증 없이 **"있는 그대로"** 제공됩니다. [LICENSE](LICENSE)를 참조하세요.
 - 이것은 개인 프로젝트입니다. **오류, 오래된 정보, 불완전한 내용이 있을 수 있습니다.** 반드시 [공식 VRChat 문서](https://creators.vrchat.com/)와 대조하여 확인하세요.
 - 이 리포지토리로 인해 발생하는 문제(빌드 오류, 업로드 거부, 예상치 못한 월드 동작 등)에 대해 저자는 어떠한 책임도 지지 않습니다.
-- SDK 지원 범위(3.7.1 - 3.10.3)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
+- SDK 지원 범위(3.7.1 - 3.10.4)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
 
 ### AI 지원 제작
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **English** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -203,7 +203,8 @@ Supports both **Bash** (`validate-udonsharp.sh`) and **PowerShell** (`validate-u
 | **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | Supported |
 | **3.10.1** | Bug fixes, stability improvements | Supported |
 | **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Supported |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Latest Stable |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Supported |
+| **3.10.4** | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary capacity APIs | Latest Stable |
 
 > **Note**: SDK < 3.9.0 was deprecated on December 2, 2025. New world uploads require 3.9.0+.
 
@@ -244,7 +245,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 - Content is provided **"AS IS"** without warranty. See [LICENSE](LICENSE).
 - This is a personal project. **Errors, outdated information, or incomplete content may exist.** Always verify against [official VRChat documentation](https://creators.vrchat.com/).
 - The author assumes no liability for issues caused by this repository (build errors, upload rejections, unexpected world behavior, etc.).
-- SDK coverage (3.7.1 - 3.10.3) reflects the last update. Behavior may change with new VRChat releases.
+- SDK coverage (3.7.1 - 3.10.4) reflects the last update. Behavior may change with new VRChat releases.
 
 ### AI-Assisted Creation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | **简体中文** | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="AI Agent 技能" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="许可证" />
@@ -203,7 +203,8 @@ Q3: 是否持续变化？（位置/旋转）
 | **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支持 |
 | **3.10.1** | Bug 修复、稳定性改进 | 已支持 |
 | **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 已支持 |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（头像）、Mirror 渲染顺序修复 | 最新稳定版 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（头像）、Mirror 渲染顺序修复 | 已支持 |
+| **3.10.4** | VRCTween、Box 形 Contacts、Global Avatar PhysBone Colliders、世界 `VRCPhysBoneCollider` Udon 访问、DataList/DataDictionary 容量 API | 最新稳定版 |
 
 > **注意**：SDK < 3.9.0 已于 2025 年 12 月 2 日弃用。上传新世界需要 3.9.0+。
 
@@ -244,7 +245,7 @@ Q3: 是否持续变化？（位置/旋转）
 - 内容以 **"按原样"（AS IS）** 提供，不附带任何保证。请参阅 [LICENSE](LICENSE)。
 - 这是一个个人项目。**可能存在错误、过时信息或不完整的内容。** 请始终以 [VRChat 官方文档](https://creators.vrchat.com/) 为准进行验证。
 - 作者不对因使用本仓库而导致的任何问题（构建错误、上传被拒、意外的世界行为等）承担责任。
-- SDK 覆盖范围（3.7.1 - 3.10.3）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
+- SDK 覆盖范围（3.7.1 - 3.10.4）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
 
 ### AI 辅助创建
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | **繁體中文** | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.3-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="授權條款" />
@@ -203,7 +203,8 @@ PostToolUse 掛鉤會在 `.cs` 檔案被編輯時自動執行。
 | **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支援 |
 | **3.10.1** | 錯誤修正、穩定性改善 | 已支援 |
 | **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 已支援 |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（頭像）、Mirror 渲染順序修正 | 最新穩定版 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（頭像）、Mirror 渲染順序修正 | 已支援 |
+| **3.10.4** | VRCTween、Box 形 Contacts、Global Avatar PhysBone Colliders、世界 `VRCPhysBoneCollider` Udon 存取、DataList/DataDictionary 容量 API | 最新穩定版 |
 
 > **注意**：SDK 3.9.0 以下版本已於 2025 年 12 月 2 日棄用。新的世界上傳需使用 3.9.0 以上版本。
 
@@ -244,7 +245,7 @@ PostToolUse 掛鉤會在 `.cs` 檔案被編輯時自動執行。
 - 內容以**「現狀」**提供，不附帶任何保證。請參閱 [LICENSE](LICENSE)。
 - 這是一個個人專案。**可能存在錯誤、過時資訊或不完整的內容。** 請務必與 [VRChat 官方文件](https://creators.vrchat.com/) 進行核對。
 - 作者不對本儲存庫造成的問題承擔任何責任（建置錯誤、上傳被拒絕、非預期的世界行為等）。
-- SDK 涵蓋範圍（3.7.1 - 3.10.3）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
+- SDK 涵蓋範圍（3.7.1 - 3.10.4）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
 
 ### AI 輔助建立
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.3 Coverage**
+**SDK 3.7.1 - 3.10.4 Coverage**
 
 ## Blocked Features and Alternatives
 
@@ -25,6 +25,7 @@
 | `[NetworkCallable]` | 3.8.1 | Parameterized network events |
 | Persistence | 3.7.4 | PlayerData/PlayerObject |
 | Dynamics for Worlds | 3.10.0 | PhysBones, Contacts |
+| VRCTween | 3.10.4 | Local tweens, cancelable delayed calls |
 
 ---
 
@@ -113,7 +114,7 @@ public void SetValue(int newValue) {
 | `OnOwnershipTransferred(VRCPlayerApi)` | Ownership changed |
 | `OnPlayerRestored(VRCPlayerApi)` | **3.7.4+** Persistence data loaded |
 | `OnContactEnter(ContactEnterInfo)` | **3.10+** Contact started |
-| `OnPhysBoneGrab(PhysBoneGrabInfo)` | **3.10+** PhysBone grabbed |
+| `OnPhysBoneGrabbed(PhysBoneGrabbedInfo)` | **3.10+** PhysBone grabbed |
 
 ---
 
@@ -205,6 +206,42 @@ public void DoLoop() {
 }
 ```
 
+For cancelable timers on SDK 3.10.4+, use `VRCTween.DelayedCall`; keep helper-`GameObject` cancellation workarounds only for older SDK projects.
+
+---
+
+## VRCTween (SDK 3.10.4+)
+
+```csharp
+using VRC.SDK3.Components;
+
+private VRCTweenHandle _scaleTween;
+
+public void Pulse() {
+    _scaleTween.Kill(); // safe no-op when invalid/default
+    _scaleTween = gameObject.TweenScale(Vector3.one * 1.2f, 0.15f, VRCTweenEase.OutQuad)
+        .OnComplete(this, nameof(OnPulseUp));
+}
+
+public void OnPulseUp() {
+    _scaleTween = gameObject.TweenScale(Vector3.one, 0.15f, VRCTweenEase.OutQuad);
+}
+
+void OnDestroy() {
+    gameObject.KillAllTweens();
+}
+```
+
+| Need | Use | Notes |
+|------|-----|-------|
+| Smooth transform/UI/audio changes | `TweenPosition`, `TweenScale`, `TweenFade`, `TweenPitch` | Returns `VRCTweenHandle` |
+| Cancelable delayed event | `VRCTween.DelayedCall(this, nameof(Method), seconds)` | Prefer over helper objects on SDK 3.10.4+ |
+| Delayed active toggle | `VRCTween.DelayedSetActive(target, active, seconds)` | Use for local visibility/state toggles |
+| Cleanup | `handle.Kill()` / `gameObject.KillAllTweens()` | Kill stored handles and long/infinite tweens |
+| High-frequency retargeting | `ChangeEndValue`, `SetDuration`, `SetEase`, `Restart` | Reuse a handle instead of kill/recreate in hot paths |
+
+VRCTween is **local-only**: it does not automatically sync. For shared animation state, sync the intent/time separately and recreate or seek the local tween per client. Invalid/default `VRCTweenHandle` operations are safe no-ops; check `handle.IsValid` only when branching on creation success.
+
 ---
 
 ## Inter-Script Communication
@@ -271,13 +308,17 @@ PlayerData.SetInt(Networking.LocalPlayer, "score", 100);
 ```csharp
 // Contact events
 public override void OnContactEnter(ContactEnterInfo info) {
-    if (info.isAvatar) {
-        Debug.Log($"Touched by: {info.player?.displayName}");
-    }
+    ContactSenderProxy sender = info.contactSender;
+    if (!sender.isValid) return;
+
+    VRCPlayerApi player = sender.player;
+    Debug.Log(player != null
+        ? $"Touched by: {player.displayName}"
+        : $"Touched by usage: {sender.usage}");
 }
 
 // PhysBone events
-public override void OnPhysBoneGrab(PhysBoneGrabInfo info) {
+public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo info) {
     Debug.Log($"Grabbed by: {info.player?.displayName}");
 }
 ```
@@ -391,6 +432,7 @@ For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` arr
 | Initialization, interaction, player detection, timer, audio, pickup, animation, UI, and teleportation patterns | [references/patterns-core.md](references/patterns-core.md) |
 | Cross-class call overhead, partial classes, update handlers, PostLateUpdate, spatial queries, and animator hashes | [references/patterns-performance.md](references/patterns-performance.md) |
 | Array helpers, event bus, GameObject relay communication, pseudo-struct double-cast, and callback patterns | [references/patterns-utilities.md](references/patterns-utilities.md) |
+| VRCTween local animation, cancelable delayed calls, cleanup, and high-frequency reuse | [references/vrctween.md](references/vrctween.md) |
 | VRCImageDownloader GPU memory lifecycle, safe texture cleanup, fades, and staggering | [references/image-loading-vram.md](references/image-loading-vram.md) |
 | Advanced packed resource loading with VRCStringDownloader | [references/web-loading-advanced.md](references/web-loading-advanced.md) |
 | SDK upgrade steps, version-by-version changes, and migration checklists | [references/sdk-migration.md](references/sdk-migration.md) |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.4.0"
+    version: "2.5.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -5,12 +5,15 @@ description: >
     Use this skill when writing, reviewing, or debugging UdonSharp C# code.
     Covers compile constraints (List<T>/async/await/try/catch/LINQ blocked),
     network sync (UdonSynced, RequestSerialization, FieldChangeCallback, NetworkCallable),
-    persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts),
-    Web Loading, VRAM management (texture lifecycle, Dispose vs Destroy),
-    and event handling. SDK 3.7.1 - 3.10.3 coverage.
+    persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts,
+    VRCTween, VRCPhysBoneCollider Udon access), Web Loading, DataList/DataDictionary
+    capacity APIs, VRAM management (texture lifecycle, Dispose vs Destroy),
+    and event handling. SDK 3.7.1 - 3.10.4 coverage.
     Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
     NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
-    synced variables, VRChat world scripting, C# to Udon.
+    VRCTween, Box Contacts, Global Avatar PhysBone Colliders, VRCPhysBoneCollider,
+    DataList capacity, DataDictionary EnsureCapacity, synced variables,
+    VRChat world scripting, C# to Udon.
 license: MIT
 metadata:
     author: niaka3dayo
@@ -56,7 +59,7 @@ These constraints cause either **compile-time failures** or **silent runtime fai
 
 | # | NEVER do this | Why it fails silently | Use instead |
 |---|---------------|----------------------|-------------|
-| 1 | Use `List<T>`, `Dictionary<T,K>`, or any generic collection | Compile error — blocked by Udon compiler | `T[]` arrays, `DataList`, `DataDictionary` |
+| 1 | Use `List<T>`, `Dictionary<T,K>`, or any generic collection | Compile error — blocked by Udon compiler | `T[]` arrays, `DataList`, `DataDictionary` (`DataDictionary.EnsureCapacity` / custom capacities require SDK 3.10.4+) |
 | 2 | Use `async`/`await`, `System.Threading`, or coroutines | Udon is single-threaded; these features do not exist | `SendCustomEventDelayedSeconds()` |
 | 3 | Modify `[UdonSynced]` fields without owning the object | Change appears local but is **silently reverted** on next deserialization | `Networking.SetOwner()` before modify, then `RequestSerialization()` |
 | 4 | Forget `RequestSerialization()` after modifying synced fields (Manual sync) | State changes never leave the local client — no error, no warning | Always call `RequestSerialization()` after modifying `[UdonSynced]` fields |
@@ -69,7 +72,7 @@ These constraints cause either **compile-time failures** or **silent runtime fai
 | 11 | Mix Continuous and Manual sync concerns on one behaviour | Wastes bandwidth (discrete values in Continuous) or loses control (redundant `RequestSerialization` in Continuous) | Separate behaviours: Continuous for position/rotation, Manual for discrete state |
 | 12 | Write to `[UdonSynced]` fields without an `IsOwner` guard | Non-owner writes are purely local and silently reverted on the next deserialization from the actual owner | `Networking.SetOwner` first if needed (locally immediate), then write under `IsOwner` and call `RequestSerialization()` |
 | 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compiles but silently ignored at runtime — the attribute has no effect and methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
-| 14 | Use PhysBones/Contacts API (`OnPhysBoneGrab`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
+| 14 | Use PhysBones/Contacts API (`OnPhysBoneGrabbed`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
 | 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
 | 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
@@ -119,7 +122,9 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Building UI/menus | `patterns-ui.md`, `events.md` | `patterns-core.md`, `api.md` | `networking-bandwidth.md`, `dynamics.md`, `web-loading.md` |
 | Implementing persistence (save/load) | `persistence.md` | `patterns-networking.md`, `events.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Downloading strings/images from web | `web-loading.md` | `web-loading-advanced.md`, `image-loading-vram.md` | `dynamics.md`, `persistence.md`, `networking-bandwidth.md` |
-| Using PhysBones/Contacts/Constraints | `dynamics.md`, `events.md` | `patterns-networking.md`, `api.md` | `web-loading.md`, `image-loading-vram.md`, `persistence.md` |
+| Using VRCTween, cancelable delayed calls, or tween cleanup | `vrctween.md` | `patterns-utilities.md`, `api.md` | `dynamics.md`, `web-loading.md`, `persistence.md` |
+| Using PhysBones/Contacts/Constraints, Box Contacts, Global Avatar PhysBone Colliders, or world `VRCPhysBoneCollider` Udon access | `dynamics.md`, `events.md` | `patterns-networking.md`, `api.md` | `web-loading.md`, `image-loading-vram.md`, `persistence.md` |
+| Tuning DataList/DataDictionary capacity or using `DataDictionary.EnsureCapacity` | `api.md` | `constraints.md`, `patterns-utilities.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `networking-bandwidth.md` |
 | Optimizing performance (Update loops) | `patterns-performance.md` | `patterns-utilities.md`, `api.md` | `dynamics.md`, `web-loading.md`, `persistence.md` |
 | Building a video player | `patterns-video.md` | `events.md`, `web-loading.md` | `dynamics.md`, `persistence.md`, `image-loading-vram.md` |
 | Debugging/troubleshooting | `troubleshooting.md` | `constraints.md`, `networking.md`, `testing.md` | `patterns-*.md`, `dynamics.md`, `web-loading.md` |
@@ -209,6 +214,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
 | 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
+| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary custom capacity, `DataDictionary.EnsureCapacity` |
 
 > **Note**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible.
 
@@ -226,12 +232,12 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 
 | File | Contents | Search Hints |
 |------|----------|--------------|
-| `constraints.md` | C# feature availability in UdonSharp; blocked features; syncable types; attributes; DataList vs array decision guidance; advanced workarounds (object array pseudo-struct); synced VRCUrl lists | List, async, try/catch, LINQ, generics, DataList, DataDictionary, DataList vs array, when to use DataList, VRCUrl array, VRCUrl sync, pseudo-struct, object array cast, multi-field state container |
+| `constraints.md` | C# feature availability in UdonSharp; blocked features; syncable types; attributes; DataList vs array decision guidance; DataList/DataDictionary capacity APIs; advanced workarounds (object array pseudo-struct); synced VRCUrl lists | List, async, try/catch, LINQ, generics, DataList, DataDictionary, DataList capacity, DataDictionary capacity, EnsureCapacity, DataList vs array, when to use DataList, VRCUrl array, VRCUrl sync, pseudo-struct, object array cast, multi-field state container |
 | `networking.md` | Ownership model, sync modes, RequestSerialization, NetworkCallable, network events, data limits | UdonSynced, SetOwner, BehaviourSyncMode, FieldChangeCallback, OnDeserialization, master leave, ownership cascade |
 | `networking-bandwidth.md` | Bandwidth throttling, bit packing, synced data size examples, debugging, owner-centric architecture | IsClogged, bandwidth, throttle, bit packing, data budget, IsMaster |
 | `networking-antipatterns.md` | 6 anti-patterns to avoid; 5 advanced sync patterns with template links | anti-pattern, race condition, ownership fight, late-joiner, PackedStateSync, BatchedSync |
 | `persistence.md` | Storage layer decision tree (local/synced/PlayerData/PlayerObject); PlayerData/PlayerObject API (SDK 3.7.4+); per-player save data; storage usage query API (SDK 3.10.0+) | storage layer, decision tree, local variable, PlayerData, PlayerObject, OnPlayerRestored, SetInt, TryGetInt, GetPlayerDataStorageUsage, GetPlayerDataStorageLimit, GetPlayerObjectStorageUsage, GetPlayerObjectStorageLimit, RequestStorageUsageUpdate, OnPersistenceUsageUpdated, storage quota, storage usage, which storage, when to use PlayerData |
-| `dynamics.md` | PhysBones, Contacts, VRC Constraints (SDK 3.10.0+) | PhysBone, ContactReceiver, ContactSender, VRCConstraint, OnContactEnter |
+| `dynamics.md` | PhysBones, Contacts, VRC Constraints (SDK 3.10.0+); VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access (SDK 3.10.4+) | PhysBone, ContactReceiver, ContactSender, Box Contact, Global Avatar PhysBone Collider, VRCPhysBoneCollider, VRCTween, VRCConstraint, OnContactEnter |
 | `patterns-core.md` | Initialization, interaction, player detection, timer, audio, pickup, animation, UI, teleportation, lazy init guard, remote players | Interact, OnEnable, Initialize, AudioSource, VRCPickup, Animator, UI, TeleportTo, remote players, GetRemotePlayers, exclude local player, FindAll alternative |
 | `patterns-networking.md` | Object pooling, NetworkCallable patterns, persistence integration, dynamics integration, synced game state, distant-room pseudo-multi-room (state/presentation split, self-owned vs master-approved tiers), delayed event debounce, string join for array sync | pool, MasterManagedPlayerPool, NetworkCallable, DamageReceiver, game state, distant room, pseudo multi-room, room assignment, roomIndex, LocalRoomPresenter, RoomAssignment, NoVariableSync, TeleportTo per-client, debounce, state machine, string join, array sync, paragraph separator, U+2029 |
 | `patterns-performance.md` | Partial class pattern, update handler, PostLateUpdate, spatial query, platform optimization, frame budget Stopwatch, heavy processing architecture (rebuild, replay, reset/cancel), rate limit resolver, GameObject lookup cost tiers | Update, PostLateUpdate, Bounds, AnimatorHash, performance, mobile, PC, Stopwatch, frame budget, SendCustomEventDelayedFrames, heavy processing, rebuild, replay, reset, cancel, operation log, authoritative data, derived state, cursor rebuild, rate limit, URL scheduler, video load queue, GameObject.Find, Find cost, lookup cost tier, SerializeField vs Find, silent failure on rename, SendCustomEvent cost, cross-behaviour call, EventBus hot path, delayed loop spike, public method lookup, event dispatch tier |

--- a/skills/unity-vrc-udon-sharp/assets/templates/ContactReceiver.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/ContactReceiver.cs
@@ -1,17 +1,18 @@
 using UdonSharp;
 using UnityEngine;
+using VRC.Dynamics;
 using VRC.SDKBase;
 using VRC.Udon;
 
 /// <summary>
 /// VRCContactReceiver template for VRChat worlds (SDK 3.10.0+).
-/// Demonstrates OnContactEnter/Stay/Exit, avatar vs world object detection,
+/// Demonstrates OnContactEnter/Exit, avatar vs world object detection,
 /// debounce cooldown, and visual/audio feedback.
 ///
 /// Setup:
 /// 1. Add "VRC Contact Receiver" component to this GameObject.
-/// 2. Set Shape Type to Sphere or Capsule. Capsule also requires Height (Y-axis).
-/// 3. Configure Radius, Allow Self, Allow Others, and Content Types on it.
+/// 2. Set Shape Type to Sphere, Capsule, or Box. Capsule uses Height; Box uses Vector3 Size.
+/// 3. Configure Radius/Size, content usage, and collision tags.
 /// 4. Assign the public fields below in the Inspector.
 ///
 /// See references/dynamics.md "Contacts" for full API documentation.
@@ -49,7 +50,7 @@ public class ContactReceiver : UdonSharpBehaviour
     [Tooltip("Minimum seconds between repeated OnContactEnter triggers")]
     public float cooldownTime = 0.5f;
 
-    [Tooltip("If true, only accept contacts from avatars (isAvatar == true)")]
+    [Tooltip("If true, only accept contacts from avatar-owned Contact Senders")]
     public bool avatarOnlyMode = false;
 
     [Tooltip("Enable debug logging")]
@@ -77,7 +78,7 @@ public class ContactReceiver : UdonSharpBehaviour
 
     // -------------------------------------------------------------------------
     // VRCContactReceiver callbacks
-    // All three callbacks must use 'override' when declared on UdonSharpBehaviour.
+    // Contact callbacks must use 'override' when declared on UdonSharpBehaviour.
     // -------------------------------------------------------------------------
 
     /// <summary>
@@ -85,8 +86,15 @@ public class ContactReceiver : UdonSharpBehaviour
     /// </summary>
     public override void OnContactEnter(ContactEnterInfo info)
     {
-        // Optionally filter out world-object senders (non-avatar contacts).
-        if (avatarOnlyMode && !info.isAvatar)
+        ContactSenderProxy sender = info.contactSender;
+        ContactReceiverProxy receiver = info.contactReceiver;
+        if (!sender.isValid || !receiver.isValid)
+        {
+            return;
+        }
+
+        // Optionally filter out world/item senders.
+        if (avatarOnlyMode && sender.usage != DynamicsUsage.Avatar)
         {
             return;
         }
@@ -110,31 +118,11 @@ public class ContactReceiver : UdonSharpBehaviour
         // Log source type and player name for debugging.
         if (debugMode)
         {
-            if (info.isAvatar)
-            {
-                // info.player can be null for remote contacts before the
-                // player object is fully initialized; always guard.
-                string playerName = (info.player != null && info.player.IsValid())
-                    ? info.player.displayName
-                    : "unknown";
-                Debug.Log($"[ContactReceiver:{gameObject.name}] Enter (avatar) player={playerName} sender={info.senderName}");
-            }
-            else
-            {
-                Debug.Log($"[ContactReceiver:{gameObject.name}] Enter (world object) sender={info.senderName}");
-            }
+            string playerName = (sender.player != null && sender.player.IsValid())
+                ? sender.player.displayName
+                : "none";
+            Debug.Log($"[ContactReceiver:{gameObject.name}] Enter usage={sender.usage} player={playerName} point={info.contactPoint}");
         }
-    }
-
-    /// <summary>
-    /// Called every frame while at least one Contact Sender overlaps this receiver.
-    /// Use this for continuous effects such as progress bars or held-trigger logic.
-    /// </summary>
-    public override void OnContactStay(ContactStayInfo info)
-    {
-        // Example: per-frame logic while contact is held.
-        // Add continuous effects here (particle rate, shader value, etc.).
-        // Avoid heavy allocation or per-frame logging in production builds.
     }
 
     /// <summary>
@@ -142,6 +130,18 @@ public class ContactReceiver : UdonSharpBehaviour
     /// </summary>
     public override void OnContactExit(ContactExitInfo info)
     {
+        ContactSenderProxy sender = info.contactSender;
+        ContactReceiverProxy receiver = info.contactReceiver;
+        if (!sender.isValid || !receiver.isValid)
+        {
+            return;
+        }
+
+        if (avatarOnlyMode && sender.usage != DynamicsUsage.Avatar)
+        {
+            return;
+        }
+
         _contactCount--;
 
         // Clamp to zero to guard against missed Enter events (e.g. late join).
@@ -159,7 +159,7 @@ public class ContactReceiver : UdonSharpBehaviour
 
             if (debugMode)
             {
-                Debug.Log($"[ContactReceiver:{gameObject.name}] Exit (all senders gone) sender={info.senderName}");
+                Debug.Log($"[ContactReceiver:{gameObject.name}] Exit (all senders gone) usage={sender.usage}");
             }
         }
     }

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -2,7 +2,7 @@
 
 Complete reference of VRChat-specific classes, methods, and types available in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 ## VRCPlayerApi
 
@@ -89,7 +89,7 @@ float radius  = player.GetVoiceVolumetricRadius();
 bool  lowpass = player.GetVoiceLowpass();
 ```
 
-> **Note**: The voice getters are named in the [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) — added to `VRCPlayerApi` and exposed to Udon — but do not appear on the current [Player Audio](https://creators.vrchat.com/worlds/udon/players/player-audio/), Players, or UdonSharp API reference pages. Each is parameterless and returns the value type of its matching setter (4 `float`, 1 `bool`). This entry records that they exist and their signatures; it does not specify runtime read semantics. What a getter returns before its setter has run, whether it reflects the last value set versus the live effective value, and whether local- and remote-player reads behave identically, are not verified here — confirm against your SDK/client before relying on a getter's return value (for example, before using one in place of your own tracked state). Re-check after the Voice Audio Rework (SDK 3.10.4) lands.
+> **Note**: The voice getters are named in the [SDK 3.6.1 release notes](https://creators.vrchat.com/releases/release-3-6-1/) — added to `VRCPlayerApi` and exposed to Udon — but do not appear on the current [Player Audio](https://creators.vrchat.com/worlds/udon/players/player-audio/), Players, or UdonSharp API reference pages. Each is parameterless and returns the value type of its matching setter (4 `float`, 1 `bool`). This entry records that they exist and their signatures; it does not specify runtime read semantics. What a getter returns before its setter has run, whether it reflects the last value set versus the live effective value, and whether local- and remote-player reads behave identically, are not verified here — confirm against your SDK/client before relying on a getter's return value (for example, before using one in place of your own tracked state). The planned voice-audio rework did not ship in SDK version 3.10.4; re-check these getter semantics when an official release includes that rework.
 
 ### Avatar Methods
 
@@ -719,7 +719,7 @@ Generic-like collections from `VRC.SDK3.Data`:
 using VRC.SDK3.Data;
 
 // DataList (replaces List<T>)
-DataList list = new DataList();
+DataList list = new DataList(); // SDK 3.10.4+: use new DataList(64) when count is known
 list.Add("item1");
 list.Add(42);
 list.Add(3.14f);
@@ -733,7 +733,8 @@ list.RemoveAt(0);
 list.Clear();
 
 // DataDictionary (replaces Dictionary<string, T>)
-DataDictionary dict = new DataDictionary();
+DataDictionary dict = new DataDictionary(); // SDK 3.10.4+: use new DataDictionary(64) when count is known
+dict.EnsureCapacity(128); // SDK 3.10.4+: grow once before bulk inserts
 dict["key1"] = "value1";
 dict["key2"] = 100;
 
@@ -743,6 +744,10 @@ int num = dict["key2"].Int;
 bool hasKey = dict.ContainsKey("key1");
 dict.Remove("key1");
 ```
+
+### Capacity and Allocation (SDK 3.10.4+)
+
+Use `DataList(int capacity)`, `DataDictionary(int capacity)`, and `DataDictionary.EnsureCapacity(int)` when the expected item count is known before a bulk load or parse. Match the initial capacity to the expected entries, then grow once with `EnsureCapacity` before larger inserts if needed. Pre-sizing reduces internal growth reallocations; arrays are still preferable for tight per-frame loops and single-type hot data.
 
 ### DataToken
 
@@ -949,19 +954,32 @@ Receives contact events from Contact Senders.
 // Get contact receiver component
 VRCContactReceiver receiver = GetComponent<VRCContactReceiver>();
 
-// Configure allowed content types
-string[] allowedTypes = new string[] { "Hand", "Finger", "Custom" };
-receiver.UpdateContentTypes(allowedTypes);
+// Configure allowed content usage flags and collision tags
+receiver.UpdateContentTypes(DynamicsUsageFlags.Avatar | DynamicsUsageFlags.World);
+receiver.UpdateCollisionTags(new string[] { "Hand", "Finger", "Custom" });
 
-// Properties
-bool allowSelf = receiver.allowSelf;     // Allow contacts from same avatar
-bool allowOthers = receiver.allowOthers; // Allow contacts from other avatars
-float radius = receiver.radius;          // Collision radius (both shapes; max 3 m)
+// Shape properties
+float radius = receiver.radius;          // Sphere/Capsule radius (max 3 m)
 float height = receiver.height;          // Capsule height along Y, half-spheres included (max 6 m)
-ContactBase.ShapeType shapeType = receiver.shapeType; // Sphere or Capsule
+Vector3 size = receiver.size;            // Box dimensions (max 6 m per axis after scale)
+ContactBase.ShapeType shapeType = receiver.shapeType; // Sphere, Capsule, or Box
 ```
 
-Shape and dimension properties are read/write from Udon. `height` is only meaningful when `shapeType` is `ContactBase.ShapeType.Capsule`.
+Shape and dimension properties are read/write from Udon. `height` is only meaningful for Capsule contacts, and `Vector3 size` is only meaningful for Box contacts. When changing runtime shape fields, batch the changes and call `ApplyConfigurationChanges()` once after the batch.
+
+```csharp
+receiver.shapeType = ContactBase.ShapeType.Box;
+receiver.size = new Vector3(0.5f, 0.1f, 0.5f);
+receiver.position = new Vector3(0f, 1f, 0f);
+receiver.ApplyConfigurationChanges();
+
+// Assign a scene VRCContactSender in the Inspector, use info.contactSender
+// from a contact callback, or call GetComponent only when the Sender is on this GameObject.
+VRCContactSender sender = GetComponent<VRCContactSender>();
+float proximity = receiver.CalculateProximity(sender);
+```
+
+`CalculateProximity(sender)` returns a `0.0-1.0` value for how close the sender is to the receiver center. For a Box receiver with `Use Face Proximity` enabled, the value is measured toward the receiver's positive-Z face instead.
 
 ### VRCContactSender
 
@@ -971,13 +989,13 @@ Sends contact events to receivers.
 VRCContactSender sender = GetComponent<VRCContactSender>();
 
 // Properties
-float radius = sender.radius;             // Collision radius (both shapes; max 3 m)
+float radius = sender.radius;             // Sphere/Capsule radius (max 3 m)
 float height = sender.height;             // Capsule height along Y, half-spheres included (max 6 m)
-ContactBase.ShapeType shapeType = sender.shapeType; // Sphere or Capsule
-string contentType = sender.contentType;  // Contact tag string (e.g. "Finger", "Hand", or custom)
+Vector3 size = sender.size;               // Box dimensions (max 6 m per axis after scale)
+ContactBase.ShapeType shapeType = sender.shapeType; // Sphere, Capsule, or Box
 ```
 
-Shape and dimension properties are read/write from Udon. `height` is only meaningful when `shapeType` is `ContactBase.ShapeType.Capsule`.
+Shape and dimension properties are read/write from Udon. `height` is only meaningful for Capsule contacts, and `Vector3 size` is only meaningful for Box contacts. After changing shape fields, call `ApplyConfigurationChanges()` once after batching all edits.
 
 ### VRCPhysBone
 
@@ -986,63 +1004,81 @@ Physics-based bone system in worlds.
 ```csharp
 VRCPhysBone physBone = GetComponent<VRCPhysBone>();
 
-// Properties (read-only in most cases)
-bool isGrabbed = physBone.IsGrabbed();
-VRCPlayerApi grabbingPlayer = physBone.GetGrabbingPlayer();
+// Properties (read-only state)
+bool grabbed = physBone.IsGrabbed;
+bool posed = physBone.IsPosed;
+float angle = physBone.Angle;
+float squish = physBone.Squish;
+float stretch = physBone.Stretch;
 
-// Get affected transforms
-Transform[] affectedBones = physBone.GetAffectedTransforms();
+// Runtime configuration changes require ApplyConfigurationChanges().
+physBone.pull = 0.2f;
+physBone.spring = 0.8f;
+physBone.ApplyConfigurationChanges();
 ```
 
-### Contact Event Info Structs
+### VRCPhysBoneCollider
+
+World PhysBone colliders can be adjusted from Udon.
 
 ```csharp
-// ContactEnterInfo
-public struct ContactEnterInfo
-{
-    public string senderName;       // Contact sender name
-    public bool isAvatar;           // True if from avatar
-    public VRCPlayerApi player;     // Player if isAvatar is true
-    public Vector3 position;        // Contact position
-    public Vector3 normal;          // Contact normal
-}
+VRCPhysBoneCollider collider = GetComponent<VRCPhysBoneCollider>();
 
-// ContactStayInfo
-public struct ContactStayInfo
-{
-    public string senderName;
-    public bool isAvatar;
-    public VRCPlayerApi player;
-    public Vector3 position;
-    public Vector3 normal;
-}
-
-// ContactExitInfo
-public struct ContactExitInfo
-{
-    public string senderName;
-    public bool isAvatar;
-    public VRCPlayerApi player;
-}
+collider.shapeType = VRC.Dynamics.VRCPhysBoneColliderBase.ShapeType.Capsule;
+collider.radius = 0.2f;
+collider.height = 1.0f;
+collider.position = new Vector3(0f, 0.5f, 0f);
+collider.rotation = Quaternion.identity;
+collider.ApplyConfigurationChanges();
 ```
 
-### PhysBone Event Info Structs
+`shapeType`, `radius`, `height`, `position`, and `rotation` are documented as read/write for world `VRCPhysBoneCollider` components. Global Collision is configured on the component: avatar global colliders can affect world PhysBones when Allow Collision rules permit it; avatars may have up to four additional global colliders; worlds have no documented count limit; and Global Collision supports only Sphere and Capsule colliders. Udon access for changing global-collider flags is not documented.
+
+### Contact Event Info Payloads
 
 ```csharp
-// PhysBoneGrabInfo
-public struct PhysBoneGrabInfo
+public override void OnContactEnter(ContactEnterInfo info)
 {
-    public VRCPlayerApi player;     // Grabbing player
-    public Transform bone;          // Grabbed bone
+    ContactSenderProxy sender = info.contactSender;
+    ContactReceiverProxy receiver = info.contactReceiver;
+
+    if (!sender.isValid || !receiver.isValid) return;
+
+    Vector3 point = info.contactPoint;
+    Vector3 velocity = info.enterVelocity;
+    string[] matchingTags = info.matchingTags;
+
+    if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
+    {
+        Debug.Log($"Avatar sender: {sender.player.displayName}");
+    }
+    else if (sender.usage == DynamicsUsage.World)
+    {
+        Debug.Log("World sender");
+    }
 }
 
-// PhysBoneReleaseInfo
-public struct PhysBoneReleaseInfo
+public override void OnContactExit(ContactExitInfo info)
 {
-    public VRCPlayerApi player;
-    public Transform bone;
+    if (!info.contactSender.isValid || !info.contactReceiver.isValid) return;
+    string[] matchingTags = info.matchingTags;
 }
 ```
+
+`ContactEnterInfo` carries `contactSender`, `contactReceiver`, `contactPoint`, `enterVelocity`, and `matchingTags`. `ContactExitInfo` carries `contactSender`, `contactReceiver`, and `matchingTags`. The sender/receiver values are proxy objects; check `isValid`, then use `player` and `usage` to distinguish avatar-owned and world-side contacts.
+
+### PhysBone Event Info Payloads
+
+Use the SDK 3.10.4 UdonSharp event names:
+
+```csharp
+public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo physBoneInfo) { }
+public override void OnPhysBoneReleased(PhysBoneReleasedInfo physBoneInfo) { }
+public override void OnPhysBonePosed(PhysBonePosedInfo physBoneInfo) { }
+public override void OnPhysBoneUnPosed(PhysBoneUnPosedInfo physBoneInfo) { }
+```
+
+Attach the UdonBehaviour to the same GameObject as the `VRCPhysBone` component. Use the event payload's player reference for grab/pose source information, and read `VRCPhysBone.IsGrabbed`, `IsPosed`, `Angle`, `Squish`, and `Stretch` for current state.
 
 ### Usage Example: Interactive Button with Contacts
 
@@ -1057,12 +1093,21 @@ public class ContactButton : UdonSharpBehaviour
     public override void OnContactEnter(ContactEnterInfo info)
     {
         if (isPressed) return;
+        if (!info.contactSender.isValid || !info.contactReceiver.isValid) return;
 
         isPressed = true;
         clickSound.Play();
         buttonAnimator.SetTrigger("Press");
 
-        Debug.Log($"Button pressed by: {(info.isAvatar ? info.player?.displayName : "world object")}");
+        ContactSenderProxy sender = info.contactSender;
+        if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
+        {
+            Debug.Log($"Button pressed by: {sender.player.displayName}");
+        }
+        else
+        {
+            Debug.Log($"Button pressed by: {sender.usage}");
+        }
     }
 
     public override void OnContactExit(ContactExitInfo info)

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -3,7 +3,7 @@
 Complete reference of C# features and their availability in UdonSharp, including SDK version availability,
 compiler behavior details, and annotated code examples.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 > For the quick-reference checklist and code generation rules, see `rules/udonsharp-constraints.md`.
 

--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -1,8 +1,8 @@
 # VRChat Dynamics for Worlds Reference
 
-Comprehensive guide to PhysBones, Contacts, and VRC Constraints in VRChat worlds (SDK 3.10.0 - 3.10.3).
+Comprehensive guide to PhysBones, Contacts, and VRC Constraints in VRChat worlds (SDK 3.10.0 - 3.10.4).
 
-**Supported SDK Versions**: 3.10.0 - 3.10.3
+**Supported SDK Versions**: 3.10.0 - 3.10.4
 
 ## Overview
 
@@ -28,21 +28,26 @@ Contacts provide a collision detection system between **Senders** and **Receiver
 #### Contact Sender
 
 1. Add `VRC Contact Sender` component to a GameObject
-2. Choose `Shape Type`: `Sphere` or `Capsule`
-3. Configure `Radius` (and `Height` for Capsule)
-4. Set `Content Type` (identifies what kind of contact this is)
+2. Choose `Shape Type`: `Sphere`, `Capsule`, or `Box`
+3. Configure `Radius` (and `Height` for Capsule, or `Vector3 size` for Box)
+4. Set collision tags (matching tags are reported as `matchingTags`)
 
 ```text
 VRC Contact Sender (Sphere)
 ├── Shape Type: Sphere
 ├── Radius: 0.02 (finger-sized; max 3 m)
-└── Content Type: "Finger"
+└── Collision Tags: ["Finger"]
 
 VRC Contact Sender (Capsule)
 ├── Shape Type: Capsule
 ├── Radius: 0.05 (max 3 m)
 ├── Height: 0.3 (Y-axis, half-spheres included; max 6 m)
-└── Content Type: "Custom"
+└── Collision Tags: ["Custom"]
+
+VRC Contact Sender (Box)
+├── Shape Type: Box
+├── Size: (0.2, 0.1, 0.05) Vector3 size (max 6 m per axis after scale)
+└── Collision Tags: ["Custom"]
 ```
 
 **Shape comparison:**
@@ -51,30 +56,35 @@ VRC Contact Sender (Capsule)
 |-------|--------|-------------|
 | `Sphere` | `Radius` | Point contacts (fingers, small projectiles) |
 | `Capsule` | `Radius` + `Height` | Elongated contacts (arms, props, area triggers) |
+| `Box` | `Vector3 size` | Flat panels, rectangular trigger volumes, face-proximity surfaces |
 
 #### Contact Receiver
 
 1. Add `VRC Contact Receiver` component to a GameObject
 2. Add UdonBehaviour to the **same** GameObject
 3. Choose `Shape Type` and configure its dimensions
-4. Configure allowed content types
+4. Configure allowed content usage and collision tags
 5. Implement contact events in Udon
 
 ```text
 VRC Contact Receiver (Sphere)
 ├── Shape Type: Sphere
 ├── Radius: 0.05 (max 3 m)
-├── Allow Self: true (contacts from same avatar)
-├── Allow Others: true (contacts from other avatars)
-└── Content Types: ["Finger", "Hand"]
+├── Content Types: Avatar, World
+└── Collision Tags: ["Finger", "Hand"]
 
 VRC Contact Receiver (Capsule)
 ├── Shape Type: Capsule
 ├── Radius: 0.05 (max 3 m)
 ├── Height: 0.5 (Y-axis, half-spheres included; max 6 m)
-├── Allow Self: true
-├── Allow Others: true
-└── Content Types: ["Hand"]
+├── Content Types: Avatar, World
+└── Collision Tags: ["Hand"]
+
+VRC Contact Receiver (Box)
+├── Shape Type: Box
+├── Size: (0.5, 0.1, 0.5) Vector3 size (max 6 m per axis after scale)
+├── Use Face Proximity: true (proximity measures toward the positive-Z face)
+└── Collision Tags: ["Hand"]
 ```
 
 ### Contact Events
@@ -82,6 +92,7 @@ VRC Contact Receiver (Capsule)
 ```csharp
 using UdonSharp;
 using UnityEngine;
+using VRC.Dynamics;
 using VRC.SDKBase;
 
 public class ContactButton : UdonSharpBehaviour
@@ -97,33 +108,39 @@ public class ContactButton : UdonSharpBehaviour
     {
         if (isPressed) return;
 
+        ContactSenderProxy sender = info.contactSender;
+        if (!sender.isValid) return;
+
         isPressed = true;
         buttonRenderer.material = pressedMaterial;
         clickSound.Play();
 
-        // Check if from avatar or world object
-        if (info.isAvatar)
+        if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
         {
-            Debug.Log($"Pressed by: {info.player?.displayName}");
+            Debug.Log($"Pressed by: {sender.player.displayName}");
         }
-        else
+        else if (sender.usage == DynamicsUsage.World)
         {
-            Debug.Log("Pressed by world object");
+            Debug.Log("Pressed by world contact sender");
         }
+
+        Debug.Log($"Contact point: {info.contactPoint}, velocity: {info.enterVelocity}");
 
         // Perform button action
         OnButtonPressed();
-    }
-
-    public override void OnContactStay(ContactStayInfo info)
-    {
-        // Called every frame while contact is maintained
     }
 
     public override void OnContactExit(ContactExitInfo info)
     {
         isPressed = false;
         buttonRenderer.material = normalMaterial;
+    }
+
+    void Update()
+    {
+        if (!isPressed) return;
+
+        // Add lightweight continuous held-contact effects here.
     }
 
     private void OnButtonPressed()
@@ -133,22 +150,44 @@ public class ContactButton : UdonSharpBehaviour
 }
 ```
 
-### ContactEnterInfo Struct
+### Contact Event Payloads (SDK 3.10.4+)
+
+`ContactEnterInfo` and `ContactExitInfo` expose proxy objects for the sender and receiver involved in the collision. Always check proxy `isValid` before reading `player`, `usage`, transform data, or comparing it with a scene `VRCContactSender` / `VRCContactReceiver` reference.
 
 ```csharp
-public struct ContactEnterInfo
+public override void OnContactEnter(ContactEnterInfo info)
 {
-    public string senderName;       // Name of the Contact Sender
-    public bool isAvatar;           // True if from avatar, false if from world
-    public VRCPlayerApi player;     // Player reference (only valid if isAvatar)
-    public Vector3 position;        // World position of contact point
-    public Vector3 normal;          // Contact normal direction
+    ContactSenderProxy sender = info.contactSender;
+    ContactReceiverProxy receiver = info.contactReceiver;
+
+    if (!sender.isValid || !receiver.isValid) return;
+
+    if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
+    {
+        Debug.Log($"Avatar sender: {sender.player.displayName}");
+    }
+    else if (sender.usage == DynamicsUsage.World)
+    {
+        Debug.Log("World contact sender");
+    }
+
+    Vector3 point = info.contactPoint;
+    Vector3 velocity = info.enterVelocity;
+    string[] tags = info.matchingTags;
+}
+
+public override void OnContactExit(ContactExitInfo info)
+{
+    if (!info.contactSender.isValid || !info.contactReceiver.isValid) return;
+    string[] tags = info.matchingTags;
 }
 ```
 
-### Dynamic Content Types
+`ContactEnterInfo` includes `contactSender`, `contactReceiver`, `enterVelocity`, `contactPoint`, and `matchingTags`. `ContactExitInfo` includes `contactSender`, `contactReceiver`, and `matchingTags`.
 
-> **Breaking Change (SDK 3.10.1)**: The signature of `VRCContactReceiver.UpdateContentTypes()` changed from `IEnumerable<string>` to **`string[]`**. If you were passing `List<string>` directly, you would need `.ToArray()`, but since `List<T>` is not available in UdonSharp, the correct pattern is to pass `string[]` directly as shown below.
+### Dynamic Content Usage and Collision Tags
+
+Use `UpdateContentTypes(DynamicsUsageFlags)` to choose accepted content categories and `UpdateCollisionTags(string[])` to change the matching tag set. A Contact can use up to 16 collision tags; extra tags are ignored.
 
 ```csharp
 public class DynamicReceiver : UdonSharpBehaviour
@@ -160,21 +199,42 @@ public class DynamicReceiver : UdonSharpBehaviour
         receiver = GetComponent<VRCContactReceiver>();
     }
 
-    public void EnableHandsOnly()
+    public void EnableAvatarHandsOnly()
     {
-        // Only respond to hand contacts
-        string[] types = new string[] { "Hand", "Finger" };
-        receiver.UpdateContentTypes(types); // Pass string[] directly
+        receiver.UpdateContentTypes(DynamicsUsageFlags.Avatar);
+        receiver.UpdateCollisionTags(new string[] { "Hand", "Finger" });
     }
 
-    public void EnableAll()
+    public void EnableAvatarsAndWorldSenders()
     {
-        // Respond to any contact
-        string[] types = new string[] { "Hand", "Finger", "Head", "Foot", "Custom" };
-        receiver.UpdateContentTypes(types);
+        receiver.UpdateContentTypes(DynamicsUsageFlags.Avatar | DynamicsUsageFlags.World);
+        receiver.UpdateCollisionTags(new string[] { "Hand", "Finger", "Head", "Foot", "Custom" });
     }
 }
 ```
+
+
+### Runtime Contact Configuration
+
+`VRCContactSender` and `VRCContactReceiver` expose `shapeType`, `radius`, `height`, `size`, `position`, and `rotation` from Udon. `size` is a `Vector3 size` for Box contacts; each box axis is capped at 6 meters after GameObject scale is applied. Batch runtime configuration writes, then call `ApplyConfigurationChanges()` once so the contact volume uses the new values.
+
+```csharp
+public VRCContactReceiver receiver;
+public VRCContactSender sender;
+
+public void ResizeBoxReceiver(Vector3 newSize, Vector3 offset)
+{
+    receiver.shapeType = ContactBase.ShapeType.Box;
+    receiver.size = newSize;
+    receiver.position = offset;
+    receiver.ApplyConfigurationChanges();
+
+    float proximity = receiver.CalculateProximity(sender);
+    Debug.Log($"Current proximity: {proximity}");
+}
+```
+
+Use `CalculateProximity(sender)` when you need an immediate `0.0-1.0` proximity value between a receiver and sender instead of waiting for avatar parameters or event state. For a Box receiver with `Use Face Proximity` enabled, proximity is measured toward the receiver's positive-Z face; otherwise it is measured toward the receiver center.
 
 ### Contact Sender Control from Udon
 
@@ -229,6 +289,7 @@ VRC Phys Bone
 ```csharp
 using UdonSharp;
 using UnityEngine;
+using VRC.Dynamics;
 using VRC.SDKBase;
 
 public class GrabbableRope : UdonSharpBehaviour
@@ -238,7 +299,7 @@ public class GrabbableRope : UdonSharpBehaviour
 
     private VRCPlayerApi currentGrabber;
 
-    public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
+    public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo info)
     {
         currentGrabber = info.player;
         grabSound.Play();
@@ -249,7 +310,7 @@ public class GrabbableRope : UdonSharpBehaviour
         }
     }
 
-    public override void OnPhysBoneRelease(PhysBoneReleaseInfo info)
+    public override void OnPhysBoneReleased(PhysBoneReleasedInfo info)
     {
         currentGrabber = null;
         releaseSound.Play();
@@ -257,10 +318,10 @@ public class GrabbableRope : UdonSharpBehaviour
         Debug.Log("Rope released");
     }
 
-    public bool IsGrabbed()
+    public bool HasActiveGrab()
     {
         VRCPhysBone physBone = GetComponent<VRCPhysBone>();
-        return physBone.IsGrabbed();
+        return physBone.IsGrabbed;
     }
 
     public VRCPlayerApi GetGrabber()
@@ -275,100 +336,43 @@ public class GrabbableRope : UdonSharpBehaviour
 ```csharp
 VRCPhysBone physBone = GetComponent<VRCPhysBone>();
 
-// Check if grabbed
-bool grabbed = physBone.IsGrabbed();
+// Check current state
+bool grabbed = physBone.IsGrabbed;
+bool posed = physBone.IsPosed;
 
-// Get grabbing player
-VRCPlayerApi grabber = physBone.GetGrabbingPlayer();
-
-// Get affected transforms
-Transform[] bones = physBone.GetAffectedTransforms();
-
-// Force release (SDK 3.10.0+)
-physBone.ForceReleaseGrab();  // Force release the grab
-physBone.ForceReleasePose();  // Force release the pose (reset bent PhysBone)
+// Force release on the local client (SDK 3.10.0+)
+physBone.ReleaseGrabs(); // Force release active grabs
+physBone.ReleasePoses(); // Release frozen poses
 ```
 
-### PhysBone Udon Callbacks (Collider Events)
+### PhysBone Global Collision and Collider Udon Access
 
-In addition to grab/release, VRC PhysBone fires Udon callbacks when **PhysBone Colliders** interact with the bone chain. These three events are raised on any UdonBehaviour attached to the **same GameObject as the VRC Phys Bone** component.
+`VRCPhysBoneCollider` can be marked as **Global Collision** in the Inspector so PhysBones in the selected content types treat it as part of their collider list. The target PhysBone's Allow Collision rules still decide whether the collision is processed.
 
-| Event | When Called |
-|-------|-------------|
-| `void OnPhysBoneColliderEnter(PhysBoneColliderInfo info)` | A PhysBone collider starts intersecting the bone chain |
-| `void OnPhysBoneColliderStay(PhysBoneColliderInfo info)` | A PhysBone collider continues to intersect the bone chain |
-| `void OnPhysBoneColliderExit(PhysBoneColliderInfo info)` | A PhysBone collider stops intersecting the bone chain |
+- Avatar global colliders can affect PhysBones in worlds when the world PhysBone allows avatar collisions.
+- Avatars can have at most four additional PhysBone colliders with Global Collision enabled.
+- Worlds have no documented count limit for global PhysBone colliders, but each collider still has runtime cost.
+- Global Collision is supported only on Sphere and Capsule PhysBone colliders.
+- Udon scripts can modify world collider shape fields, but the documented Udon-accessible fields do not include enabling/disabling `Global Collision` or changing whether a collider is global.
 
-#### PhysBoneColliderInfo Struct
+For world `VRCPhysBoneCollider` components, Udon can read and write `shapeType`, `radius`, `height`, `position`, and `rotation`. Batch changes and call `ApplyConfigurationChanges()` once after editing fields.
 
 ```csharp
-public struct PhysBoneColliderInfo
+public VRCPhysBoneCollider collider;
+
+public void ConfigureCapsuleCollider(float radius, float height, Vector3 offset)
 {
-    public VRCPhysBoneCollider collider; // The collider that intersected the bone chain
-    public bool isAvatar;               // True if the collider belongs to an avatar
-    public VRCPlayerApi player;         // Player reference (only valid if isAvatar is true)
-    public Transform bone;              // The specific bone transform that was hit
+    collider.shapeType = VRC.Dynamics.VRCPhysBoneColliderBase.ShapeType.Capsule;
+    collider.radius = radius;
+    collider.height = height;
+    collider.position = offset;
+    collider.ApplyConfigurationChanges();
 }
 ```
 
-#### Callback Example
+### PhysBone Collider Udon Boundary
 
-```csharp
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-
-public class PhysBoneColliderReactor : UdonSharpBehaviour
-{
-    public AudioSource touchSound;
-    public ParticleSystem touchEffect;
-
-    private int activeColliderCount = 0;
-
-    public override void OnPhysBoneColliderEnter(PhysBoneColliderInfo info)
-    {
-        activeColliderCount++;
-
-        if (info.isAvatar && info.player != null)
-        {
-            Debug.Log($"PhysBone touched by avatar: {info.player.displayName}, bone: {info.bone?.name}");
-        }
-        else
-        {
-            Debug.Log($"PhysBone touched by world collider, bone: {info.bone?.name}");
-        }
-
-        if (activeColliderCount == 1)
-        {
-            // First contact — play feedback
-            touchSound.Play();
-            touchEffect.Play();
-        }
-    }
-
-    public override void OnPhysBoneColliderStay(PhysBoneColliderInfo info)
-    {
-        // Called every frame while the collider continues to intersect.
-        // Avoid heavy per-frame logic here; use OnPhysBoneColliderEnter
-        // and OnPhysBoneColliderExit for state changes instead.
-    }
-
-    public override void OnPhysBoneColliderExit(PhysBoneColliderInfo info)
-    {
-        activeColliderCount--;
-        if (activeColliderCount < 0) activeColliderCount = 0;
-
-        if (activeColliderCount == 0)
-        {
-            touchEffect.Stop();
-        }
-
-        Debug.Log($"PhysBone collider exited, bone: {info.bone?.name}");
-    }
-}
-```
-
-> **Note:** `OnPhysBoneColliderStay` fires every frame while a collider remains in contact and can generate significant callback overhead. Keep stay handlers lightweight or leave the body empty when you only need enter/exit transitions.
+SDK 3.10.4 exposes world `VRCPhysBoneCollider` configuration fields to Udon, but it does not expose separate PhysBone-collider enter/stay/exit callbacks on `UdonSharpBehaviour`. Use `OnPhysBoneGrabbed/Released/Posed/UnPosed` for PhysBone interaction state, and use Contacts when a world needs collider-like touch events.
 
 ### PhysBone Dependency Sorting (SDK 3.8.0+)
 
@@ -831,7 +835,7 @@ public class GrabbableLever : UdonSharpBehaviour
         }
     }
 
-    public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
+    public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo info)
     {
         // Take ownership when grabbed
         Networking.SetOwner(info.player, gameObject);
@@ -875,8 +879,8 @@ public class TouchSurface : UdonSharpBehaviour
         touchCount++;
         UpdateVisual();
 
-        // Spawn effect at touch point
-        SpawnTouchEffect(info.position);
+        // Spawn effect at estimated touch point on the receiver surface.
+        SpawnTouchEffect(info.contactPoint);
     }
 
     public override void OnContactExit(ContactExitInfo info)
@@ -905,18 +909,19 @@ public class TouchSurface : UdonSharpBehaviour
 ```csharp
 public override void OnContactEnter(ContactEnterInfo info)
 {
-    if (info.isAvatar)
+    ContactSenderProxy sender = info.contactSender;
+    if (!sender.isValid) return;
+
+    if (sender.usage == DynamicsUsage.Avatar)
     {
-        // Contact from an avatar (player)
-        // - "Allow Self" setting applies
-        // - "Allow Others" setting applies
-        VRCPlayerApi player = info.player;
+        // Contact from an avatar-owned sender.
+        // - Avatar receiver Allow Self / Allow Others settings apply on avatars.
+        VRCPlayerApi player = sender.player;
     }
-    else
+    else if (sender.usage == DynamicsUsage.World)
     {
-        // Contact from a world object (VRC Contact Sender in world)
-        // - "Allow Self" and "Allow Others" are IGNORED
-        // - Always triggers regardless of settings
+        // Contact from a world object (VRC Contact Sender in world).
+        // - Avatar-only Allow Self / Allow Others settings do not describe world senders.
     }
 }
 ```
@@ -937,15 +942,22 @@ public class DynamicsDebug : UdonSharpBehaviour
 {
     public override void OnContactEnter(ContactEnterInfo info)
     {
-        Debug.Log($"[Contact] Enter - Sender: {info.senderName}, " +
-                  $"Avatar: {info.isAvatar}, Player: {info.player?.displayName}, " +
-                  $"Position: {info.position}");
+        ContactSenderProxy sender = info.contactSender;
+        if (!sender.isValid) return;
+
+        string playerName = (sender.player != null && sender.player.IsValid())
+            ? sender.player.displayName
+            : "none";
+        Debug.Log($"[Contact] Enter - Usage: {sender.usage}, Player: {playerName}, " +
+                  $"Point: {info.contactPoint}, Velocity: {info.enterVelocity}");
     }
 
-    public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
+    public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo info)
     {
-        Debug.Log($"[PhysBone] Grab - Player: {info.player?.displayName}, " +
-                  $"Bone: {info.bone?.name}");
+        string playerName = (info.player != null && info.player.IsValid())
+            ? info.player.displayName
+            : "none";
+        Debug.Log($"[PhysBone] Grab - Player: {playerName}, Object: {gameObject.name}");
     }
 }
 ```
@@ -953,14 +965,14 @@ public class DynamicsDebug : UdonSharpBehaviour
 ## Best Practices
 
 1. **Test with multiple players** - Contacts behave differently with network latency
-2. **Use appropriate content types** - Be specific to avoid unwanted triggers
-3. **Handle null players** - `info.player` can be null for world objects
+2. **Use precise DynamicsUsageFlags and collision tags** - Be specific to avoid unwanted triggers
+3. **Handle null proxy players** - after `isValid`, read `info.contactSender.player` / `info.contactReceiver.player`; world-side contacts may not have a player
 4. **Sync state, not events** - Use `[UdonSynced]` for persistent state
 5. **Debounce rapid contacts** - Add cooldown to prevent spam
 6. **Clean up on player leave** - Reset state in `OnPlayerLeft`
 
 ## See Also
 
-- [events.md](events.md) - Full reference for `OnContactEnter/Stay/Exit` and `OnPhysBoneGrab/Release` signatures
+- [events.md](events.md) - Full reference for `OnContactEnter/Exit` and `OnPhysBoneGrabbed/Released` signatures
 - [patterns-core.md](patterns-core.md) - Common patterns for interactive objects using Contacts and PhysBones
 - [networking.md](networking.md) - Syncing contact/grab state across players with `[UdonSynced]`

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -2,7 +2,7 @@
 
 Complete reference of all events available in UdonSharp. Override these methods to respond to events.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 ## Important: override vs Non-override
 
@@ -10,7 +10,7 @@ UdonSharp events include those that **require override** and those that **do not
 
 ### override Required (VRChat/Udon-Specific Events)
 
-`PostLateUpdate`, `OnPlayerJoined`, `OnPlayerLeft`, `OnPlayerRespawn`, `OnMasterTransferred`, `OnPlayerSuspendChanged`, `OnAvatarChanged`, `OnAvatarEyeHeightChanged`, `OnLanguageChanged`, `OnVRCPlusMassGift`, `OnDeserialization`, `OnPreSerialization`, `OnPostSerialization`, `OnOwnershipTransferred`, `OnOwnershipRequest`, `Interact`, `OnPickup`, `OnDrop`, `OnPickupUseDown`, `OnPickupUseUp`, `OnPlayerTriggerEnter/Stay/Exit`, `OnPlayerCollisionEnter/Stay/Exit`, `OnPlayerParticleCollision`, `OnControllerColliderHitPlayer`, `OnStationEntered/Exited`, `OnPlayerRestored`, `OnPlayerDataUpdated`, `OnPersistenceUsageUpdated`, `OnPlayerDataStorageExceeded/Warning`, `OnPlayerObjectStorageExceeded/Warning`, `OnContactEnter/Stay/Exit`, `OnPhysBoneGrab/Release`, `OnPhysBoneColliderEnter/Stay/Exit`, `OnPhysBonePosed`, `OnPhysBoneUnPosed`, `OnDroneTriggerEnter/Stay/Exit`, `InputJump`, `InputUse`, `InputGrab`, `InputDrop`, `InputMoveHorizontal/Vertical`, `InputLookHorizontal/Vertical`, `OnInputMethodChanged`, `MidiNoteOn/Off`, `MidiControlChange`, `OnVideo*`, `OnStringLoad*`, `OnImageLoad*`, `OnSpawn`, `OnVRCQualitySettingsChanged`, `OnVRCCameraSettingsChanged`, `OnScreenUpdate`, `OnAsyncGpuReadbackComplete`, `OnPurchaseConfirmed`, `OnPurchaseConfirmedMultiple`, `OnPurchaseExpired`, `OnPurchasesLoaded`, `OnListAvailableProducts`, `OnListProductOwners`, `OnListPurchases`, `OnProductEvent`
+`PostLateUpdate`, `OnPlayerJoined`, `OnPlayerLeft`, `OnPlayerRespawn`, `OnMasterTransferred`, `OnPlayerSuspendChanged`, `OnAvatarChanged`, `OnAvatarEyeHeightChanged`, `OnLanguageChanged`, `OnVRCPlusMassGift`, `OnDeserialization`, `OnPreSerialization`, `OnPostSerialization`, `OnOwnershipTransferred`, `OnOwnershipRequest`, `Interact`, `OnPickup`, `OnDrop`, `OnPickupUseDown`, `OnPickupUseUp`, `OnPlayerTriggerEnter/Stay/Exit`, `OnPlayerCollisionEnter/Stay/Exit`, `OnPlayerParticleCollision`, `OnControllerColliderHitPlayer`, `OnStationEntered/Exited`, `OnPlayerRestored`, `OnPlayerDataUpdated`, `OnPersistenceUsageUpdated`, `OnPlayerDataStorageExceeded/Warning`, `OnPlayerObjectStorageExceeded/Warning`, `OnContactEnter/Exit`, `OnPhysBoneGrabbed/Released`, `OnPhysBonePosed`, `OnPhysBoneUnPosed`, `OnDroneTriggerEnter/Stay/Exit`, `InputJump`, `InputUse`, `InputGrab`, `InputDrop`, `InputMoveHorizontal/Vertical`, `InputLookHorizontal/Vertical`, `OnInputMethodChanged`, `MidiNoteOn/Off`, `MidiControlChange`, `OnVideo*`, `OnStringLoad*`, `OnImageLoad*`, `OnSpawn`, `OnVRCQualitySettingsChanged`, `OnVRCCameraSettingsChanged`, `OnScreenUpdate`, `OnAsyncGpuReadbackComplete`, `OnPurchaseConfirmed`, `OnPurchaseConfirmedMultiple`, `OnPurchaseExpired`, `OnPurchasesLoaded`, `OnListAvailableProducts`, `OnListProductOwners`, `OnListPurchases`, `OnProductEvent`
 
 ### override Not Required (Standard Unity Callbacks)
 
@@ -259,34 +259,31 @@ Called for PhysBones and Contacts in worlds.
 | Event | When Called |
 |-------|-------------|
 | `void OnContactEnter(ContactEnterInfo info)` | Contact sender starts contacting receiver |
-| `void OnContactStay(ContactStayInfo info)` | Contact ongoing |
 | `void OnContactExit(ContactExitInfo info)` | Contact ends |
 
 ```csharp
 public override void OnContactEnter(ContactEnterInfo info)
 {
-    Debug.Log($"Contact from: {info.senderName}");
+    ContactSenderProxy sender = info.contactSender;
+    ContactReceiverProxy receiver = info.contactReceiver;
+    if (!sender.isValid || !receiver.isValid) return;
 
-    // Determine if contact is from avatar or world object
-    if (info.isAvatar)
+    if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
     {
-        // Contact from avatar
-        VRCPlayerApi player = info.player;
-        if (player != null && player.IsValid())
-        {
-            Debug.Log($"Touched by: {player.displayName}");
-        }
+        Debug.Log($"Touched by: {sender.player.displayName}");
     }
-    else
+    else if (sender.usage == DynamicsUsage.World)
     {
-        // Contact from world object
         Debug.Log("Touched by world object");
     }
+
+    Debug.Log($"Contact point: {info.contactPoint}, velocity: {info.enterVelocity}");
 }
 
 public override void OnContactExit(ContactExitInfo info)
 {
-    Debug.Log($"Contact ended: {info.senderName}");
+    if (!info.contactSender.isValid || !info.contactReceiver.isValid) return;
+    Debug.Log($"Contact ended with {info.matchingTags.Length} matching tags");
 }
 ```
 
@@ -294,46 +291,34 @@ public override void OnContactExit(ContactExitInfo info)
 
 | Event | When Called |
 |-------|-------------|
-| `void OnPhysBoneGrab(PhysBoneGrabInfo info)` | PhysBone grabbed |
-| `void OnPhysBoneRelease(PhysBoneReleaseInfo info)` | PhysBone released |
-| `void OnPhysBoneColliderEnter(PhysBoneColliderInfo info)` | A PhysBone collider starts intersecting the bone chain |
-| `void OnPhysBoneColliderStay(PhysBoneColliderInfo info)` | A PhysBone collider continues to intersect the bone chain |
-| `void OnPhysBoneColliderExit(PhysBoneColliderInfo info)` | A PhysBone collider stops intersecting the bone chain |
+| `void OnPhysBoneGrabbed(PhysBoneGrabbedInfo physBoneInfo)` | PhysBone grabbed |
+| `void OnPhysBoneReleased(PhysBoneReleasedInfo physBoneInfo)` | PhysBone released |
 | `void OnPhysBonePosed(PhysBonePosedInfo physBoneInfo)` | A PhysBone is manually posed by a player |
 | `void OnPhysBoneUnPosed(PhysBoneUnPosedInfo physBoneInfo)` | A PhysBone pose is released |
 
 ```csharp
-public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
+public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo physBoneInfo)
 {
-    Debug.Log($"PhysBone grabbed by {info.player?.displayName}");
+    Debug.Log($"PhysBone grabbed by {physBoneInfo.player?.displayName}");
 }
 
-public override void OnPhysBoneRelease(PhysBoneReleaseInfo info)
+public override void OnPhysBoneReleased(PhysBoneReleasedInfo physBoneInfo)
 {
     Debug.Log($"PhysBone released");
 }
 
-public override void OnPhysBoneColliderEnter(PhysBoneColliderInfo info)
+public override void OnPhysBonePosed(PhysBonePosedInfo physBoneInfo)
 {
-    // info.isAvatar — true if the collider belongs to an avatar
-    // info.player   — player reference (valid when isAvatar is true)
-    // info.bone     — the specific bone transform that was hit
-    Debug.Log($"PhysBone collider entered — bone: {info.bone?.name}, " +
-              $"avatar: {info.isAvatar}, player: {info.player?.displayName}");
+    Debug.Log($"PhysBone posed by {physBoneInfo.player?.displayName}");
 }
 
-public override void OnPhysBoneColliderStay(PhysBoneColliderInfo info)
+public override void OnPhysBoneUnPosed(PhysBoneUnPosedInfo physBoneInfo)
 {
-    // Called every frame while the collider intersects. Keep this lightweight.
-}
-
-public override void OnPhysBoneColliderExit(PhysBoneColliderInfo info)
-{
-    Debug.Log($"PhysBone collider exited — bone: {info.bone?.name}");
+    Debug.Log("PhysBone pose released");
 }
 ```
 
-**Note:** Contact/PhysBone events are triggered on all UdonBehaviours attached to the same GameObject as the receiver.
+**Note:** Contact events fire on UdonBehaviours attached to the same GameObject as the Contact Receiver. PhysBone events fire on UdonBehaviours attached to the same GameObject as the VRCPhysBone component. SDK 3.10.4 does not expose separate Contact stay or PhysBone-collider enter/stay/exit callbacks on `UdonSharpBehaviour`.
 
 ## Player Trigger/Collision Events
 

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,6 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide to networking and synchronization in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 > **Warning**: Networking in Udon is a work in progress and can be fragile. Keep implementations simple and test thoroughly with multiple players.
 >

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -389,6 +389,8 @@ public class UnlockSystem : UdonSharpBehaviour
 
 ## Dynamics Patterns (SDK 3.10.0+)
 
+Contact examples use the SDK 3.10.4 proxy payload: `contactSender`, `contactReceiver`, `contactPoint`, `enterVelocity`, and `matchingTags`. Check proxy `isValid` before reading `player` or `usage`.
+
 ### Interactive Button
 
 ```csharp
@@ -449,10 +451,19 @@ public class ContactButton : UdonSharpBehaviour
 
     private void OnButtonPressed(ContactEnterInfo info)
     {
-        if (info.isAvatar && info.player != null)
+        ContactSenderProxy sender = info.contactSender;
+        if (!sender.isValid) return;
+
+        if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
         {
-            Debug.Log($"Button pressed by: {info.player.displayName}");
+            Debug.Log($"Button pressed by: {sender.player.displayName}");
         }
+        else if (sender.usage == DynamicsUsage.World)
+        {
+            Debug.Log("Button pressed by world contact sender");
+        }
+
+        Debug.Log($"Contact point: {info.contactPoint}, velocity: {info.enterVelocity}");
         // Add your button action here
     }
 }
@@ -504,7 +515,7 @@ public class GrabbableRope : UdonSharpBehaviour
     public AudioSource grabSound;
     public AudioSource releaseSound;
 
-    public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
+    public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo info)
     {
         Networking.SetOwner(info.player, gameObject);
         if (info.player.isLocal)
@@ -517,10 +528,10 @@ public class GrabbableRope : UdonSharpBehaviour
         grabSound.Play();
     }
 
-    public override void OnPhysBoneRelease(PhysBoneReleaseInfo info)
+    public override void OnPhysBoneReleased(PhysBoneReleasedInfo info)
     {
-        // PhysBoneReleaseInfo carries no player field; the grabber owns the
-        // object after the grab, so gate the synced writes on ownership.
+        // The grabber owns the object after the grab, so gate synced writes
+        // on ownership when the release event arrives.
         if (Networking.IsOwner(gameObject))
         {
             isGrabbed = false;
@@ -531,7 +542,7 @@ public class GrabbableRope : UdonSharpBehaviour
         releaseSound.Play();
     }
 
-    public bool IsGrabbed() => isGrabbed;
+    public bool HasActiveGrab() => isGrabbed;
 
     public VRCPlayerApi GetGrabber()
     {

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -508,16 +508,38 @@ public class MyResultHandler : ProcessCallbackBase
 
 `SendCustomEventDelayedSeconds` has no cancellation API. Once scheduled, the callback will fire even if the caller's state has changed and the event is no longer wanted. The pending-callback-counter debounce (see [Delayed Event Debounce in patterns-networking.md](patterns-networking.md)) handles "soft cancel" — it lets the callback fire but makes it a no-op. That is sufficient for debounce cases but not for situations where the callback absolutely must not execute: side effects inside the callback (audio playback, network requests, object destruction) will still run through the guard check even if they then return early.
 
-### Solution
+### Solution for SDK 3.10.4+
 
-Instantiate a helper `GameObject` that carries a tiny `UdonSharpBehaviour`. Schedule `SendCustomEventDelayedSeconds` on the helper itself. To cancel, call `Destroy(helperGameObject)` before the delay expires — the destroyed behaviour never executes its scheduled callback.
+Prefer `VRCTween.DelayedCall`, which behaves like `SendCustomEventDelayedSeconds` but returns a `VRCTweenHandle` that can be killed before it fires. See [VRCTween Patterns](vrctween.md#cancelable-delays) for the routeable SDK 3.10.4+ guidance.
 
-**Trade-off:** Allocates a `GameObject` per timer instance. Use the pending-callback-counter pattern for high-frequency debounce; use this pattern only when the callback truly must not fire.
+```csharp
+using VRC.SDK3.Components;
+
+private VRCTweenHandle _retryTimer;
+
+public void ScheduleRetry()
+{
+    _retryTimer.Kill(); // invalid/default handles no-op
+    _retryTimer = VRCTween.DelayedCall(this, nameof(OnRetryFired), 5f);
+}
+
+public void CancelPendingRetry()
+{
+    _retryTimer.Kill();
+}
+```
+
+### Fallback for Older SDKs
+
+For projects pinned below SDK 3.10.4, instantiate a helper `GameObject` that carries a tiny `UdonSharpBehaviour`. Schedule `SendCustomEventDelayedSeconds` on the helper itself. To cancel, call `Destroy(helperGameObject)` before the delay expires — the destroyed behaviour never executes its scheduled callback.
+
+**Trade-off:** Allocates a `GameObject` per timer instance. Use `VRCTween.DelayedCall` on SDK 3.10.4+; use the pending-callback-counter pattern for high-frequency debounce; use this fallback only when an older SDK project needs a callback that truly must not fire.
 
 **When to use:**
+- SDK < 3.10.4 projects where `VRCTween.DelayedCall` is unavailable
 - Retry timers that must be cancelled when the user changes their action before the retry fires
 - Load timeout timers where a successful load must cleanly suppress the "timed out" callback
-- Any case where the callback has irreversible side effects (network events, audio, state mutation)
+- Any older-SDK case where the callback has irreversible side effects (network events, audio, state mutation)
 
 ```csharp
 using UdonSharp;

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -2,7 +2,7 @@
 
 Step-by-step guide for upgrading UdonSharp worlds across major SDK versions.
 
-**Applies to**: SDK 3.7.x through 3.10.3
+**Applies to**: SDK 3.7.x through 3.10.4
 
 > **Deprecation Notice**: SDK versions below 3.9.0 were deprecated on **December 2, 2025**.
 > New world uploads are no longer possible with those versions.
@@ -200,12 +200,12 @@ The largest addition of the 3.10 series: **PhysBones**, **Contacts**, and **VRC 
 ```csharp
 public class GrabbableRope : UdonSharpBehaviour
 {
-    public override void OnPhysBoneGrab(PhysBoneGrabInfo info)
+    public override void OnPhysBoneGrabbed(PhysBoneGrabbedInfo info)
     {
         Debug.Log($"Grabbed by {info.player?.displayName}");
     }
 
-    public override void OnPhysBoneRelease(PhysBoneReleaseInfo info)
+    public override void OnPhysBoneReleased(PhysBoneReleasedInfo info)
     {
         Debug.Log("Released");
     }
@@ -213,9 +213,9 @@ public class GrabbableRope : UdonSharpBehaviour
 
 // PhysBone API
 VRCPhysBone pb = GetComponent<VRCPhysBone>();
-bool grabbed      = pb.IsGrabbed();
-pb.ForceReleaseGrab();  // force-release a grab
-pb.ForceReleasePose();  // reset a bent chain
+bool grabbed = pb.IsGrabbed;
+pb.ReleaseGrabs(); // force-release grabs on the local client
+pb.ReleasePoses(); // release frozen poses on the local client
 ```
 
 **Contacts** — collision detection between `VRC Contact Sender` and `VRC Contact Receiver` components.
@@ -225,10 +225,15 @@ public class ContactButton : UdonSharpBehaviour
 {
     public override void OnContactEnter(ContactEnterInfo info)
     {
-        if (info.isAvatar)
-            Debug.Log($"Pressed by {info.player?.displayName}");
-        else
+        if (!info.contactSender.isValid) return;
+
+        ContactSenderProxy sender = info.contactSender;
+        if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
+            Debug.Log($"Pressed by {sender.player.displayName}");
+        else if (sender.usage == DynamicsUsage.World)
             Debug.Log("Pressed by world object");
+
+        Debug.Log($"Point: {info.contactPoint}, velocity: {info.enterVelocity}");
     }
 
     public override void OnContactExit(ContactExitInfo info) { }
@@ -298,29 +303,37 @@ SendCustomEventDelayedFrames(nameof(UpdateCamera), 1, EventTiming.PostLateUpdate
 
 `FixedUpdate` and `PostLateUpdate` are new in SDK 3.10.2; `Update` and `LateUpdate` existed since SDK 3.7.1.
 
-#### PhysBone Collider Callbacks (SDK 3.10.0+)
+#### PhysBone Udon Callbacks (SDK 3.10.0+)
 
-In addition to grab/release events, PhysBones now fire three collider-interaction callbacks on any UdonBehaviour attached to the same GameObject as the `VRC Phys Bone` component:
+World PhysBones expose grab, release, pose, and unpose callbacks on any UdonBehaviour attached to the same GameObject as the `VRC Phys Bone` component:
 
 | Event | Trigger |
 |-------|---------|
-| `OnPhysBoneColliderEnter(PhysBoneColliderInfo info)` | A PhysBone collider starts intersecting the bone chain |
-| `OnPhysBoneColliderStay(PhysBoneColliderInfo info)` | A PhysBone collider continues intersecting each frame |
-| `OnPhysBoneColliderExit(PhysBoneColliderInfo info)` | A PhysBone collider stops intersecting |
+| `OnPhysBoneGrabbed(PhysBoneGrabbedInfo physBoneInfo)` | PhysBone is grabbed |
+| `OnPhysBoneReleased(PhysBoneReleasedInfo physBoneInfo)` | PhysBone is released from a grab |
+| `OnPhysBonePosed(PhysBonePosedInfo physBoneInfo)` | PhysBone is locked to a pose |
+| `OnPhysBoneUnPosed(PhysBoneUnPosedInfo physBoneInfo)` | PhysBone pose is released |
 
-Keep `OnPhysBoneColliderStay` handlers lightweight; it fires every frame and can create significant overhead.
+SDK 3.10.4 does not expose separate PhysBone-collider enter/stay/exit callbacks on `UdonSharpBehaviour`; use Contacts for collider-like touch events.
 
 ### Breaking Changes
 
-#### VRCContactReceiver.UpdateContentTypes() Signature Change (SDK 3.10.1)
+#### VRCContactReceiver.UpdateContentTypes() and Tags
 
-The parameter type of `UpdateContentTypes()` changed from `IEnumerable<string>` to `string[]`. Since `List<T>` is not available in UdonSharp, correct code already used `string[]` directly. If any script was passing a collection via an interface reference, update to a `string[]` literal or array variable.
+For SDK 3.10.4 documentation, `UpdateContentTypes()` takes `DynamicsUsageFlags` for allowed content categories, while `UpdateCollisionTags(string[])` changes the matching tag set.
 
 ```csharp
-// Correct (works in all 3.10.x)
-string[] types = new string[] { "Hand", "Finger" };
-receiver.UpdateContentTypes(types);
+receiver.UpdateContentTypes(DynamicsUsageFlags.Avatar | DynamicsUsageFlags.World);
+receiver.UpdateCollisionTags(new string[] { "Hand", "Finger" });
 ```
+
+#### Contact Shape and Payload Updates (SDK 3.10.4)
+
+Contacts now support Box shapes in addition to Sphere and Capsule. Box contacts use `Vector3 size`, with each axis limited to 6 m after scaling. Box receivers can use `Use Face Proximity` so proximity is measured toward the positive-Z face instead of the receiver center.
+
+Runtime shape/configuration edits on `VRCContactSender` or `VRCContactReceiver` must be batched and followed by `ApplyConfigurationChanges()`. Use `CalculateProximity(sender)` when Udon needs an immediate `0.0-1.0` proximity value between a receiver and sender.
+
+Contact event examples should use the proxy payload fields: `contactSender`, `contactReceiver`, `contactPoint`, `enterVelocity`, and `matchingTags`, with proxy `isValid`, `player`, and `usage` checks.
 
 #### Unity Constraints — Quest Impact
 
@@ -341,7 +354,7 @@ Namespace for all VRC Constraints: `VRC.SDK3.Dynamics.Constraint.Components`.
 
 - [ ] Replace all Unity Constraint components with VRC Constraint equivalents (mandatory for Quest support)
 - [ ] Add `using VRC.SDK3.Dynamics.Constraint.Components;` to any script that references VRC Constraints
-- [ ] Verify `VRCContactReceiver.UpdateContentTypes()` calls pass `string[]` (not a list or interface type)
+- [ ] Verify contact receivers use `UpdateContentTypes(DynamicsUsageFlags)` for content categories and `UpdateCollisionTags(string[])` for matching tags
 - [ ] Implement `OnPersistenceUsageUpdated` if your world writes PlayerData and you want to warn players of storage limits
 - [ ] Audit `SendCustomEventDelayed*` calls: use `EventTiming.FixedUpdate` for physics-coupled callbacks, `EventTiming.PostLateUpdate` for camera/IK callbacks, instead of frame-delay workarounds
 - [ ] For worlds using PhysBones in world space: avoid placing them inside `Instantiate()`-created objects (PhysBones in instantiated objects may not be network-synced; use scene-placed objects or VRChat Object Pool instead)

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -2,7 +2,7 @@
 
 Practical guide for testing and debugging UdonSharp worlds in VRChat.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common errors, causes, and solutions for VRChat UdonSharp development.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 ## Table of Contents
 
@@ -772,9 +772,9 @@ public override void OnContactEnter(ContactEnterInfo info)
 
 ### Contact/PhysBone Player Is Null
 
-**Symptoms:** `info.player` is null when accessed
+**Symptoms:** a contact proxy `player` is null when accessed
 
-**Cause:** Contact is from a world object, not from an avatar
+**Cause:** Contact can come from a world object or item, not only from an avatar. Contact event data uses `contactSender` / `contactReceiver` proxy objects; check proxy `isValid` and `usage` before reading `player`.
 
 **Solution:**
 
@@ -782,19 +782,19 @@ public override void OnContactEnter(ContactEnterInfo info)
 
 public override void OnContactEnter(ContactEnterInfo info)
 {
-    if (info.isAvatar)
+    ContactSenderProxy sender = info.contactSender;
+    if (!sender.isValid) return;
+
+    if (sender.usage == DynamicsUsage.Avatar && sender.player != null && sender.player.IsValid())
     {
-        // From avatar - player is valid
-        if (info.player != null && info.player.IsValid())
-        {
-            Debug.Log($"Contact from: {info.player.displayName}");
-        }
+        Debug.Log($"Contact from: {sender.player.displayName}");
     }
-    else
+    else if (sender.usage == DynamicsUsage.World)
     {
-        // From world object - player is null
         Debug.Log("Contact from world object");
     }
+
+    Debug.Log($"Contact point: {info.contactPoint}, matching tags: {info.matchingTags.Length}");
 }
 
 ```
@@ -1752,7 +1752,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | **NetworkCallable not working** | Add `[NetworkCallable]`, make public |
 | **PlayerData empty** | Wait for `OnPlayerRestored` first |
 | **OnContactEnter not firing** | UdonBehaviour must be on same GameObject |
-| **Contact player is null** | Check `info.isAvatar` before accessing |
+| **Contact player is null** | Check `contactSender.isValid`, then `contactSender.usage` before accessing `contactSender.player` |
 | **Trigger not firing for seated players** | PlayerLocal collider disabled in station — use position check workaround |
 | **.asset missing / script not loaded** | Install auto-generator in `Assets/Editor/`, then reimport the affected `.cs` |
 | **UdonBehaviour silently does nothing** | Check `Program Source` slot — likely empty; assign `.asset` or use `AddUdonSharpComponent` |

--- a/skills/unity-vrc-udon-sharp/references/vrctween.md
+++ b/skills/unity-vrc-udon-sharp/references/vrctween.md
@@ -1,0 +1,131 @@
+# VRCTween Patterns (SDK 3.10.4+)
+
+Route animation and cancelable-delay questions here when a project can use SDK 3.10.4 or newer.
+
+## When to Use VRCTween
+
+Use `VRCTween` for local animation and delayed callbacks instead of writing per-frame interpolation by hand:
+
+- Transform animation: `TweenPosition`, `TweenLocalPosition`, `TweenRotation`, `TweenLocalRotation`, `TweenScale`
+- UI / renderer / light / audio animation: `TweenFade`, `TweenColor`, `TweenIntensity`, `TweenVolume`, `TweenPitch`
+- Timers: `VRCTween.DelayedCall`
+- Delayed active toggles: `VRCTween.DelayedSetActive`
+
+All creation methods return a `VRCTweenHandle` for cleanup and control.
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDK3.Components;
+
+[UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
+public class TweenedDoor : UdonSharpBehaviour
+{
+    [SerializeField] private GameObject _door;
+    [SerializeField] private AudioSource _motor;
+
+    private VRCTweenHandle _doorTween;
+    private VRCTweenHandle _pitchTween;
+    private VRCTweenHandle _autoCloseTimer;
+
+    public override void Interact()
+    {
+        OpenLocal();
+    }
+
+    public void OpenLocal()
+    {
+        _doorTween.Kill(); // invalid/default handles no-op
+        _pitchTween.Kill();
+        _autoCloseTimer.Kill();
+
+        _doorTween = _door.TweenLocalPosition(new Vector3(0f, 3f, 0f), 0.4f, VRCTweenEase.OutCubic);
+        _pitchTween = _motor.TweenPitch(1.25f, 0.2f, VRCTweenEase.OutQuad);
+        _autoCloseTimer = VRCTween.DelayedCall(this, nameof(CloseLocal), 5f);
+    }
+
+    public void CloseLocal()
+    {
+        _doorTween.Kill();
+        _pitchTween.Kill();
+        _autoCloseTimer.Kill();
+
+        _doorTween = _door.TweenLocalPosition(Vector3.zero, 0.4f, VRCTweenEase.InCubic);
+        _pitchTween = _motor.TweenPitch(0.8f, 0.2f, VRCTweenEase.InQuad);
+    }
+
+    void OnDestroy()
+    {
+        _door.KillAllTweens();
+        _pitchTween.Kill();
+        _autoCloseTimer.Kill();
+    }
+}
+```
+
+## Cancelable Delays
+
+Prefer `VRCTween.DelayedCall` over `SendCustomEventDelayedSeconds` helper-`GameObject` cancellation workarounds on SDK 3.10.4+:
+
+```csharp
+private VRCTweenHandle _timer;
+
+public void Schedule()
+{
+    _timer.Kill();
+    _timer = VRCTween.DelayedCall(this, nameof(OnTimer), 2f);
+}
+
+public void Cancel()
+{
+    _timer.Kill();
+}
+```
+
+Keep the helper-`GameObject` workaround only for projects pinned to older SDKs where `VRCTween.DelayedCall` is unavailable.
+
+Use `VRCTween.DelayedSetActive(target, active, seconds)` for a simple delayed local active-state change. Store the returned `VRCTweenHandle` if the toggle may need cancellation.
+
+## Cleanup Rules
+
+- Store `VRCTweenHandle` when you need to cancel, pause, restart, retarget, or test creation success.
+- Call `handle.Kill()` before replacing a still-running one-shot tween on the same target/property.
+- Call `gameObject.KillAllTweens()` in `OnDestroy` for long-running, looped, or externally owned tweens on that object.
+- Invalid/default handles are safe no-ops for control calls such as `Kill()`. Use `handle.IsValid` only when code must branch on whether creation succeeded.
+
+## Local-Only Networking Rule
+
+VRCTween does **not** sync automatically. Each client creates and controls its own tween.
+
+For networked effects, sync intent rather than the handle:
+
+1. Send a network event or synced state such as `doorOpen = true`.
+2. Each client starts the local tween in response.
+3. For late joiners or deterministic timing, sync the authoritative state/time and use `Goto(...)` or recreate the tween at the correct local state.
+
+Never put `VRCTweenHandle` in synced variables; handles are scene-local control tokens, not network state.
+
+## High-Frequency Reuse
+
+For one-shot interaction polish, simple kill-and-create code is usually clearer. For hot paths where a tween is redirected often, create a reusable paused handle and retarget it instead:
+
+```csharp
+private VRCTweenHandle _moveHandle;
+
+void Start()
+{
+    _moveHandle = gameObject.TweenPosition(transform.position, 0f, VRCTweenEase.Linear)
+        .SetLoops(-1, VRCTweenLoopType.Restart)
+        .Pause();
+}
+
+public void MoveToward(Vector3 target, float duration)
+{
+    _moveHandle.ChangeEndValue(target, true)
+        .SetDuration(duration)
+        .SetEase(VRCTweenEase.OutCubic)
+        .Restart();
+}
+```
+
+Use this pattern for frequent retargeting such as local UI follow effects, aim indicators, or many-object controllers. Avoid it for simple button/door/audio effects where readability matters more than allocation reduction.

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -1,6 +1,6 @@
 # Web Loading — Advanced Packed Resource Patterns
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 Advanced techniques for embedding multiple textures in a single `VRCStringDownloader` response
 to work around `VRCImageDownloader` limitations. For the base API reference see

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -1,6 +1,6 @@
 # Web Loading (String / Image Download)
 
-**Supported SDK Versions**: 3.7.1 - 3.10.3
+**Supported SDK Versions**: 3.7.1 - 3.10.4
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # VRC World SDK 3 Cheatsheet
 
-**SDK 3.7.1 - 3.10.3 supported**
+**SDK 3.7.1 - 3.10.4 supported**
 
 ---
 
@@ -9,7 +9,7 @@
 | Section | Content |
 |---------|---------|
 | [Scene Setup](#scene-setup) | VRCWorld, Spawns, Respawn |
-| [Components](#components) | Pickup, Station, ObjectSync |
+| [Components](#components) | Pickup, Station, ObjectSync, Contacts, PhysBones |
 | [Layers](#layers) | Layer numbers and purposes |
 | [Performance](#performance) | Limits and optimization |
 | [Lighting](#lighting) | Bake settings |
@@ -126,6 +126,39 @@ public override void Interact()
 {
     mirrorObject.SetActive(!mirrorObject.activeSelf);
 }
+```
+
+### Contacts (SDK 3.10.4)
+
+```text
+VRC Contact Sender / VRC Contact Receiver shapes:
+- Sphere: Radius
+- Capsule: Radius + Height
+- Box: Box Size X/Y/Z axes
+
+Limits are applied after transform scale:
+- Sphere/Capsule radius ≤ 3 m
+- Box width/height/depth ≤ 6 m
+
+Box-shaped Contact Receiver:
+- Use Face Proximity = proximity to the local positive-Z face
+```
+
+For Contact Sender / Contact Receiver Udon events and APIs, use
+`../../unity-vrc-udon-sharp/references/dynamics.md` instead of this world authoring sheet.
+
+### PhysBones / Global Collision (SDK 3.10.4)
+
+```text
+VRCPhysBoneCollider Global Collision:
+- World PhysBones can collide with avatar-origin globals when Allow Collision permits
+- Avatars can add up to 4 additional global PhysBone colliders
+- Worlds have no documented global collider count limit
+- Global Collision supports Sphere/Capsule only
+- PhysBone Allow Collision rules still apply
+
+World Udon can edit VRCPhysBoneCollider settings; call
+ApplyConfigurationChanges() after batched configuration changes.
 ```
 
 ---
@@ -374,7 +407,8 @@ site:github.com/vrchat-community "issue keyword"
 | 3.7.4 | Persistence API |
 | 3.8.1 | [NetworkCallable] |
 | 3.9.0 | Camera Dolly, Auto Hold |
-| 3.10.0 | Dynamics (PhysBones) |
+| 3.10.0 | Dynamics (PhysBones, Contacts) |
+| 3.10.4 | Box-shaped Contact Sender/Receiver authoring updates |
 
 ---
 
@@ -384,7 +418,7 @@ site:github.com/vrchat-community "issue keyword"
 |-------|------|
 | Performance targets, Quest optimization checklist | [references/performance.md](references/performance.md) |
 | Lightmap settings, Quest bake parameter reference | [references/lighting.md](references/lighting.md) |
-| Full SDK 3.7.1-3.10.3 world component reference | [references/components.md](references/components.md) |
+| Full SDK 3.7.1-3.10.4 world component reference | [references/components.md](references/components.md) |
 | VRChat layer system, collision, and selective rendering reference | [references/layers.md](references/layers.md) |
 | Audio and video configuration, voice settings, Steam Audio, and video players | [references/audio-video.md](references/audio-video.md) |
 | Upload procedure, pre-upload checklist, validation, world settings, and post-upload steps | [references/upload.md](references/upload.md) |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -6,11 +6,13 @@ description: >
     setting up layers, optimizing performance, or uploading worlds.
     Covers VRC_SceneDescriptor, spawn points, VRC_Pickup, VRC_Station,
     VRC_Mirror, VRC_ObjectSync, VRC_CameraDolly, layer/collision matrix,
-    baked lighting, Quest/Android limits, and upload workflow.
-    SDK 3.7.1 - 3.10.3 coverage.
+    baked lighting, Quest/Android limits, Dynamics for Worlds, and upload workflow.
+    SDK 3.7.1 - 3.10.4 coverage.
     Triggers on: VRChat world, VRC SDK, scene setup, VRC_SceneDescriptor,
     spawn point, VRC_Pickup, VRC_Station, VRC_ObjectSync, layer setup,
-    optimization, Quest support, light baking, upload, FPS improvement.
+    PhysBones, Contacts, Box Contacts, Global Avatar PhysBone Colliders,
+    VRCPhysBoneCollider, VRCTween, optimization, Quest support, light baking,
+    upload, FPS improvement.
     Related: Use unity-vrc-udon-sharp for UdonSharp C# coding.
 license: MIT
 metadata:
@@ -63,6 +65,7 @@ Load only what the task requires.
 |------|---------------|----------|-------------|----------------|
 | Setting up a new scene from scratch | `components.md`, `layers.md` | `upload.md` | `audio-video.md`, `troubleshooting.md` | Collision matrix non-obvious; component deps needed upfront |
 | Making objects grabbable (VRC_Pickup) | `components.md` | `layers.md` | `audio-video.md`, `lighting.md` | Pickup/Rigidbody requirements not in standard Unity docs |
+| Configuring Dynamics for Worlds (PhysBones, Contacts, Box Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` access) | `components.md` | `layers.md`, `troubleshooting.md`; use `unity-vrc-udon-sharp` for Udon code | `audio-video.md`, `lighting.md` | Dynamics component availability and Udon access are SDK-version sensitive |
 | Setting up seating (VRC_Station) | `components.md` | `layers.md` | `audio-video.md`, `performance.md` | Station collider + exit requirements are VRChat-specific |
 | Optimizing FPS for Quest | `performance.md`, `lighting.md` | `troubleshooting.md` | `audio-video.md`, `upload.md` | Quest limits differ from PC; bake requirements non-obvious |
 | Adding audio or video player / voice zones (SetVoiceGain, Steam Audio) | `audio-video.md`, `components.md` | `troubleshooting.md` | `lighting.md`, `performance.md` | AVPro vs Unity Video selection is VRChat-specific |
@@ -112,7 +115,7 @@ Quest required? → Yes
 
 ## SDK Versions
 
-**Supported versions**: SDK 3.7.1 - 3.10.3
+**Supported versions**: SDK 3.7.1 - 3.10.4
 
 | SDK    | New Features                                                                   | Status         |
 | ------ | ------------------------------------------------------------------------------ | -------------- |
@@ -125,7 +128,8 @@ Quest required? → Yes
 | 3.10.0 | **Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints)                 | ✅             |
 | 3.10.1 | Bug fixes and stability improvements                                           | ✅             |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅             |
-| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix         | ✅ Latest stable |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix         | ✅             |
+| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, Data Container capacity APIs | ✅ Latest stable |
 
 > **Important**: SDK versions below 3.9.0 are **deprecated as of December 2, 2025**. New world uploads are no longer possible with these versions.
 
@@ -433,7 +437,7 @@ Starter templates for common SDK component patterns. Each template compiles with
 
 | File                            | Content                                                                                          | Approx. Lines |
 | ------------------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
-| `references/components.md`      | All component details, component whitelist, editor-only exclusion (EditorOnly tag / IEditorOnly) | 800+          |
+| `references/components.md`      | All component details, component whitelist, Dynamics for Worlds, editor-only exclusion (EditorOnly tag / IEditorOnly) | 800+          |
 | `references/layers.md`          | Layers & collision                                                                               | 300+          |
 | `references/performance.md`     | Performance optimization                                                                         | 700+          |
 | `references/lighting.md`        | Lighting settings                                                                                | 400+          |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.4.0"
+    version: "2.5.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -1,6 +1,6 @@
 # VRChat World Components Complete Reference
 
-Full component reference for SDK 3.7.1 - 3.10.3.
+Full component reference for SDK 3.7.1 - 3.10.4.
 
 ## Table of Contents
 
@@ -15,6 +15,8 @@ Full component reference for SDK 3.7.1 - 3.10.3.
 - [VRC_AvatarPedestal](#vrc_avatarpedestal)
 - [VRC_CameraDolly](#vrc_cameradolly)
 - [VRCCameraSettings API](#vrccamerasettings-api)
+- [Contacts in Worlds](#contacts-in-worlds)
+- [PhysBones and Global Collision in Worlds](#physbones-and-global-collision-in-worlds)
 - [Avatar-driven features that read world colliders](#avatar-driven-features-that-read-world-colliders)
 - [Allowed Unity Components](#allowed-unity-components)
 
@@ -618,6 +620,59 @@ public class DollyTrigger : UdonSharpBehaviour
 
 For the full scripting reference, see the udon-sharp skill's
 [`api.md` Camera Dolly section](../../unity-vrc-udon-sharp/references/api.md#vrc-camera-dolly-api-sdk-390).
+
+---
+
+## Contacts in Worlds
+
+`VRC Contact Sender` and `VRC Contact Receiver` components can be used in worlds for touch volumes, avatar/world interaction triggers, and world-side contact routing. This section is for world authoring setup only; for Udon event signatures, `VRCContactSender` / `VRCContactReceiver` scripting, and `Contact*Info` fields, use the UdonSharp dynamics/API references.
+
+### Contact Sender / Contact Receiver shapes (SDK 3.10.4)
+
+Both Contact Sender and Contact Receiver support these shape types:
+
+| Shape Type | Size fields | World-authoring notes |
+|------------|-------------|-----------------------|
+| Sphere | Radius | Simple radial touch volume |
+| Capsule | Radius + Height | Tall/limb-shaped touch volume along the local Y axis |
+| Box | Size | Box-shaped Contact volumes with independent X/Y/Z Box Size axes |
+
+Box-shaped Contact Sender and Box-shaped Contact Receiver setup uses the same transform, tag, and content-type rules as Sphere/Capsule contacts, but `Box Size` X/Y/Z defines the extents instead of radius/height. Contact dimensions are capped after object scale is applied: Sphere/Capsule radius is limited to 3 m, and Box width/height/depth are limited to **6 m** each. Avoid hiding extra scale in parent transforms when measuring the effective 6 m post-scale limit.
+
+### Receiver proximity behavior
+
+For proximity calculations, Sphere/Capsule proximity is based on closeness to the receiver volume center. For a box-shaped Contact Receiver, enabling `Use Face Proximity` changes the proximity calculation so the reported value measures closeness to the box's local positive-Z face. Use this when a box represents a panel, pad, or surface where approaching the front face should drive the proximity signal.
+
+### World scripting boundary
+
+Keep world component authoring here. Detailed Udon script behavior belongs in the UdonSharp references:
+
+- [dynamics.md Contacts](../../unity-vrc-udon-sharp/references/dynamics.md#contacts)
+- [api.md VRCContactReceiver / VRCContactSender](../../unity-vrc-udon-sharp/references/api.md#vrccontactreceiver)
+
+---
+
+## PhysBones and Global Collision in Worlds
+
+Worlds can include PhysBones and `VRCPhysBoneCollider` components. The world-side authoring concern is which colliders can influence world PhysBones, especially when avatar-origin global colliders are present.
+
+### Global Avatar PhysBone Colliders impact
+
+`Global Collision` on a `VRCPhysBoneCollider` makes that collider available to PhysBones in the selected content types, but each PhysBone's `Allow Collision` setting still decides whether global colliders are considered. For worlds:
+
+- World PhysBones can collide with avatar-origin global PhysBone colliders when their `Allow Collision` rules permit it.
+- Avatars can add up to four additional PhysBone colliders with `Global Collision` enabled.
+- Worlds have no documented global collider count limit, but every active collider can add runtime cost; keep world global colliders intentional.
+- `Global Collision` supports Sphere and Capsule collider shapes only. Plane/other shapes are not global-collision shapes.
+
+### VRCPhysBoneCollider Udon access
+
+In worlds, Udon can access `VRCPhysBoneCollider` for runtime-controlled collider properties. Use Udon scripting instead of animator-driven changes for world objects. After changing collider configuration fields from Udon, call `ApplyConfigurationChanges()` once after batching the edits so the runtime collider applies the new shape/size/offset.
+
+For the detailed Udon API, event callbacks, and examples, use the UdonSharp dynamics/API references rather than duplicating script guidance here:
+
+- [dynamics.md PhysBones](../../unity-vrc-udon-sharp/references/dynamics.md#physbones)
+- [api.md PhysBones and Contacts](../../unity-vrc-udon-sharp/references/api.md#physbones-and-contacts-sdk-3100)
 
 ---
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.3)
+## SDK (3.7.1 - 3.10.4)
 
 | Version | Key Features |
 |---------|--------------|
@@ -29,6 +29,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
 | 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
+| 3.10.4 | VRCTween, Box Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, Data Container capacity APIs |
 
 ## Docs Reference
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.3)
+## SDK (3.7.1 - 3.10.4)
 
 | Version | Key Features |
 |---------|--------------|
@@ -29,6 +29,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
 | 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
+| 3.10.4 | VRCTween, Box Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, Data Container capacity APIs |
 
 ## Docs Reference
 

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -18,7 +18,7 @@ Read the following Rules before writing any UdonSharp code:
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.3)
+## SDK (3.7.1 - 3.10.4)
 
 | Version | Key Features |
 |---------|--------------|
@@ -29,6 +29,7 @@ Read the following Rules before writing any UdonSharp code:
 | 3.10.1 | Bug fixes and stability improvements |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
 | 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
+| 3.10.4 | VRCTween, Box Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, Data Container capacity APIs |
 
 ## Docs Reference
 


### PR DESCRIPTION
## Pre-flight checklist (Step 1 must be done BEFORE this PR is opened)

- [x] **Version bumped on `dev`** via a separate `chore(version): bump to v2.5.0` PR, already merged.
  Verify with `node -p "require('./package.json').version"` on `dev` — it must equal the target version.
- [x] All 5 version fields are in sync (Version Sync CI checks this; verify locally too):
  - `package.json` → `.version`
  - `.claude-plugin/marketplace.json` → `.metadata.version`
  - `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
  - `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
  - `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`

## Summary

Release v2.5.0 — SDK 3.10.4 final guidance for UdonSharp and World SDK skills.

**2 PRs since v2.4.0:**

- #264 — `docs`: SDK 3.10.4 coverage and accuracy updates
- #265 — `chore`: v2.5.0 version source synchronization

**Version bump driver**: `release: feature` → `minor`.

## What changed

### SDK 3.10.4 skill coverage (#264)

- Adds VRCTween routing and references for local tweens, cancelable delayed calls, handle cleanup, and high-frequency reuse.
- Updates Contacts, PhysBones, Box Contacts, world PhysBone Collider, and Data Container capacity guidance against official docs and local SDK 3.10.4 evidence.
- Records scoped exclusions for announced or client-facing items that do not expose a documented authoring/API surface in SDK 3.10.4.

### Release source (#265)

- Synchronizes all five source version fields to v2.5.0 before the release PR.

## Reporter acknowledgement

None.

## Merge instructions

**DO NOT SQUASH** — use a plain merge commit so Release Drafter sees each underlying PR.

## Post-merge

1. Release Drafter creates/updates a draft release on `main`.
2. Rewrite the draft notes before publishing.
3. `gh release edit v2.5.0 --draft=false` to publish — triggers `publish.yml` → `npm publish`.

## Test plan

- [x] PR #264 CI green
- [x] PR #265 CI green
- [x] Local version sync check passed on `dev`
- [x] Local `npm pack --dry-run` passed for v2.5.0
- [ ] Release PR CI green
- [ ] Release Drafter draft body reflects the merged PRs
- [ ] After publish: `npm view agent-skills-vrc-udon version` returns v2.5.0

## Release impact

`release: feature` → `minor` bump.
