### PR TITLE
docs(udon-sharp): add assembly definition guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Check build validation reference coverage
         run: bash tests/docs/build-validation-reference.test.sh
 
+      - name: Check assembly definitions reference coverage
+        run: bash tests/docs/assembly-definitions-reference.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/README.ja.md
+++ b/README.ja.md
@@ -99,7 +99,7 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（24ファイル）
+    references/                          # 詳細ドキュメント（25ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8ファイル）
 templates/                               # AIツール設定テンプレート

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,7 +99,7 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (24개 파일)
+    references/                          # 상세 문서 (25개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (8개 파일)
 templates/                               # AI 도구 설정 템플릿

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (24 files)
+    references/                          # Detailed documentation (25 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (8 files)
 templates/                               # AI tool config templates

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（24 个文件）
+    references/                          # 详细文档（25 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8 个文件）
 templates/                               # AI 工具配置模板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（24 個檔案）
+    references/                          # 詳細文件（25 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8 個檔案）
 templates/                               # AI 工具設定範本

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -246,6 +246,12 @@ VRCTween is **local-only**: it does not automatically sync. For shared animation
 
 ---
 
+## Assembly Definitions
+
+For simple world scripts, do not add an asmdef by default. If a package/asmdef workflow puts an `UdonSharpBehaviour` under a Unity `.asmdef`, create the corresponding U# Assembly Definition and set Source Assembly to that Unity Assembly Definition asset. Auto Referenced is a compile reference policy, not build inclusion: ON is friendlier for prefab/simple-world integration; OFF creates an explicit boundary where user scripts need their own asmdef/reference. See [references/assembly-definitions.md](references/assembly-definitions.md).
+
+---
+
 ## Inter-Script Communication
 
 ```csharp
@@ -422,6 +428,7 @@ For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` arr
 | UI / Canvas patterns | [references/patterns-ui.md](references/patterns-ui.md) |
 | Video player patterns | [references/patterns-video.md](references/patterns-video.md) |
 | Custom inspectors, editor-only setup components (IEditorOnly) | [references/editor-scripting.md](references/editor-scripting.md) |
+| Assembly definitions, VPM package workflow, and Auto Referenced tradeoffs | [references/assembly-definitions.md](references/assembly-definitions.md) |
 | UdonSharp C# feature constraints and compiler behavior | [references/constraints.md](references/constraints.md) |
 | UdonSharp event overrides and Unity callback rules | [references/events.md](references/events.md) |
 | Common compile, runtime, networking, persistence, dynamics, editor, and performance issues | [references/troubleshooting.md](references/troubleshooting.md) |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -8,17 +8,19 @@ description: >
     persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts,
     VRCTween, VRCPhysBoneCollider Udon access), Web Loading, DataList/DataDictionary
     capacity APIs, VRAM management (texture lifecycle, Dispose vs Destroy),
-    and event handling. SDK 3.7.1 - 3.10.4 coverage.
+    asmdef / Assembly Definition / U# Assembly Definition guidance, VPM package
+    workflow boundaries, Auto Referenced tradeoffs, and event handling. SDK 3.7.1 - 3.10.4 coverage.
     Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
     NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
     VRCTween, Box Contacts, Global Avatar PhysBone Colliders, VRCPhysBoneCollider,
-    DataList capacity, DataDictionary EnsureCapacity, synced variables,
+    DataList capacity, DataDictionary EnsureCapacity, synced variables, asmdef,
+    Assembly Definition, U# Assembly Definition, VPM package, Auto Referenced,
     VRChat world scripting, C# to Udon.
 license: MIT
 metadata:
     author: niaka3dayo
     version: "2.5.1"
-    tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
+    tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 
 # UdonSharp Skill
