### PR TITLE
Release v2.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.0"
+    "version": "2.5.1"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.0"
+    version: "2.5.1"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -47,7 +47,8 @@ themselves should also include a thank-you (in the reporter's language).
 2. Rewrite the draft notes (`gh release edit vX.Y.Z --notes "$(cat <<'NOTES' ... NOTES)"`):
    - Remove the auto-generated "Release vX.Y.Z (#N)" self-reference line.
    - Convert bare PR titles to user-facing prose.
-   - Add reporter thank-you if applicable, in the reporter's language.
+   - Use a bilingual structure: English release notes first, then Japanese release notes below.
+   - Add reporter thank-you if applicable, explicitly naming the Issue number and reporter.
 3. `gh release edit vX.Y.Z --draft=false` to publish — triggers `publish.yml` → `npm publish`.
 
 ## Test plan

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 *.tgz
 .npm/
 plans/
+state/
 
 # Local Unity project for SDK API verification (see unity-project-for-sdk-search/README.md).
 # The directory itself is gitignored so the SDK never gets bundled into the npm tarball;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,14 +159,17 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
    # Always rewrite the auto-generated notes before publishing:
    #   - Remove the "Release vX.Y.Z (#N)" self-reference line
    #   - Replace bare PR titles with user-facing prose
-   #   - Add a reporter acknowledgement section if any bundled PR closed an
-   #     externally-reported Issue. Mirror the reporter's language for the
-   #     release-notes acknowledgement (Japanese reporter → Japanese; English
-   #     reporter → English). Issue/PR titles and bodies remain English-first
-   #     per repo convention; the reporter-language rule applies only to
-   #     user-facing release notes.
+   #   - Use a bilingual structure: English release notes first, then a Japanese
+   #     version of the same user-facing content below it.
+   #   - Add a contributor acknowledgement section when any bundled PR closed an
+   #     externally-reported Issue. Name the Issue number and reporter explicitly.
+   #     Keep the acknowledgement respectful and mirror the reporter's language
+   #     when possible.
    gh release edit vX.Y.Z --notes "$(cat <<'NOTES'
    ## What's New in vX.Y.Z
+   ...
+
+   ## vX.Y.Z の変更点
    ...
    NOTES
    )"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -142,6 +142,8 @@ public void PlaySound() {
 }
 ```
 
+VRChat world scene setup: pair each `AudioSource` with `VRC_SpatialAudioSource`. For warning-only additions, use Gain 0 dB and preserve existing 2D/3D intent, volume, max distance, and rolloff curves.
+
 | Scenario | Pattern |
 |----------|---------|
 | Always active | `Start()` only is fine |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.0"
+    version: "2.5.1"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
 ---
 

--- a/skills/unity-vrc-udon-sharp/assets/templates/BasicInteraction.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/BasicInteraction.cs
@@ -15,6 +15,7 @@ public class BasicInteraction : UdonSharpBehaviour
 
     [Header("Audio")]
     [Tooltip("Audio source for interaction sounds")]
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
     [Tooltip("Sound to play on interaction")]
     public AudioClip interactSound;

--- a/skills/unity-vrc-udon-sharp/assets/templates/ContactReceiver.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/ContactReceiver.cs
@@ -38,6 +38,7 @@ public class ContactReceiver : UdonSharpBehaviour
 
     [Header("Audio")]
     [Tooltip("Audio source for contact sounds")]
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
 
     [Tooltip("Sound to play when contact begins")]

--- a/skills/unity-vrc-udon-sharp/assets/templates/CustomInspector.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/CustomInspector.cs
@@ -28,6 +28,7 @@ public class CustomInspectorExample : UdonSharpBehaviour
 
     [Header("References")]
     public Transform targetPoint;
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
 
     // Synced variable example

--- a/skills/unity-vrc-udon-sharp/assets/templates/StateMachine.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/StateMachine.cs
@@ -49,6 +49,7 @@ public class StateMachine : UdonSharpBehaviour
 
     [Header("Audio")]
     [Tooltip("Audio source for state change sounds")]
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
 
     [Tooltip("Sound played when entering Active state")]

--- a/skills/unity-vrc-udon-sharp/assets/templates/SyncedObject.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/SyncedObject.cs
@@ -16,6 +16,7 @@ public class SyncedObject : UdonSharpBehaviour
     public GameObject[] controlledObjects;
 
     [Header("Audio")]
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
     public AudioClip toggleSound;
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-core.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-core.md
@@ -73,6 +73,8 @@ public class RobustGimmick : UdonSharpBehaviour
 }
 ```
 
