### PR TITLE
chore(version): bump to v2.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.1"
+    "version": "2.5.2"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.1"
+    version: "2.5.2"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.1"
+    version: "2.5.2"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.1"
+    version: "2.5.2"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
## Summary

Bump the source-of-truth version fields to v2.5.2 before the release PR.

## Scope

- `package.json`
- `.claude-plugin/marketplace.json`
- `skills/unity-vrc-udon-sharp/SKILL.md`
- `skills/unity-vrc-world-sdk-3/SKILL.md`
- `.claude/skills/unity-vrc-skills-renovator/SKILL.md`

## Validation

- Local version consistency check: all 5 fields report `2.5.2`
- `bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh`
- `bash tests/hooks/validate-udonsharp.test.sh`
- `bash tests/docs/build-validation-reference.test.sh`
- `bash tests/docs/assembly-definitions-reference.test.sh`
- `npm pack --dry-run`
- `git diff --check`

Part of #278.