@@ -79,9 +81,10 @@ These constraints cause either **compile-time failures** or **silent runtime fai
 | 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compiles but silently ignored at runtime — the attribute has no effect and methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
 | 14 | Use PhysBones/Contacts API (`OnPhysBoneGrabbed`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
-| 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
-| 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
-| 18 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and simple arrays of these are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
+| 16 | Put a Unity `.asmdef` around UdonSharpBehaviour without matching U# Assembly Definition | Unity compiles the C# assembly, but UdonSharp reports the script does not belong to a U# assembly | For simple world scripts, avoid asmdef; for package/asmdef workflows, create the corresponding U# Assembly Definition and set Source Assembly to the Unity `.asmdef` (see `references/assembly-definitions.md`) |
+| 17 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
+| 18 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
+| 19 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and simple arrays of these are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
 
 ## Sync Mode Quick Decision
 
@@ -138,7 +141,8 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Setting up new script files (.cs/.asset wiring, program asset generation) | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
-| Building editor setup tools / placement UX (custom inspectors, scene wiring helpers, IEditorOnly) | `editor-scripting.md` | `constraints.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
+| VPM/package/asmdef workflows, U# Assembly Definition wiring, Auto Referenced decisions | `assembly-definitions.md` | `editor-scripting.md`, `troubleshooting.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
+| Building editor setup tools / placement UX (custom inspectors, scene wiring helpers, IEditorOnly) | `editor-scripting.md` | `constraints.md`, `assembly-definitions.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
 
 ## Pattern Selection Guide
 
@@ -255,6 +259,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | `api.md` | VRCPlayerApi, Networking, enums reference, VRCObjectPool methods + Interact-driven ownership patterns | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity, Drone, VRCDroneApi, VRCObjectPool, TryToSpawn, Return, Shuffle, pool owner, Interact pool, pool forwarded spawn, pool ownership transfer |
 | `events.md` | All Udon events (including OnPlayerRestored, OnContactEnter) | OnPlayerJoined, OnPlayerLeft, OnPlayerTriggerEnter, OnOwnershipTransferred, OnControllerColliderHitPlayer, CharacterController, OnMasterTransferred, OnAvatarChanged, OnSpawn, VRC Economy, OnPurchaseConfirmed, OnAsyncGpuReadbackComplete |
 | `editor-scripting.md` | Editor scripting, proxy system, custom inspectors, editor-only setup components (IEditorOnly), build pipeline callbacks, and UdonSharpProgramAsset auto-generation | UdonSharpEditor, UdonSharpBehaviourProxy, SerializedObject, UdonSharpProgramAsset, auto-generate, AssetPostprocessor, .asset missing, IEditorOnly, EditorOnly tag, setup helper, setup component, build exclusion, custom inspector, ContextMenu, IVRCSDKBuildRequestedCallback, OnBuildRequested, build callback, IPreprocessCallbackBehaviour, OnPreprocess |
+| `assembly-definitions.md` | UdonSharp assembly definitions, Unity `.asmdef` vs U# Assembly Definition, VPM package workflows, Runtime/Editor separation, and Auto Referenced tradeoffs | asmdef, Assembly Definition, U# Assembly Definition, Source Assembly, VPM package, Auto Referenced, Runtime, Editor, package layout, prefab-first, code-integration API |
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |

--- a/skills/unity-vrc-udon-sharp/references/assembly-definitions.md
+++ b/skills/unity-vrc-udon-sharp/references/assembly-definitions.md
@@ -1,0 +1,66 @@
+# UdonSharp Assembly Definitions and VPM Package Workflows
+
+## Beginner-Friendly Default
+
+For ordinary, world-only, simple one-off UdonSharp scripts, **do not add an asmdef by default**. Keep the script under `Assets/` without a Unity assembly definition unless there is a concrete package, compile-boundary, or editor/runtime separation need. This keeps the script in Unity's default `Assembly-CSharp` path and avoids extra UdonSharp assembly wiring for beginners.
+
+Reach for assembly definitions only when the project needs a deliberate boundary, such as a reusable VPM package, shared runtime API, faster package compilation, or explicit dependency control.
+
+## Two Different Assembly Assets
+
+Unity and UdonSharp use two related but different assets:
+
+| Asset | File / type | Purpose |
+|-------|-------------|---------|
+| Unity assembly definition | `.asmdef` JSON asset | Tells Unity to compile scripts in that folder tree into a named C# assembly and controls references such as Auto Referenced. |
+| U# Assembly Definition | UdonSharp `.asset` | Tells UdonSharp which Unity assembly contains UdonSharp scripts that should be compiled to Udon. |
+
+A Unity `.asmdef` alone changes the C# assembly. It does **not** automatically register that assembly with UdonSharp.
+
+## UdonSharpBehaviour Under an `.asmdef`
+
+If an `UdonSharpBehaviour` lives under a Unity `.asmdef`, create a corresponding **U# Assembly Definition** asset for that assembly. In the U# Assembly Definition, set **Source Assembly** to the Unity Assembly Definition asset (`.asmdef`) that owns those scripts.
+
+Without that corresponding U# asset, UdonSharp can compile the C# assembly in Unity but still refuse to treat the behaviour as part of a UdonSharp assembly. A common symptom is:
+
+```text
+[UdonSharp] Script ... does not belong to a U# assembly ...
+```
+
+Fix the assembly relationship before moving files: verify the script's containing `.asmdef`, create or update the U# Assembly Definition, and point its Source Assembly at the Unity Assembly Definition asset.
+
+## VPM Package Layout Is a Design Choice
+
+Do not force a single folder layout on every package. Choose the boundary from how creators consume the package:
+
+| Package style | Typical choice | Why |
+|---------------|----------------|-----|
+| **prefab-first** | Keep public runtime scripts easy to reference from default world scripts; often leave package runtime assembly Auto Referenced ON. | Creators drag prefabs into a world and may add small `Assembly-CSharp` scripts that talk to package components. |
+| **code-integration API** | Expose a small stable runtime assembly/API; document whether user scripts need their own asmdef reference. | Creators intentionally call package APIs from their code. The package boundary is part of the integration contract. |
+| **internal runtime code** | Hide or minimize direct references; consider Auto Referenced OFF only when the package expects explicit assembly references. | Package internals should not become accidental public API. |
+
+Use `Runtime/` for code that can compile into player/world assemblies. Use `Editor/` folders or editor-only assemblies for custom inspectors, importers, generators, and build tools.
+
+Editor-only scripts should not be UdonSharpBehaviours. Use plain `MonoBehaviour` setup helpers with `IEditorOnly` when a scene component is needed, or editor classes under an `Editor` folder/assembly when no runtime component is needed.
+
+## Auto Referenced Tradeoff
+
+Unity `.asmdef` **Auto Referenced** is a compile reference policy, **not build inclusion**. It controls whether predefined assemblies such as `Assembly-CSharp` automatically reference the assembly.
+
+- **Auto Referenced ON**: beginner- and prefab-friendly; also useful for code-integration APIs that support `Assembly-CSharp` consumers. Default world scripts can reference package runtime types without requiring the creator to create their own `.asmdef` or manual assembly reference.
+- **Auto Referenced OFF**: stricter explicit boundary. User scripts must live under an `.asmdef` that references the package assembly, or they cannot compile against the package runtime types.
+
+Do not globally force Auto Referenced OFF for all VPM packages. Use it when the package deliberately requires explicit integration boundaries; leave it ON when the package is meant to be easy to consume from simple world scripts.
+
+## Runtime/Editor Separation Checklist
+
+- Put UdonSharp runtime behaviours and runtime helper types in runtime folders/assemblies.
+- Put custom inspectors, asset postprocessors, build gates, and generator code in `Editor/` folders or editor-only assemblies.
+- Do not make editor-only tooling inherit `UdonSharpBehaviour`.
+- If an editor tool creates or moves UdonSharp scripts under a Unity `.asmdef`, also ensure the corresponding U# Assembly Definition exists and points Source Assembly at that `.asmdef`.
+- For package samples, state whether consumers can call runtime types from `Assembly-CSharp` or must create their own `.asmdef` reference.
+
+## Primary Evidence
+
+- UdonSharp migration docs: <https://udonsharp.docs.vrchat.com/migration/>
+- Unity assembly definition file format: <https://docs.unity3d.com/Manual/assembly-definition-file-format.html>

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -768,7 +768,7 @@ Note: `ExecuteInEditMode` can cause issues with UdonSharp. Use with caution.
 
 ### The Problem
 
-When AI creates a new `.cs` UdonSharp script file, the corresponding `.asset` (UdonSharpProgramAsset) is **not auto-generated**. Without this asset file, Unity cannot associate the C# script with an UdonBehaviour, resulting in "The associated script cannot be loaded" errors.
+When a `.cs` UdonSharp script file is created directly on the filesystem, the corresponding `.asset` (UdonSharpProgramAsset) is **not auto-generated**. Without this asset file, Unity cannot associate the C# script with an UdonBehaviour, resulting in "The associated script cannot be loaded" errors.
 
 ### The `.cs` to `.asset` Relationship
 
@@ -779,7 +779,9 @@ MyScript.cs          → Source code (UdonSharpBehaviour)
 MyScript.asset       → UdonSharpProgramAsset (links script to Udon compiler)
 ```
 
-When creating scripts through the Unity Editor (Assets > Create > U# Script), both files are generated automatically. However, when AI creates `.cs` files directly on the filesystem, the `.asset` file is missing.
+When creating scripts through the Unity Editor (Assets > Create > U# Script), both files are generated automatically. However, when `.cs` files are created directly on the filesystem, the `.asset` file is missing.
+
+If an editor tool creates or moves UdonSharp scripts under a Unity `.asmdef`, also read [assembly-definitions.md](assembly-definitions.md): those scripts need the corresponding U# Assembly Definition with Source Assembly set to the Unity Assembly Definition asset. Keep editor-only code in an `Editor` folder or editor-only assembly, and do not make editor-only scripts inherit `UdonSharpBehaviour`.
 
 ### Auto-Generation via AssetPostprocessor
 
@@ -950,3 +952,4 @@ public class UdonSharpProgramAssetAutoGenerator : AssetPostprocessor
 - The `Editor` folder placement is required (scripts in `Editor` are not compiled by UdonSharp)
 - Generation only runs after domain reload (`didDomainReload`), not on every asset import
 - **Asset generation does not wire `UdonBehaviour.programSource`** — this generator only creates the `.asset` file. Assigning it to a `UdonBehaviour` on a GameObject is a separate step; use [`AddUdonSharpComponent`](#addudonsharpcomponent) for new components, or see "UdonBehaviour with Empty Program Source" in `troubleshooting.md` for diagnosing existing components
+- **Asset generation does not create U# Assembly Definitions** — if generated scripts live under a Unity `.asmdef`, follow [assembly-definitions.md](assembly-definitions.md) and wire the matching U# Assembly Definition separately

--- a/tests/docs/assembly-definitions-reference.test.sh
+++ b/tests/docs/assembly-definitions-reference.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UDON_DIR="$ROOT_DIR/skills/unity-vrc-udon-sharp"
+SKILL="$UDON_DIR/SKILL.md"
+CHEATSHEET="$UDON_DIR/CHEATSHEET.md"
+EDITOR_REF="$UDON_DIR/references/editor-scripting.md"
+REF="$UDON_DIR/references/assembly-definitions.md"
+CI="$ROOT_DIR/.github/workflows/ci.yml"
+
+require_file() {
+    local path="$1"
+    if [[ ! -f "$path" ]]; then
+        echo "ERROR: missing file: $path" >&2
+        exit 1
+    fi
+}
+
+require_text() {
+    local path="$1"
+    local needle="$2"
+    if ! grep -Fq "$needle" "$path"; then
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    fi
+}
+
+require_any_text() {
+    local path="$1"
+    shift
+    local needle
+    for needle in "$@"; do
+        if grep -Fq "$needle" "$path"; then
+            return 0
+        fi
+    done
+    echo "ERROR: $path does not contain any expected text: $*" >&2
+    exit 1
+}
+
+require_file "$REF"
+
+# Core reference guidance and evidence links
+require_any_text "$REF" "world-only" "simple one-off" "ordinary"
+require_text "$REF" "do not add an asmdef by default"
+require_text "$REF" 'Unity `.asmdef`'
+require_text "$REF" "U# Assembly Definition"
+require_text "$REF" "Source Assembly"
+require_text "$REF" "does not belong to a U# assembly"
+require_text "$REF" "VPM"
+require_text "$REF" "Runtime/Editor"
+require_any_text "$REF" "Editor-only scripts" "editor-only scripts"
+require_text "$REF" "UdonSharpBehaviours"
+require_text "$REF" "Auto Referenced"
+require_text "$REF" "compile reference policy"
+require_text "$REF" "not build inclusion"
+require_any_text "$REF" "prefab-first" "prefab first"
+require_text "$REF" "code-integration API"
+require_text "$REF" "internal runtime code"
+require_text "$REF" "https://udonsharp.docs.vrchat.com/migration/"
+require_text "$REF" "https://docs.unity3d.com/Manual/assembly-definition-file-format.html"
+
+# Entrypoints route asmdef/package work to the reference.
+for path in "$SKILL" "$CHEATSHEET" "$EDITOR_REF"; do
+    require_file "$path"
+    require_text "$path" "assembly-definitions.md"
+done
+
+# SKILL.md discovery surfaces and tables include the new topic.
+require_text "$SKILL" "asmdef"
+require_text "$SKILL" "VPM package"
+require_text "$SKILL" "U# Assembly Definition"
+require_text "$SKILL" "Auto Referenced"
+require_text "$SKILL" 'Unity `.asmdef`'
+require_text "$SKILL" "without matching U# Assembly Definition"
+require_text "$SKILL" "VPM/package/asmdef workflows"
+require_text "$SKILL" "assembly-definitions.md"
+
+# Cheatsheet includes the short decision note.
+require_any_text "$CHEATSHEET" "simple world scripts" "world scripts"
+require_any_text "$CHEATSHEET" "package/asmdef" "U# Assembly Definition"
+require_text "$CHEATSHEET" "Auto Referenced"
+
+# CI docs job runs this smoke test.
+require_text "$CI" "assembly-definitions-reference.test.sh"
+
+echo "PASS: assembly-definitions reference coverage smoke test"


### PR DESCRIPTION
## Summary
- Added UdonSharp assembly definition guidance for VPM/package workflows.
- Routed the new guidance from the UdonSharp skill entrypoint, cheat sheet, and editor scripting reference.
- Added a documentation smoke test and wired it into the CI docs job.
- Synced the reference file count across the localized READMEs.

## Background
UdonSharp package workflows can use Unity `.asmdef` files, but `UdonSharpBehaviour` scripts under a Unity assembly definition also need a matching U# Assembly Definition asset. The new reference separates Unity `.asmdef` and U# Assembly Definition responsibilities, explains beginner-safe defaults, and documents when `Auto Referenced` is a convenience versus a package-boundary decision.

## Impact
- Documentation and skill-routing update only.
- No runtime, hook-enforcement, or package-layout behavior changes.

## Validation
- `bash -n tests/docs/assembly-definitions-reference.test.sh`
- `bash tests/docs/assembly-definitions-reference.test.sh`
- `bash tests/docs/build-validation-reference.test.sh`
- `bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh`
- `bash tests/hooks/validate-udonsharp.test.sh`
- `npm pack --dry-run`
- `git diff --check`

Closes #275