+> Scene setup: in VRChat worlds, pair `AudioSource` components with `VRC_SpatialAudioSource` in Unity, not Udon. For warning-only additions, use Gain 0 dB and preserve 2D/global intent plus existing `volume`, `spatialBlend`, `rolloffMode`, `maxDistance`, and custom 3D curves.
+
 ### Full Pattern: Defensive Initialization
 
 ```csharp
@@ -566,11 +568,14 @@ public class RepeatingAction : UdonSharpBehaviour
 
 ## Audio Patterns
 
+Scene setup for all examples in this section: pair each `AudioSource` with `VRC_SpatialAudioSource`. For warning-only additions, use Gain 0 dB, preserve 2D/3D intent, and keep existing distance curves.
+
 ### Simple Audio Player
 
 ```csharp
 public class AudioPlayer : UdonSharpBehaviour
 {
+    // Scene setup: pair with VRC_SpatialAudioSource; preserve 2D/3D intent and Gain 0 dB for warning-only additions.
     public AudioSource audioSource;
     public AudioClip[] clips;
 
@@ -604,6 +609,7 @@ public class AudioPlayer : UdonSharpBehaviour
 ```csharp
 public class SyncedMusicPlayer : UdonSharpBehaviour
 {
+    // Scene setup: pair with VRC_SpatialAudioSource; preserve 2D/3D intent and Gain 0 dB for warning-only additions.
     public AudioSource audioSource;
     public AudioClip[] tracks;
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -282,12 +282,16 @@ Do NOT place:
 
 ### VRC_SpatialAudioSource
 
-| Property | Default | Range |
-|----------|---------|-------|
-| Gain | 10 dB | 0-24 dB |
-| Near | 0 m | Attenuation start |
-| Far | 40 m | Attenuation end |
-| Volumetric Radius | 0 m | Source spread |
+Pair world `AudioSource` components with `VRC_SpatialAudioSource` to avoid SDK Build Panel warnings. For warning-only additions, use Gain 0 dB and preserve existing `volume`, `spatialBlend`, rolloff, max distance, custom curves, and 2D/3D intent.
+
+| Property | Baseline | Safe-preserve note |
+|----------|----------|--------------------|
+| Gain | 10 dB common default | Use 0 dB when adding only to avoid a warning |
+| Near | 0 m | Keep 0 m unless `minDistance` / Near was authored |
+| Far | Per use case | Match `maxDistance` or intended audible range; avoid wider Auto Fix ranges |
+| Volumetric Radius | 0 m | Set intentionally for wide sources |
+| Enable Spatialization | true for 3D | false for intentional 2D/global audio |
+| Use AudioSource Volume Curve | false common default | true when preserving authored 3D rolloff |
 
 ### Video Player Comparison
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.0"
+    version: "2.5.1"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -332,13 +332,17 @@ Exactly **one** is required in every VRChat world.
 
 ### VRC_SpatialAudioSource
 
-| Property              | Description           | Default            |
-| --------------------- | --------------------- | ------------------ |
-| Gain                  | Volume boost (0-24 dB) | 10 dB (world default) |
-| Near                  | Attenuation start     | 0m                 |
-| Far                   | Attenuation end       | 40m                |
-| Volumetric Radius     | Source spread          | 0m                 |
-| Enable Spatialization | 3D positioning        | true               |
+Plan each world `AudioSource` with a `VRC_SpatialAudioSource`: a bare `AudioSource` triggers a VRChat SDK Build Panel warning. Add the companion deliberately, avoid Auto Fix as a blind default, and do not overwrite existing `VRC_SpatialAudioSource` values or tuned `AudioSource` curves unless requested.
+
+| Property              | Description           | Baseline / safe-preserve note |
+| --------------------- | --------------------- | ----------------------------- |
+| Gain                  | Volume boost (0-24 dB) | 10 dB is common/default; use 0 dB for warning-only additions to preserve loudness |
+| Near                  | Attenuation start     | 0m unless the sound needs an intentional near field |
+| Far                   | Attenuation end       | Match existing `maxDistance` or the intended audible range; avoid blind default/Auto Fix ranges |
+| Volumetric Radius     | Source spread          | 0m for point sources; set intentionally for wide sources |
+| Enable Spatialization | 3D positioning        | false for intentional 2D/global audio; true for authored 3D audio |
+
+When preserving an existing `AudioSource`, keep `volume`, `spatialBlend`, `rolloffMode`, `maxDistance`, and custom curves; use Gain 0 dB; enable `Use AudioSource Volume Curve` for tuned 3D rolloff; match Far to the existing `maxDistance` or intended audible range; and keep Near at 0m unless an existing `minDistance`/Near value was intentionally authored.
 
 ### Video Player Selection
 

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Pickup_Rigidbody.cs
@@ -36,6 +36,7 @@ public class VRC_Pickup_Rigidbody : UdonSharpBehaviour
 {
     [Header("Audio Feedback")]
     [Tooltip("Audio source used for pickup and drop sounds")]
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
 
     [Tooltip("Sound played when the object is picked up")]

--- a/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs
+++ b/skills/unity-vrc-world-sdk-3/assets/templates/VRC_Station_Basic.cs
@@ -47,6 +47,7 @@ public class VRC_Station_Basic : UdonSharpBehaviour
 
     [Header("Audio Feedback")]
     [Tooltip("Audio source for enter and exit sounds")]
+    // Scene setup: pair with VRC_SpatialAudioSource; keep 2D/3D intent; Gain 0 dB only for warning fixes.
     public AudioSource audioSource;
 
     [Tooltip("Sound played when any player enters this station")]

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -23,7 +23,7 @@ Complete guide for audio and video configuration.
 | Component | Purpose | Use Case |
 |-----------|---------|----------|
 | AudioSource | Unity standard audio | Basic sound playback |
-| VRC_SpatialAudioSource | VRChat spatial audio | Sounds requiring 3D positioning |
+| VRC_SpatialAudioSource | VRChat spatial audio | Companion for AudioSource; avoids SDK Build Panel warnings |
 | VoiceSettings | Voice settings | Configured in VRC_SceneDescriptor |
 
 ### Audio System Architecture
@@ -44,16 +44,34 @@ Complete guide for audio and video configuration.
 
 ### Component Settings
 
-VRC_SpatialAudioSource is added alongside a Unity AudioSource.
+Add `VRC_SpatialAudioSource` alongside Unity `AudioSource` components in world scenes to avoid SDK Build Panel warnings. Choose settings that preserve the sound's intent.
 
-| Property | Type | Description | Default |
-|----------|------|-------------|---------|
-| **Gain** | float (dB) | Volume adjustment (0-24 dB) | 10 dB |
-| **Near** | float (m) | Attenuation start distance | 0 m |
-| **Far** | float (m) | Attenuation end distance (0=infinite) | 40 m |
-| **Volumetric Radius** | float (m) | Source spread | 0 m |
-| **Enable Spatialization** | bool | Enable 3D positioning | true |
-| **Use AudioSource Volume Curve** | bool | Use AudioSource curve | false |
+| Property | Type | Description | Default / safe-preserve note |
+|----------|------|-------------|------------------------------|
+| **Gain** | float (dB) | Volume adjustment (0-24 dB) | 10 dB is common/default; use 0 dB for warning-only additions to preserve loudness |
+| **Near** | float (m) | Attenuation start distance | 0 m unless the sound needs an intentional near field |
+| **Far** | float (m) | Attenuation end distance (0=infinite) | Match existing `AudioSource.maxDistance` or intended audible range; avoid wider Auto Fix/default ranges |
+| **Volumetric Radius** | float (m) | Source spread | 0 m for point sources; set intentionally for wide sources |
+| **Enable Spatialization** | bool | Enable 3D positioning | false for intentional 2D/global audio; true for authored 3D audio |
+| **Use AudioSource Volume Curve** | bool | Use AudioSource curve | true when preserving an existing custom 3D rolloff; otherwise choose deliberately |
+
+### AudioSource Pairing Rule
+
+```text
+For every AudioSource in a VRChat world:
+1. Add or keep VRC_SpatialAudioSource on the same GameObject.
+2. Do not overwrite existing VRC_SpatialAudioSource values.
+3. Preserve `volume`, `spatialBlend`, `rolloffMode`, `maxDistance`, and custom curves.
+4. Use Gain = 0 dB for warning-only additions; raise Gain only for intentional sound design.
+5. Set Far from `maxDistance` or the intended audible range; keep Near at 0 m unless an existing `minDistance`/Near value was intentionally authored.
+```
+
+| Audio intent | Safe VRC_SpatialAudioSource setup | Notes |
+|--------------|-----------------------------------|-------|
+| BGM / UI / global 2D audio | Enable Spatialization = false, Gain = 0 dB | Keeps the original 2D presentation; Near/Far are not the design control. |
+| New 3D point SFX | Enable Spatialization = true, Gain = 0 dB, Far set to the intended audible distance | Tune loudness with `AudioSource.volume` first, then raise Gain only intentionally. |
+| Existing tuned 3D AudioSource | Enable Spatialization = true, Use AudioSource Volume Curve = true, Gain = 0 dB, Far matched to `maxDistance`/design distance | Keeps authored rolloff/custom curves; avoid changing Near/Far unless requested. |
+| Wide area source | Enable Spatialization = true, Gain = 0 dB unless intentionally boosted, set Volumetric Radius/Far explicitly | Use Volumetric Radius for source size; do not make Far large just to make it audible. |
 
 ### Distance Attenuation Model
 
@@ -92,7 +110,7 @@ AudioSource:
 └── Volume: 0.5
 
 VRC_SpatialAudioSource:
-├── Gain: 10 dB (default)
+├── Gain: 0 dB (preserve original loudness)
 ├── Enable Spatialization: false
 └── (Near/Far ignored in 2D mode)
 ```
@@ -106,9 +124,9 @@ AudioSource:
 └── Volume: 1.0
 
 VRC_SpatialAudioSource:
-├── Gain: 10 dB (default)
+├── Gain: 0 dB (start from AudioSource volume)
 ├── Near: 1 m
-├── Far: 15 m
+├── Far: 15 m (intended audible distance)
 ├── Volumetric Radius: 0
 └── Enable Spatialization: true
 ```
@@ -122,9 +140,9 @@ AudioSource:
 └── Volume: 1.0
 
 VRC_SpatialAudioSource:
-├── Gain: 10 dB (default — official guidance keeps Gain at default; Volumetric Radius below provides the area size)
+├── Gain: 0 dB unless the wide source is intentionally boosted
 ├── Near: 5 m
-├── Far: 50 m
+├── Far: 50 m (authored area, not an Auto Fix fallback)
 ├── Volumetric Radius: 10 m
 └── Enable Spatialization: true
 ```
@@ -241,8 +259,11 @@ When Steam Audio becomes the default (no action required before then):
 
 ```text
 VRC_SpatialAudioSource components:
+□ Every AudioSource has a companion VRC_SpatialAudioSource, so the SDK Build Panel has no bare-AudioSource warning
+□ Existing VRC_SpatialAudioSource values were preserved unless the design required a change
+□ Warning-only additions use Gain = 0 dB and keep 2D/3D intent unchanged
 □ Verify Near/Far values still achieve the intended effect
-□ Check Gain values — behavior is preserved but double-check critical audio
+□ Check Gain values — especially sources touched by SDK Auto Fix
 □ Volumetric Radius sources (waterfalls, crowds) should behave identically
 
 Reverb zones:
@@ -560,9 +581,9 @@ Countermeasures:
 |-------|-------|----------|
 | No sound | Volume = 0 | Check Volume |
 | No sound | Spatial Blend misconfigured | Check 2D/3D |
-| No 3D positioning | Enable Spatialization = false | Enable it |
-| Too loud/quiet | Gain setting | Adjust |
-| Can't hear at distance | Far setting too small | Increase Far |
+| No 3D positioning | Enable Spatialization = false | Enable it for authored 3D audio only |
+| Too loud/quiet | Gain or AudioSource volume setting | Start with `AudioSource.volume`; use Gain intentionally |
+| Can't hear at distance | Far setting too small | Increase Far only to the intended audible distance |
 
 ### Video Issues
 
@@ -614,14 +635,22 @@ Debug.Log($"Video playing: {videoPlayer.IsPlaying}");
 
 ## Quick Reference
 
-### VRC_SpatialAudioSource Defaults
+### VRC_SpatialAudioSource Defaults and Safe Additions
 
 ```text
-Gain: 10 dB (world audio source default)
+Common/default starting points:
+Gain: 10 dB
 Near: 0 m
-Far: 40 m
+Far: 40 m common default, but prefer existing AudioSource.maxDistance or intended range
 Volumetric Radius: 0 m
-Enable Spatialization: true
+Enable Spatialization: true for 3D audio
+
+Safe warning-only addition:
+Gain: 0 dB
+Enable Spatialization: keep the AudioSource intent (false for 2D/global, true for 3D)
+Use AudioSource Volume Curve: true when preserving an authored 3D rolloff
+Far: match existing AudioSource.maxDistance or intended range
+Near: keep 0 m unless an existing minDistance/Near value was authored
 ```
 
 ### Video Player Events

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -458,37 +458,57 @@ Creates a portal to another world.
 
 ## VRC_SpatialAudioSource
 
-Configures 3D spatial audio. Automatically added to AudioSource.
+Configures VRChat spatial audio for an `AudioSource`. Add it deliberately with each world `AudioSource` to avoid SDK Build Panel warnings; Auto Fix may change authored loudness or range.
 
 ### All Properties
 
-| Property | Type | Description | Default | Range |
-|----------|------|-------------|---------|-------|
-| Gain | float | Additional volume | 10 dB (world audio sources) | 0-24 dB |
-| Near | float | Attenuation start distance | 0 m | - |
-| Far | float | Attenuation end distance | 40 m | - |
-| Volumetric Radius | float | Source size | 0 m | < Far |
-| Use AudioSource Volume Curve | bool | Use curve | false | - |
-| Enable Spatialization | bool | 3D positioning | true | - |
+| Property | Type | Description | Default / safe-preserve note | Range |
+|----------|------|-------------|------------------------------|-------|
+| Gain | float | Additional volume | 10 dB common/default; 0 dB for warning-only additions that preserve loudness | 0-24 dB |
+| Near | float | Attenuation start distance | 0 m unless intentionally authored | - |
+| Far | float | Attenuation end distance | Match existing `AudioSource.maxDistance` or the intended audible range | - |
+| Volumetric Radius | float | Source size | 0 m for point sources | < Far |
+| Use AudioSource Volume Curve | bool | Use curve | true when preserving existing custom 3D rolloff | - |
+| Enable Spatialization | bool | 3D positioning | false for 2D/global audio; true for authored 3D audio | - |
 
 ### Settings by Use Case
 
 ```csharp
-// BGM (2D):
+// Rule: do not overwrite existing VRC_SpatialAudioSource values or tuned
+// AudioSource volume, spatialBlend, rolloffMode, maxDistance, or curves
+// unless the user asks for a new sound design.
+
+// BGM / UI / global audio (2D):
 // Enable Spatialization = false
-// Near = 0, Far = 0
+// Gain = 0 dB when adding only to avoid the SDK warning
+// Keep AudioSource.spatialBlend = 0 and tune loudness with AudioSource.volume
 
-// Ambient sound (wide source):
-// Near = 0, Far = 20-40
-// Volumetric Radius = 5-10
+// Existing tuned 3D AudioSource:
+// Enable Spatialization = true
+// Use AudioSource Volume Curve = true
+// Gain = 0 dB
+// Match Far to existing maxDistance or the intended audible range
 
-// Sound effects (point source):
-// Near = 0, Far = 10
+// New 3D sound effects (point source):
+// Enable Spatialization = true
+// Gain = 0 dB to start
+// Near = 0, Far = 10-15 or the explicitly intended audible range
 // Volumetric Radius = 0
 
-// Voice-like:
-// Near = 0, Far = 25
-// Gain = adjust appropriately
+// Ambient sound (wide source):
+// Enable Spatialization = true
+// Gain = 0 dB unless intentionally boosted
+// Far and Volumetric Radius must be authored for the area size
+```
+
+### AudioSource Pairing
+
+```text
+⚠️ AudioSource pairing:
+- Always add a VRC_SpatialAudioSource companion for world AudioSource components.
+- If the AudioSource is intentionally 2D/global, keep Enable Spatialization off and Gain at 0 dB.
+- If the AudioSource is tuned for 3D rolloff, preserve it with Use AudioSource Volume Curve.
+- Match Far to maxDistance / intended audible range; keep Near at 0 m unless minDistance / Near was authored.
 ```
 
 ### Avatar Restrictions
@@ -497,8 +517,7 @@ Configures 3D spatial audio. Automatically added to AudioSource.
 ⚠️ AudioSource on avatars:
 - Avatar gain cap: 10 dB
 - Far limit: 40 m
-- Always add VRC_SpatialAudioSource
-  (If not added, SDK auto-generates one, causing unexpected behavior)
+- Pair with VRC_SpatialAudioSource; do not rely on SDK-generated values
 ```
 
 ---


### PR DESCRIPTION
## Pre-flight checklist

- [x] Version bumped on `dev` via a separate `chore(version): bump to v2.5.1` PR, already merged.
- [x] All 5 version fields are in sync:
  - `package.json`
  - `.claude-plugin/marketplace.json`
  - `skills/unity-vrc-udon-sharp/SKILL.md`
  - `skills/unity-vrc-world-sdk-3/SKILL.md`
  - `.claude/skills/unity-vrc-skills-renovator/SKILL.md`

## Summary

Release v2.5.1 — patch release for AudioSource / VRC_SpatialAudioSource guidance and release-note policy cleanup.

**4 PRs since v2.5.0:**

- #268 — maintenance: ignore local `.state/` working artifacts
- #269 — docs: clarify AudioSource and VRC_SpatialAudioSource pairing
- #271 — maintenance: document bilingual release-note convention
- #270 — maintenance: bump version to v2.5.1

**Version bump driver**: `release: docs` / `release: maintenance` → patch.

## What changed

### World SDK / UdonSharp audio guidance (#269)

- Clarifies that world `AudioSource` components should be planned together with `VRC_SpatialAudioSource`.
- Separates safe warning-only additions from SDK/Auto Fix defaults.
- Preserves existing 2D/3D intent, `spatialBlend`, rolloff, max distance, and custom curves.

### Release workflow (#271)

- Documents the release-note convention: English notes first, followed by Japanese notes.
- Requires Issue number and reporter acknowledgement when externally reported Issues are included.

### Maintenance (#268, #270)

- Ignores local `.state/` working artifacts.
- Bumps all version fields to v2.5.1.

## Reporter acknowledgement

- #267 — "AudioSourceにVRC_SpatialAudioSourceをセットで追加することを促すべき", opened by @Yodokoro.

## Merge instructions

DO NOT SQUASH — use a plain merge commit so Release Drafter sees each underlying PR.

## Test plan

- [x] Version Sync passed on the version bump PR
- [ ] CI green on this release PR
- [ ] Release Drafter draft body reflects the merged PRs
- [ ] After publish: `npm view agent-skills-vrc-udon version` returns `2.5.1`

## Release impact

Patch release.
