### PR TITLE
Release v2.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.1"
+    "version": "2.5.2"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.1"
+    version: "2.5.2"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Check build validation reference coverage
         run: bash tests/docs/build-validation-reference.test.sh
 
+      - name: Check assembly definitions reference coverage
+        run: bash tests/docs/assembly-definitions-reference.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ jobs:
       - name: Smoke test validate-udonsharp.sh
         run: bash tests/hooks/validate-udonsharp.test.sh
 
+
+  docs:
+    name: Documentation Smoke Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Check build validation reference coverage
+        run: bash tests/docs/build-validation-reference.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/README.ja.md
+++ b/README.ja.md
@@ -99,9 +99,9 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（23ファイル）
+    references/                          # 詳細ドキュメント（24ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
-    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7ファイル）
+    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8ファイル）
 templates/                               # AIツール設定テンプレート
   CLAUDE.md  AGENTS.md  GEMINI.md        # インストーラー経由でユーザーに配布
 .claude-plugin/marketplace.json         # Claude Codeプラグイン登録

--- a/README.ja.md
+++ b/README.ja.md
@@ -99,7 +99,7 @@ skills/                                  # すべてのスキル
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # コードテンプレート（17ファイル）
-    references/                          # 詳細ドキュメント（24ファイル）
+    references/                          # 詳細ドキュメント（25ファイル）
   unity-vrc-world-sdk-3/                # VRC World SDKスキル
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8ファイル）
 templates/                               # AIツール設定テンプレート

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,9 +99,9 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (23개 파일)
+    references/                          # 상세 문서 (24개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
-    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7개 파일)
+    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (8개 파일)
 templates/                               # AI 도구 설정 템플릿
   CLAUDE.md  AGENTS.md  GEMINI.md        # 인스톨러를 통해 사용자에게 배포
 .claude-plugin/marketplace.json         # Claude Code 플러그인 등록

--- a/README.ko.md
+++ b/README.ko.md
@@ -99,7 +99,7 @@ skills/                                  # 모든 스킬
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 코드 템플릿 (17개 파일)
-    references/                          # 상세 문서 (24개 파일)
+    references/                          # 상세 문서 (25개 파일)
   unity-vrc-world-sdk-3/                # VRC World SDK 스킬
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (8개 파일)
 templates/                               # AI 도구 설정 템플릿

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (24 files)
+    references/                          # Detailed documentation (25 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (8 files)
 templates/                               # AI tool config templates

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ skills/                                  # All skills
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # Code templates (17 files)
-    references/                          # Detailed documentation (23 files)
+    references/                          # Detailed documentation (24 files)
   unity-vrc-world-sdk-3/                # VRC World SDK skill
-    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (7 files)
+    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/ (8 files)
 templates/                               # AI tool config templates
   CLAUDE.md  AGENTS.md  GEMINI.md        # Distributed to users via installer
 .claude-plugin/marketplace.json         # Claude Code plugin registration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,9 +99,9 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（23 个文件）
+    references/                          # 详细文档（24 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
-    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 个文件）
+    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8 个文件）
 templates/                               # AI 工具配置模板
   CLAUDE.md  AGENTS.md  GEMINI.md        # 通过安装器分发给用户
 .claude-plugin/marketplace.json         # Claude Code 插件注册

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 代码模板（17 个文件）
-    references/                          # 详细文档（24 个文件）
+    references/                          # 详细文档（25 个文件）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8 个文件）
 templates/                               # AI 工具配置模板

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,7 +99,7 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（24 個檔案）
+    references/                          # 詳細文件（25 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
     SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8 個檔案）
 templates/                               # AI 工具設定範本

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,9 +99,9 @@ skills/                                  # 所有技能
       validate-udonsharp.sh
       validate-udonsharp.ps1
     assets/templates/                    # 程式碼範本（17 個檔案）
-    references/                          # 詳細文件（23 個檔案）
+    references/                          # 詳細文件（24 個檔案）
   unity-vrc-world-sdk-3/                # VRC World SDK 技能
-    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（7 個檔案）
+    SKILL.md, LICENSE.txt, CHEATSHEET.md, references/（8 個檔案）
 templates/                               # AI 工具設定範本
   CLAUDE.md  AGENTS.md  GEMINI.md        # 透過安裝程式分發給使用者
 .claude-plugin/marketplace.json         # Claude Code 外掛註冊

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -246,6 +246,12 @@ VRCTween is **local-only**: it does not automatically sync. For shared animation
 
 ---
 
+## Assembly Definitions
+
+For simple world scripts, do not add an asmdef by default. If a package/asmdef workflow puts an `UdonSharpBehaviour` under a Unity `.asmdef`, create the corresponding U# Assembly Definition and set Source Assembly to that Unity Assembly Definition asset. Auto Referenced is a compile reference policy, not build inclusion: ON is friendlier for prefab/simple-world integration; OFF creates an explicit boundary where user scripts need their own asmdef/reference. See [references/assembly-definitions.md](references/assembly-definitions.md).
+
+---
+
 ## Inter-Script Communication
 
 ```csharp
@@ -422,6 +428,7 @@ For dynamic URLs: (1) `VRCUrlInputField` (user manual input), (2) `VRCUrl[]` arr
 | UI / Canvas patterns | [references/patterns-ui.md](references/patterns-ui.md) |
 | Video player patterns | [references/patterns-video.md](references/patterns-video.md) |
 | Custom inspectors, editor-only setup components (IEditorOnly) | [references/editor-scripting.md](references/editor-scripting.md) |
+| Assembly definitions, VPM package workflow, and Auto Referenced tradeoffs | [references/assembly-definitions.md](references/assembly-definitions.md) |
 | UdonSharp C# feature constraints and compiler behavior | [references/constraints.md](references/constraints.md) |
 | UdonSharp event overrides and Unity callback rules | [references/events.md](references/events.md) |
 | Common compile, runtime, networking, persistence, dynamics, editor, and performance issues | [references/troubleshooting.md](references/troubleshooting.md) |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.1"
+    version: "2.5.2"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -8,17 +8,19 @@ description: >
     persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts,
     VRCTween, VRCPhysBoneCollider Udon access), Web Loading, DataList/DataDictionary
     capacity APIs, VRAM management (texture lifecycle, Dispose vs Destroy),
-    and event handling. SDK 3.7.1 - 3.10.4 coverage.
+    asmdef / Assembly Definition / U# Assembly Definition guidance, VPM package
+    workflow boundaries, Auto Referenced tradeoffs, and event handling. SDK 3.7.1 - 3.10.4 coverage.
     Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
     NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
     VRCTween, Box Contacts, Global Avatar PhysBone Colliders, VRCPhysBoneCollider,
-    DataList capacity, DataDictionary EnsureCapacity, synced variables,
+    DataList capacity, DataDictionary EnsureCapacity, synced variables, asmdef,
+    Assembly Definition, U# Assembly Definition, VPM package, Auto Referenced,
     VRChat world scripting, C# to Udon.
 license: MIT
 metadata:
     author: niaka3dayo
     version: "2.5.1"
-    tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics
+    tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 
 # UdonSharp Skill
@@ -79,9 +81,10 @@ These constraints cause either **compile-time failures** or **silent runtime fai
 | 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compiles but silently ignored at runtime — the attribute has no effect and methods never receive network calls | Verify SDK >= 3.8.1; on older SDKs use synced variables + `SendCustomNetworkEvent` |
 | 14 | Use PhysBones/Contacts API (`OnPhysBoneGrabbed`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
 | 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
-| 16 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
-| 17 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
-| 18 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and simple arrays of these are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
+| 16 | Put a Unity `.asmdef` around UdonSharpBehaviour without matching U# Assembly Definition | Unity compiles the C# assembly, but UdonSharp reports the script does not belong to a U# assembly | For simple world scripts, avoid asmdef; for package/asmdef workflows, create the corresponding U# Assembly Definition and set Source Assembly to the Unity `.asmdef` (see `references/assembly-definitions.md`) |
+| 17 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
+| 18 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
+| 19 | Use `[UdonSynced]` on a `GameObject`, `Transform`, `UdonBehaviour`, or any component reference | Only primitives, value types (Vector3, Quaternion, Color, etc.), string, VRCUrl, and simple arrays of these are syncable. Component references either fail at compile time or are silently never serialized depending on SDK version | Sync a player ID (`int`) or scene object index (`int`) and resolve the actual reference locally on each client |
 
 ## Sync Mode Quick Decision
 
@@ -138,7 +141,8 @@ Load only what you need. Over-loading wastes tokens; under-loading causes critic
 | Resuming complex work after compaction / handoff / ownership-sensitive multi-file refactor | Current task's primary references | `context-preservation.md` | Unrelated domain references |
 | Writing new UdonSharp scripts (not sure if sync needed) | `constraints.md` | `networking.md` | `dynamics.md`, `web-loading.md`, `image-loading-vram.md` |
 | Setting up new script files (.cs/.asset wiring, program asset generation) | `editor-scripting.md` | `troubleshooting.md` | `networking.md`, `dynamics.md` |
-| Building editor setup tools / placement UX (custom inspectors, scene wiring helpers, IEditorOnly) | `editor-scripting.md` | `constraints.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
+| VPM/package/asmdef workflows, U# Assembly Definition wiring, Auto Referenced decisions | `assembly-definitions.md` | `editor-scripting.md`, `troubleshooting.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
+| Building editor setup tools / placement UX (custom inspectors, scene wiring helpers, IEditorOnly) | `editor-scripting.md` | `constraints.md`, `assembly-definitions.md` | `networking.md`, `dynamics.md`, `web-loading.md` |
 
 ## Pattern Selection Guide
 
@@ -255,6 +259,7 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 | `api.md` | VRCPlayerApi, Networking, enums reference, VRCObjectPool methods + Interact-driven ownership patterns | GetPlayers, playerId, isMaster, isLocal, GetPosition, SetVelocity, Drone, VRCDroneApi, VRCObjectPool, TryToSpawn, Return, Shuffle, pool owner, Interact pool, pool forwarded spawn, pool ownership transfer |
 | `events.md` | All Udon events (including OnPlayerRestored, OnContactEnter) | OnPlayerJoined, OnPlayerLeft, OnPlayerTriggerEnter, OnOwnershipTransferred, OnControllerColliderHitPlayer, CharacterController, OnMasterTransferred, OnAvatarChanged, OnSpawn, VRC Economy, OnPurchaseConfirmed, OnAsyncGpuReadbackComplete |
 | `editor-scripting.md` | Editor scripting, proxy system, custom inspectors, editor-only setup components (IEditorOnly), build pipeline callbacks, and UdonSharpProgramAsset auto-generation | UdonSharpEditor, UdonSharpBehaviourProxy, SerializedObject, UdonSharpProgramAsset, auto-generate, AssetPostprocessor, .asset missing, IEditorOnly, EditorOnly tag, setup helper, setup component, build exclusion, custom inspector, ContextMenu, IVRCSDKBuildRequestedCallback, OnBuildRequested, build callback, IPreprocessCallbackBehaviour, OnPreprocess |
+| `assembly-definitions.md` | UdonSharp assembly definitions, Unity `.asmdef` vs U# Assembly Definition, VPM package workflows, Runtime/Editor separation, and Auto Referenced tradeoffs | asmdef, Assembly Definition, U# Assembly Definition, Source Assembly, VPM package, Auto Referenced, Runtime, Editor, package layout, prefab-first, code-integration API |
 | `sync-examples.md` | Sync pattern examples (Local/Events/SyncedVars) | Continuous, Manual, NoVariableSync, sync example |
 | `troubleshooting.md` | Common errors and solutions | NullReference, compile error, sync not working, FieldChangeCallback, VRCStation, seated player, trigger zone, OnPlayerTriggerEnter not firing, station collider, position polling, OnStationEntered |
 | `sdk-migration.md` | SDK migration guide (3.7 to 3.10), version-by-version changes and checklists | migration, deprecated, upgrade, 3.7, 3.8, 3.9, 3.10 |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -45,6 +45,11 @@ It provides a lightweight task-context note for source of truth, transport, sync
 This is optional guidance for complex work, not a step for small mechanical edits.
 Keep private data and raw transcripts out of any note.
 
+For VRChat SDK Build Panel validation alerts, red/yellow/white warnings, or
+Auto Fix side effects that involve world scene setup rather than UdonSharp
+compiler constraints, use `unity-vrc-world-sdk-3` and read
+`references/build-validation.md`.
+
 ## Core Principles
 
 1. **Constraints First** — Assume standard C# features are blocked until verified. Check `udonsharp-constraints.md` before using any API.

--- a/skills/unity-vrc-udon-sharp/references/assembly-definitions.md
+++ b/skills/unity-vrc-udon-sharp/references/assembly-definitions.md
@@ -1,0 +1,66 @@
+# UdonSharp Assembly Definitions and VPM Package Workflows
+
+## Beginner-Friendly Default
+
+For ordinary, world-only, simple one-off UdonSharp scripts, **do not add an asmdef by default**. Keep the script under `Assets/` without a Unity assembly definition unless there is a concrete package, compile-boundary, or editor/runtime separation need. This keeps the script in Unity's default `Assembly-CSharp` path and avoids extra UdonSharp assembly wiring for beginners.
+
+Reach for assembly definitions only when the project needs a deliberate boundary, such as a reusable VPM package, shared runtime API, faster package compilation, or explicit dependency control.
+
+## Two Different Assembly Assets
+
+Unity and UdonSharp use two related but different assets:
+
+| Asset | File / type | Purpose |
+|-------|-------------|---------|
+| Unity assembly definition | `.asmdef` JSON asset | Tells Unity to compile scripts in that folder tree into a named C# assembly and controls references such as Auto Referenced. |
+| U# Assembly Definition | UdonSharp `.asset` | Tells UdonSharp which Unity assembly contains UdonSharp scripts that should be compiled to Udon. |
+
+A Unity `.asmdef` alone changes the C# assembly. It does **not** automatically register that assembly with UdonSharp.
+
+## UdonSharpBehaviour Under an `.asmdef`
+
+If an `UdonSharpBehaviour` lives under a Unity `.asmdef`, create a corresponding **U# Assembly Definition** asset for that assembly. In the U# Assembly Definition, set **Source Assembly** to the Unity Assembly Definition asset (`.asmdef`) that owns those scripts.
+
+Without that corresponding U# asset, UdonSharp can compile the C# assembly in Unity but still refuse to treat the behaviour as part of a UdonSharp assembly. A common symptom is:
+
+```text
+[UdonSharp] Script ... does not belong to a U# assembly ...
+```
+
+Fix the assembly relationship before moving files: verify the script's containing `.asmdef`, create or update the U# Assembly Definition, and point its Source Assembly at the Unity Assembly Definition asset.
+
+## VPM Package Layout Is a Design Choice
+
+Do not force a single folder layout on every package. Choose the boundary from how creators consume the package:
+
+| Package style | Typical choice | Why |
+|---------------|----------------|-----|
+| **prefab-first** | Keep public runtime scripts easy to reference from default world scripts; often leave package runtime assembly Auto Referenced ON. | Creators drag prefabs into a world and may add small `Assembly-CSharp` scripts that talk to package components. |
+| **code-integration API** | Expose a small stable runtime assembly/API; document whether user scripts need their own asmdef reference. | Creators intentionally call package APIs from their code. The package boundary is part of the integration contract. |
+| **internal runtime code** | Hide or minimize direct references; consider Auto Referenced OFF only when the package expects explicit assembly references. | Package internals should not become accidental public API. |
+
+Use `Runtime/` for code that can compile into player/world assemblies. Use `Editor/` folders or editor-only assemblies for custom inspectors, importers, generators, and build tools.
+
+Editor-only scripts should not be UdonSharpBehaviours. Use plain `MonoBehaviour` setup helpers with `IEditorOnly` when a scene component is needed, or editor classes under an `Editor` folder/assembly when no runtime component is needed.
+
+## Auto Referenced Tradeoff
+
+Unity `.asmdef` **Auto Referenced** is a compile reference policy, **not build inclusion**. It controls whether predefined assemblies such as `Assembly-CSharp` automatically reference the assembly.
+
+- **Auto Referenced ON**: beginner- and prefab-friendly; also useful for code-integration APIs that support `Assembly-CSharp` consumers. Default world scripts can reference package runtime types without requiring the creator to create their own `.asmdef` or manual assembly reference.
+- **Auto Referenced OFF**: stricter explicit boundary. User scripts must live under an `.asmdef` that references the package assembly, or they cannot compile against the package runtime types.
+
+Do not globally force Auto Referenced OFF for all VPM packages. Use it when the package deliberately requires explicit integration boundaries; leave it ON when the package is meant to be easy to consume from simple world scripts.
+
+## Runtime/Editor Separation Checklist
+
+- Put UdonSharp runtime behaviours and runtime helper types in runtime folders/assemblies.
+- Put custom inspectors, asset postprocessors, build gates, and generator code in `Editor/` folders or editor-only assemblies.
+- Do not make editor-only tooling inherit `UdonSharpBehaviour`.
+- If an editor tool creates or moves UdonSharp scripts under a Unity `.asmdef`, also ensure the corresponding U# Assembly Definition exists and points Source Assembly at that `.asmdef`.
+- For package samples, state whether consumers can call runtime types from `Assembly-CSharp` or must create their own `.asmdef` reference.
+
+## Primary Evidence
+
+- UdonSharp migration docs: <https://udonsharp.docs.vrchat.com/migration/>
+- Unity assembly definition file format: <https://docs.unity3d.com/Manual/assembly-definition-file-format.html>

--- a/skills/unity-vrc-udon-sharp/references/editor-scripting.md
+++ b/skills/unity-vrc-udon-sharp/references/editor-scripting.md
@@ -768,7 +768,7 @@ Note: `ExecuteInEditMode` can cause issues with UdonSharp. Use with caution.
 
 ### The Problem
 
-When AI creates a new `.cs` UdonSharp script file, the corresponding `.asset` (UdonSharpProgramAsset) is **not auto-generated**. Without this asset file, Unity cannot associate the C# script with an UdonBehaviour, resulting in "The associated script cannot be loaded" errors.
+When a `.cs` UdonSharp script file is created directly on the filesystem, the corresponding `.asset` (UdonSharpProgramAsset) is **not auto-generated**. Without this asset file, Unity cannot associate the C# script with an UdonBehaviour, resulting in "The associated script cannot be loaded" errors.
 
 ### The `.cs` to `.asset` Relationship
 
@@ -779,7 +779,9 @@ MyScript.cs          → Source code (UdonSharpBehaviour)
 MyScript.asset       → UdonSharpProgramAsset (links script to Udon compiler)
 ```
 
-When creating scripts through the Unity Editor (Assets > Create > U# Script), both files are generated automatically. However, when AI creates `.cs` files directly on the filesystem, the `.asset` file is missing.
+When creating scripts through the Unity Editor (Assets > Create > U# Script), both files are generated automatically. However, when `.cs` files are created directly on the filesystem, the `.asset` file is missing.
+
+If an editor tool creates or moves UdonSharp scripts under a Unity `.asmdef`, also read [assembly-definitions.md](assembly-definitions.md): those scripts need the corresponding U# Assembly Definition with Source Assembly set to the Unity Assembly Definition asset. Keep editor-only code in an `Editor` folder or editor-only assembly, and do not make editor-only scripts inherit `UdonSharpBehaviour`.
 
 ### Auto-Generation via AssetPostprocessor
 
@@ -950,3 +952,4 @@ public class UdonSharpProgramAssetAutoGenerator : AssetPostprocessor
 - The `Editor` folder placement is required (scripts in `Editor` are not compiled by UdonSharp)
 - Generation only runs after domain reload (`didDomainReload`), not on every asset import
 - **Asset generation does not wire `UdonBehaviour.programSource`** — this generator only creates the `.asset` file. Assigning it to a `UdonBehaviour` on a GameObject is a separate step; use [`AddUdonSharpComponent`](#addudonsharpcomponent) for new components, or see "UdonBehaviour with Empty Program Source" in `troubleshooting.md` for diagnosing existing components
+- **Asset generation does not create U# Assembly Definitions** — if generated scripts live under a Unity `.asmdef`, follow [assembly-definitions.md](assembly-definitions.md) and wire the matching U# Assembly Definition separately

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -342,6 +342,8 @@ OnVideoReady()
 1. VRChat SDK > Show Control Panel
 2. Builder tab
 3. Check & fix Validations
+   - For red/yellow/white Build Panel alerts and Auto Fix side effects,
+     see references/build-validation.md
 4. Build & Test (local testing)
 5. Build & Upload
 6. World Settings
@@ -385,6 +387,7 @@ OnVideoReady()
 | Low FPS | Turn off mirror, bake lights |
 | Doesn't work on Quest | Use Mobile shaders |
 | Build error | Check Validation |
+| SDK red/yellow/white warning | Match in references/build-validation.md |
 | World not found after upload | Change to Public |
 
 ---
@@ -425,6 +428,7 @@ site:github.com/vrchat-community "issue keyword"
 | Full SDK 3.7.1-3.10.4 world component reference | [references/components.md](references/components.md) |
 | VRChat layer system, collision, and selective rendering reference | [references/layers.md](references/layers.md) |
 | Audio and video configuration, voice settings, Steam Audio, and video players | [references/audio-video.md](references/audio-video.md) |
+| SDK Build Panel validation alert catalog, Auto Fix side effects, red/yellow/white warning responses | [references/build-validation.md](references/build-validation.md) |
 | Upload procedure, pre-upload checklist, validation, world settings, and post-upload steps | [references/upload.md](references/upload.md) |
 | Build/upload, scene setup, component, layer, performance, networking, and Quest troubleshooting | [references/troubleshooting.md](references/troubleshooting.md) |
 | Pickup + Rigidbody template | [assets/templates/VRC_Pickup_Rigidbody.cs](assets/templates/VRC_Pickup_Rigidbody.cs) |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -6,19 +6,21 @@ description: >
     setting up layers, optimizing performance, or uploading worlds.
     Covers VRC_SceneDescriptor, spawn points, VRC_Pickup, VRC_Station,
     VRC_Mirror, VRC_ObjectSync, VRC_CameraDolly, layer/collision matrix,
-    baked lighting, Quest/Android limits, Dynamics for Worlds, and upload workflow.
+    baked lighting, Quest/Android limits, Dynamics for Worlds, Build Panel
+    validation alerts, and upload workflow.
     SDK 3.7.1 - 3.10.4 coverage.
     Triggers on: VRChat world, VRC SDK, scene setup, VRC_SceneDescriptor,
     spawn point, VRC_Pickup, VRC_Station, VRC_ObjectSync, layer setup,
     PhysBones, Contacts, Box Contacts, Global Avatar PhysBone Colliders,
     VRCPhysBoneCollider, VRCTween, optimization, Quest support, light baking,
-    upload, FPS improvement.
+    upload, SDK validation, Build Panel warning, Auto Fix, red warning,
+    yellow warning, white warning, FPS improvement.
     Related: Use unity-vrc-udon-sharp for UdonSharp C# coding.
 license: MIT
 metadata:
     author: niaka3dayo
     version: "2.5.1"
-    tags: vrchat, world-sdk, scene-setup, optimization, components, upload
+    tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 
 # VRChat World SDK 3 Guide
@@ -33,6 +35,7 @@ metadata:
 | [Performance](#performance)                | Optimization guide         | `references/performance.md`     |
 | [Lighting](#lighting)                      | Lighting settings          | `references/lighting.md`        |
 | [Audio & Video](#audio--video)            | Audio, Video players       | `references/audio-video.md`     |
+| [Build Validation](references/build-validation.md) | Red/yellow/white SDK alerts | `references/build-validation.md` |
 | [World Upload](#world-upload)              | Upload workflow            | `references/upload.md`          |
 | [Troubleshooting](#troubleshooting)        | Problem solving            | `references/troubleshooting.md` |
 | [Cheatsheet](CHEATSHEET.md)               | Quick reference            | `CHEATSHEET.md`                 |
@@ -70,7 +73,8 @@ Load only what the task requires.
 | Optimizing FPS for Quest | `performance.md`, `lighting.md` | `troubleshooting.md` | `audio-video.md`, `upload.md` | Quest limits differ from PC; bake requirements non-obvious |
 | Adding audio or video player / voice zones (SetVoiceGain, Steam Audio) | `audio-video.md`, `components.md` | `troubleshooting.md` | `lighting.md`, `performance.md` | AVPro vs Unity Video selection is VRChat-specific |
 | Baking lights / lightmap setup | `lighting.md`, `performance.md` | — | `audio-video.md`, `layers.md` | Lightmap resolution and probe placement affect Quest VRAM |
-| World upload and publish | `upload.md` | `troubleshooting.md` | `audio-video.md`, `lighting.md` | Upload steps and validation order are fragile; easy to miss |
+| SDK Build Panel validation alerts, red/yellow/white warnings, or Auto Fix questions | `build-validation.md` | `upload.md`, `troubleshooting.md` | `audio-video.md`, `lighting.md` | Alert severity, build consequence, and Auto Fix side effects must come from SDK-backed catalog |
+| World upload and publish | `upload.md` | `build-validation.md`, `troubleshooting.md` | `audio-video.md`, `lighting.md` | Upload steps and validation order are fragile; easy to miss |
 | Debugging collision or layer issues | `layers.md`, `troubleshooting.md` | `components.md` | `audio-video.md`, `lighting.md` | VRChat collision matrix differs from Unity default |
 | Mirror setup and configuration | `components.md` | `performance.md` | `audio-video.md`, `upload.md` | Mirror layer mask requirements are VRChat-specific |
 
@@ -396,6 +400,7 @@ When preserving an existing `AudioSource`, keep `volume`, `spatialBlend`, `rollo
 ```
 
 **MANDATORY READ** [`references/upload.md`](references/upload.md) before running Build & Upload. Verify all pre-upload checklist items first.
+**MANDATORY READ** [`references/build-validation.md`](references/build-validation.md) when the user asks about SDK Build Panel validation, red/yellow/white warnings, Auto Fix, or a copied validation message.
 **Do NOT Load**: `references/audio-video.md`, `references/lighting.md`.
 
 ---
@@ -446,6 +451,7 @@ Starter templates for common SDK component patterns. Each template compiles with
 | `references/performance.md`     | Performance optimization                                                                         | 700+          |
 | `references/lighting.md`        | Lighting settings                                                                                | 400+          |
 | `references/audio-video.md`     | Audio & video                                                                                    | 600+          |
+| `references/build-validation.md` | SDK 3.10.4 Build Panel red/yellow/white validation alert catalog, safe fixes, Auto Fix side effects | 180+       |
 | `references/upload.md`          | Upload procedure                                                                                 | 300+          |
 | `references/troubleshooting.md` | Troubleshooting guide                                                                            | 500+          |
 | `CHEATSHEET.md`                 | Quick reference                                                                                  | 200+          |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.1"
+    version: "2.5.2"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -45,6 +45,8 @@ Complete guide for audio and video configuration.
 ### Component Settings
 
 Add `VRC_SpatialAudioSource` alongside Unity `AudioSource` components in world scenes to avoid SDK Build Panel warnings. Choose settings that preserve the sound's intent.
+For the exact SDK warning text and Auto Fix side effects, see
+[build-validation.md](build-validation.md#audiosource-and-vrc_spatialaudiosource).
 
 | Property | Type | Description | Default / safe-preserve note |
 |----------|------|-------------|------------------------------|

--- a/skills/unity-vrc-world-sdk-3/references/build-validation.md
+++ b/skills/unity-vrc-world-sdk-3/references/build-validation.md
@@ -1,0 +1,186 @@
+# VRChat SDK Build Panel Validation Alerts
+
+SDK-backed catalog for world Build Panel alerts. Use this when a creator asks
+about VRChat SDK validation, red/yellow/white warnings, Build Panel alerts,
+"Auto Fix", or a warning message shown before Build & Test / Build & Upload.
+
+## Scope and evidence
+
+- **Last verified SDK**: VRChat Worlds SDK `3.10.4` and Base SDK `3.10.4`.
+- **Primary source files**:
+  - `Packages/com.vrchat.worlds/Editor/VRCSDK/SDK3/VRCSdkControlPanelWorldBuilder.cs`
+  - `Packages/com.vrchat.base/Editor/VRCSDK/Dependencies/VRChat/ControlPanel/VRCSdkControlPanelBuilder.cs`
+  - `Packages/com.vrchat.base/Runtime/VRCSDK/Dependencies/VRChat/Scripts/Validation/WorldValidation.cs`
+  - `Packages/com.vrchat.base/Editor/VRCSDK/Dependencies/VRChat/Components/AutoAddSpatialAudioComponents.cs`
+- **Build gating**: SDK 3.10.4 blocks the world build on `OnGUIError` entries.
+  `OnGUIWarning` and `OnGUIInformation` entries are still shown in the Build
+  Panel but are not red build blockers by themselves.
+- **Builder availability errors**: some red Build Panel states are produced
+  before the normal validation foldout, via `IsValidBuilder`,
+  `CreateBuilderErrorGUI`, or the descriptor error block. Treat them as build
+  blockers even when they are not emitted through `OnGUIError`.
+- **Button labels**: Any alert with a fix callback is displayed with an
+  **Auto Fix** button by the control panel, even when the message text says
+  "Press 'fix'".
+
+## Response policy
+
+When answering a validation question:
+
+1. Match the exact message first, then a distinctive substring, then the
+   component/category.
+2. Report **SDK severity** and **build consequence** separately.
+3. Prefer the smallest safe manual fix. Do not apply broad Unity advice unless
+   the SDK alert actually points to that setting.
+4. Before bulk changes, list affected objects and preserve intentional authored
+   values.
+5. Treat SDK Auto Fix as a convenience, not as proof that the mutation is safe
+   for every project.
+6. If the warning comes from a newer SDK than `3.10.4`, re-check the local SDK
+   source before presenting the catalog as complete.
+
+### Fix-safety classes
+
+| Class | Use when | Agent behavior |
+|---|---|---|
+| Additive-safe | A missing companion/component can be added without changing existing authored values | Recommend adding only the missing item and preserving current settings |
+| Replacement-guarded | The fix replaces a known default/generated value | Apply only to values confirmed to be default; avoid custom materials/assets/settings |
+| Behavior-changing | The fix can alter audio, visuals, physics, lighting, layer behavior, or imports | Explain impact and ask before changing a project |
+| Destructive | The fix deletes components/assets or rewires serialized fields | Do not perform automatically; require backup and explicit review |
+| Diagnostic-only | The SDK only selects objects or reports counts | Explain impact and give manual options |
+
+## Quick severity guide
+
+| SDK level | Build Panel color | Build consequence | Default response |
+|---|---|---|---|
+| `OnGUIError` | Red | Blocks Build & Test / Build & Upload | Must resolve before build |
+| `OnGUIWarning` | Yellow | Does not block by color, but may affect runtime, compatibility, or upload quality | Explain and recommend a safe fix |
+| `OnGUIInformation` | White / info | Does not block; usually readability, visual quality, or editor guidance | Explain and offer optional guarded fix |
+
+## SDK 3.10.4 world alert catalog
+
+### Red errors
+
+| Alert family | Representative message | Trigger | Safe resolution | Auto Fix | Caution | Source |
+|---|---|---|---|---|---|---|
+| SDK not loaded or no compatible builder | `The SDK did not load properly. Try selecting VRChat SDK -> Reload SDK in the Unity menu bar.` | The control panel cannot select a valid SDK builder for the current compile symbols/packages. | Reload the SDK from the Unity menu, resolve compile/package errors, then reopen the SDK panel. | No. | Do not start deleting scene objects before confirming the SDK package and compile state are healthy. | `VRCSdkControlPanelBuilder.cs:690-713` |
+| Missing scene descriptor / SDK content descriptor | `A VRCSceneDescriptor is required to build a World` / `A VRCSceneDescriptor or VRCAvatarDescriptor is required to build VRChat SDK Content` / `A VRCSceneDescriptor is required to build a VRChat World` | No active world builder descriptor is available for the selected world build. | Add exactly one `VRC_SceneDescriptor` / VRCWorld prefab to the scene, then configure spawn points and re-run validation. | Builder error UI can add the VRCWorld sample prefab; normal validation error has no Auto Fix. | Confirm the descriptor belongs to the upload scene, not to an inactive prefab or additive helper scene. | `VRCSdkControlPanelBuilder.cs:690-733`; `VRCSdkControlPanelWorldBuilder.cs:142-156, 1145-1189`; `VRCSdkControlPanelWorldBuilderV3.cs:43-55` |
+| Multiple Pipeline Managers | `Multiple Pipeline Managers found in scene. Please remove all but one.` / `You can only have a single Pipeline Manager in a Scene` | More than one `PipelineManager` exists in the scene. | Keep the one that owns the intended world blueprint ID and remove or move extras. | No; builder error UI provides Select all PipelineManagers. | Destructive if the wrong blueprint owner is removed; inspect blueprint IDs before deleting. | `VRCSdkControlPanelWorldBuilder.cs:142-156, 1145-1173`; `VRCSdkControlPanelWorldBuilderV3.cs:43-55` |
+| SDK V3 disabled | `SDK V3 is not enabled.` | The SDK3 world builder is present but V3 UI/pipeline support is disabled. | Re-enable SDK3/V3 support or reload/update the VRChat SDK package, then reopen the Build Panel. | No. | Usually indicates project/package state, not a scene-object problem. Fix SDK state before scene edits. | `VRCSdkControlPanelWorldBuilderV3.cs:43-48` |
+| Multiple SDK pipelines present | `Multiple pipelines are present. V3 pipeline will take priority` | The older world builder detects that V3 pipeline UI is enabled and steps aside. | Use the SDK3/V3 world pipeline and remove stale SDK2 workflow assumptions. If no builder becomes valid, reload the SDK and resolve package conflicts. | No. | This is a builder-selection state; do not treat it as a scene validation object by itself. | `VRCSdkControlPanelWorldBuilder.cs:142-147`; `VRCSdkControlPanelBuilder.cs:672-731` |
+| Multiple scene descriptors | `A Unity scene containing a VRChat Scene Descriptor should only contain one Scene Descriptor.` | More than one `VRC_SceneDescriptor` is found in the scene. | Keep exactly one descriptor for the world scene and remove or move extras. | No; Select only. | Check prefabs and disabled objects before deleting. | `VRCSdkControlPanelWorldBuilder.cs:224-234` |
+| SDK2 event handlers in SDK3 world | `You have Event Handlers in your scene that are not allowed in this build configuration.` | One or more `VRC_EventHandler` components are present. | Replace SDK2 event-handler logic with Udon/UdonSharp or remove legacy components. | Yes; removes each `VRC_EventHandler` component. | Destructive: removing the component can remove behavior; inspect and migrate the old event setup first. | `VRCSdkControlPanelWorldBuilder.cs:435-450` |
+| Object Sync with Manual Udon sync | `Object Sync cannot share an object with a manually synchronized Udon Behaviour` | A `VRCObjectSync` object also has a manually synchronized `UdonBehaviour`. | Split responsibilities: use `VRCObjectSync` for transform/physics and move manually synced state to another object/behaviour. | No; Select only. | Do not just change sync mode without checking late-joiner and ownership design. | `VRCSdkControlPanelWorldBuilder.cs:796-800` |
+| Object Sync with Object Pool | `Object Sync cannot share an object with an object pool` | A GameObject has both `VRCObjectSync` and `VRCObjectPool`. | Put pool management and object sync on compatible separate objects, or redesign pooled prefab ownership. | No; Select only. | Avoid deleting either component until spawn/return flow is understood. | `VRCSdkControlPanelWorldBuilder.cs:796-803` |
+| Missing valid spawn point | `You must add at least one valid spawn point to the spawns list in your scene descriptor.` | `VRC_SceneDescriptor.GetValidatedSpawnList()` returns empty. | Add at least one valid Transform to the descriptor Spawns list. | No; Select scene descriptor. | Confirm spawn is above respawn height and not inside geometry. | `VRCSdkControlPanelWorldBuilder.cs:867-888` |
+| Layers/collision unresolved at build time | `You must address Layers and Collision Matrix issues before you can build.` | Build starts while VRChat layers or collision matrix are not configured. | Run the Build Panel layer and collision setup actions, then re-open Validations. | No direct error fix; setup buttons exist in scene setup UI. | Layer setup may move custom layers and requires reassignment review. | `VRCSdkControlPanelWorldBuilder.cs:366-427, 2574-2583` |
+| SDK2 and SDK3 mixed components | `This scene contains components from the VRChat SDK version 2 and version 3...` | SDK2 and SDK3 components are both active in the scene. | Replace SDK2 components with SDK3/Udon equivalents. | No; Select SDK2 components. | Migration can change behavior; do it component-by-component. | `VRCSdkControlPanelBuilder.cs:554-566` |
+| Android texture format not ASTC | `Default texture format on Android should be set to the newer ASTC format...` | Active build target is Android and `androidBuildSubtarget` is not ASTC. | Use the SDK Auto Fix or set Android default texture format to ASTC. | Yes; sets `EditorUserBuildSettings.androidBuildSubtarget = ASTC` and refreshes assets. | Reimport can take time and affects Android texture compression defaults. | `VRCSdkControlPanelBuilder.cs:569-581` |
+| Unsupported iOS target | `iOS is not supported as a build target.` | Active build target is iOS for an account/platform that does not support iOS. | Switch to a supported build target. | No. | Do not attempt workaround uploads from an unsupported target. | `VRCSdkControlPanelBuilder.cs:584-593` |
+
+### Yellow warnings
+
+| Alert family | Representative message | Trigger | Safe resolution | Auto Fix | Caution | Source |
+|---|---|---|---|---|---|---|
+| Built-in Unity mesh referenced by Udon | `Udon Objects reference builtin Unity mesh assets, this won't work...` | Udon public variables reference built-in mesh assets. | Create project mesh assets and assign those clones to Udon variables. | Yes; clones meshes into `<scene>_MeshClones` and rewires Udon public variables. | Behavior-changing/destructive enough to review first: creates assets and changes serialized references. | `VRCSdkControlPanelWorldBuilder.cs:199-208, 1071-1136` |
+| PostProcessVolume under Reference Camera | `Scene has a PostProcessVolume on the Reference Camera...` | Main Camera has a child `PostProcessVolume`; the reference camera is disabled at runtime. | Move the volume to a normal scene GameObject. | Yes; clones/moves volume content away from Main Camera. | Review resulting object hierarchy and component copies. | `VRCSdkControlPanelWorldBuilder.cs:210-218, 278-307` |
+| Gravity has X/Z component | `Gravity vector is not straight down...` | `Physics.gravity.x` or `.z` is non-zero. | Use Project Settings > Physics and set gravity straight down unless nonstandard gravity is deliberate. | No; opens settings only. | Nonstandard gravity may be intentional, but player orientation remains upward. | `VRCSdkControlPanelWorldBuilder.cs:471-475` |
+| Gravity points upward | `Gravity vector is not straight down, inverted or zero gravity will make walking extremely difficult.` | `Physics.gravity.y > 0`. | Use normal downward gravity unless the world is intentionally unusual. | No; opens settings only. | May make normal locomotion unusable. | `VRCSdkControlPanelWorldBuilder.cs:476-479` |
+| Zero gravity | `Zero gravity will make walking extremely difficult...` | `Physics.gravity.y` is approximately zero. | Restore downward gravity or design explicit locomotion alternatives. | No; opens settings only. | Do not change if zero gravity is a core design without confirming. | `VRCSdkControlPanelWorldBuilder.cs:480-483` |
+| Custom fog shader stripping | `Fog shader stripping is set to Custom...` | Fog shader stripping is Custom and keeps at least one fog mode. | Use Automatic unless the world changes fog mode at runtime. | Yes; sets fog stripping mode to Automatic. | If the world changes fog mode at runtime, Automatic may not preserve needed variants. | `VRCSdkControlPanelWorldBuilder.cs:485-495` |
+| Deprecated Auto Spatialize Audio Sources | `Your scene previously used the 'Auto Spatialize Audio Sources' feature...` | `VRC_SceneDescriptor.autoSpatializeAudioSources` is enabled. | Disable the deprecated flag and intentionally add `VRC_SpatialAudioSource` to audio sources. | Yes; sets `autoSpatializeAudioSources = false`. | After disabling, audit all audio sources manually. | `VRCSdkControlPanelWorldBuilder.cs:498-504` |
+| Rootless PhysBone | `One or more PhysBones in the scene have no parent...` | A PhysBone root transform has no parent. | Parent the PhysBone under another GameObject appropriate for the setup. | No; Select affected objects. | Preserve intended transform hierarchy and scale. | `VRCSdkControlPanelWorldBuilder.cs:507-524` |
+| Too many PhysBones/PhysBone Colliders | `This scene contains a total of ... PhysBones and PhysBone Colliders...` | Combined PhysBone and PhysBone Collider count exceeds the client active world cap. | Reduce active world PhysBone/Collider count or split/disable optional interactions. | No. | The constant value comes from SDK runtime code; verify against current SDK when updating. | `VRCSdkControlPanelWorldBuilder.cs:527-535` |
+| Too many Contacts | `This scene contains ... Contacts...` | Contact component count exceeds the client active world cap. | Reduce active Contacts or design fewer broad contact zones. | No. | Prefer fewer intentional contact volumes over many overlapping sensors. | `VRCSdkControlPanelWorldBuilder.cs:527-540` |
+| Deprecated ONSP audio source | `Found audio source(s) using ONSP, this is deprecated...` | An `AudioSource` has an `ONSPAudioSource`. | Convert to `VRC_SpatialAudioSource` and verify audible range/loudness. | Yes; copies ONSP Gain/Near/Far/spatialization fields to VRC spatial audio and removes ONSP. | Listen in Build & Test; component replacement can alter spatial audio behavior. | `VRCSdkControlPanelWorldBuilder.cs:542-556`; `AutoAddSpatialAudioComponents.cs:126-154` |
+| Missing `VRC_SpatialAudioSource` on 3D audio | `Found 3D audio source with no VRC Spatial Audio component...` | A non-2D `AudioSource` lacks `VRC_SpatialAudioSource`. | Add `VRC_SpatialAudioSource` deliberately. For warning-only additions, preserve `AudioSource` volume, rolloff, max distance, and custom curves; use Gain `0 dB`; match Far to the existing audible range. | Yes; adds component with SDK defaults. | Do not blindly use SDK defaults: they may change intended loudness/range. | `VRCSdkControlPanelWorldBuilder.cs:559-575`; `AutoAddSpatialAudioComponents.cs:198-220` |
+| Missing disabled `VRC_SpatialAudioSource` on 2D audio | `Found 2D audio source with no VRC Spatial Audio component...` | A 2D/global `AudioSource` lacks `VRC_SpatialAudioSource`. | Add the companion component with `Enable Spatialization` off and Gain `0 dB`; keep 2D/global intent. | Yes; adds component and keeps spatialization disabled for 2D-like curves. | Do not force `spatialBlend = 1` unless the user wants 3D audio. | `VRCSdkControlPanelWorldBuilder.cs:559-575`; `AutoAddSpatialAudioComponents.cs:198-220` |
+| Substance materials | `One or more scene objects have Substance materials...` | SDK detects Substance materials in the scene. | Bake Substances to regular materials. | No; Select affected objects. | Keep original Substance sources outside the upload scene if needed. | `VRCSdkControlPanelWorldBuilder.cs:579-584` |
+| Reference Camera TAA | `The Reference Camera has a Post-process Layer component that uses Temporal Anti-Aliasing...` | Reference Camera Post-process Layer uses TAA. | Select another anti-aliasing mode for that camera. | Yes; sets anti-aliasing to None. | Confirm PC/Quest visual quality after the change. | `VRCSdkControlPanelWorldBuilder.cs:587-601` |
+| AssetBundle over size limit | Dynamic message from `GetAssetBundleOverSizeLimitMessageSDKWarning(...)` | Compressed or uncompressed world bundle exceeds SDK size checks. | Reduce asset size: textures, meshes, audio, videos, baked data, or platform-specific variants. | No. | Requires profiling; do not delete assets blindly. | `VRCSdkControlPanelWorldBuilder.cs:604-619` |
+| Unsupported mobile shader | `World uses unsupported shader 'X'...` | On Android/iOS builds, a root GameObject uses a shader outside the SDK world mobile whitelist. | Replace with supported VRChat Mobile/world shaders or platform-specific materials. | No. | May be PC-only acceptable but Quest/mobile incompatible. | `VRCSdkControlPanelWorldBuilder.cs:621-633`; `WorldValidation.cs:664-666` |
+| Oversized textures | `This scene has textures bigger than 8192...` | Renderer materials use textures whose importer max size exceeds `8192`. | Lower texture importer max size and re-check memory. | Yes; sets importer max size to `8192`, reserializes, and refreshes assets. | Reimport changes assets globally; keep source textures backed up if needed. | `VRCSdkControlPanelWorldBuilder.cs:818-840`; `VRCSdkControlPanelBuilder.cs:65, 1129-1168` |
+| Spawn too far from origin | `The spawn position is too far from the World Origin...` / `One of the spawn positions...` | Single or multi-spawn mode has a spawn outside ±1000 on any axis. | Move spawn transforms closer to world origin or redesign the origin/layout. | No; Select spawn. | Floating-origin and far-world designs need explicit review. | `VRCSdkControlPanelWorldBuilder.cs:891-899, 910-917` |
+| Spawn below respawn height | `The spawn position at ... is below the respawn height...` / `A spawn position at ...` | A valid spawn Transform is below `VRC_SceneDescriptor.RespawnHeightY`. | Move the spawn above the respawn plane or lower Respawn Height safely below playable space. | No; Select scene. | This is often the cause of spawn/respawn loops. | `VRCSdkControlPanelWorldBuilder.cs:901-905, 920-925` |
+| Unity version mismatch | `You are not using the recommended Unity version for the VRChat SDK...` | Remote SDK config recommends a different Unity version. | Use the VRChat-recommended Unity version for the installed SDK. | Yes; opens Unity download archive. | Do not change project Unity versions mid-work without source control backup. | `VRCSdkControlPanelBuilder.cs:540-551` |
+| Automatic lightmap generation | `Automatic lightmap generation is enabled...` | `Lightmapping.giWorkflowMode == Iterative`. | Turn off Auto Generate and bake intentionally before upload. | Yes; sets GI workflow to On Demand. | If the world is still being laid out, decide when to bake rather than blindly toggling. | `VRCSdkControlPanelBuilder.cs:596-617` |
+
+### White / informational alerts
+
+| Alert family | Representative message | Trigger | Safe resolution | Auto Fix | Caution | Source |
+|---|---|---|---|---|---|---|
+| No current validation issues | `Everything looks good` | The SDK validation pass has no current issues for the selected world scene. | No action. Continue with normal Build & Test / Build & Upload checks. | No. | Treat this as a current SDK panel result, not as proof that play-mode behavior or platform-specific content is correct. | `VRCSdkControlPanelWorldBuilder.cs:252-258` |
+| Native Unity text without TextMeshPro | `Your world contains one or more Unity text components, but no TextMeshPro components...` | `UnityEngine.UI.Text` or `TextMesh` exists and no TMP text/dropdown/input field is found. | Consider TextMeshPro for clearer text, especially world-space UI. | No. | Not every decorative text element needs migration; weigh prefab/style cost. | `VRCSdkControlPanelWorldBuilder.cs:453-468` |
+| Unity built-in UI shader on uGUI graphics | `Found one or more UI graphics using Unity's built-in UI shader...` | A `UnityEngine.UI.Graphic` uses `UI/Default` while the VRChat supersampled UI shader exists. | Assign `Packages/com.vrchat.worlds/Editor/VRCSDK/SDK3/VRCSuperSampledUIMaterial.mat` to affected default-material uGUI graphics, or use a material with shader `VRChat/Mobile/Worlds/Supersampled UI`. | Yes; for built-in default material, replaces the graphic material with `VRCSuperSampledUIMaterial.mat`; for project material assets, changes the material shader in place. | Replacement-guarded: do not replace intentional custom UI materials or shader-driven UI effects. Inspect affected objects first. | `VRCSdkControlPanelWorldBuilder.cs:635-747` |
+| Billboard particles allow roll | `Found one or more particle systems set to roll with the camera...` | A `ParticleSystemRenderer` is Billboard mode and `allowRoll` is enabled. | Disable `allowRoll` when camera-facing roll looks uncomfortable in VR. | Yes; sets `allowRoll = false` on all matching renderers. | Some stylized particles may intentionally roll; preview before bulk changes. | `VRCSdkControlPanelWorldBuilder.cs:749-793` |
+| Box mipmap filtering | `This scene uses textures with 'Box' mipmap filtering...` | Renderer texture importers use Box mipmap filtering on Unity 2021+. | Switch affected texture importers to Kaiser for sharper distant textures. | Yes; sets `TextureImporter.mipmapFilter = KaiserFilter`, reserializes, and refreshes assets. | Texture reimport changes asset output. If DPID mipmaps are enabled, the SDK notes they may override this. | `VRCSdkControlPanelWorldBuilder.cs:843-865` |
+
+## Special handling notes
+
+### AudioSource and `VRC_SpatialAudioSource`
+
+The SDK Auto Fix for bare `AudioSource` adds `VRC_SpatialAudioSource` with SDK
+room/avatar defaults. That is useful for clearing the warning, but it can make
+an existing sound louder or audible at a different distance than the author
+intended.
+
+For warning-only additions:
+
+- Use Gain `0 dB` unless the creator explicitly wants a volume boost.
+- Preserve `AudioSource.volume`, `spatialBlend`, `rolloffMode`, `minDistance`,
+  `maxDistance`, and custom curves.
+- For intentionally 2D/global audio, keep `Enable Spatialization` off.
+- For tuned 3D audio, enable `Use AudioSource Volume Curve` when preserving an
+  authored rolloff curve, and set Far to the existing `maxDistance` or intended
+  audible range.
+- Do not overwrite an existing `VRC_SpatialAudioSource`; explain its current
+  values and ask before changing them.
+
+### Super-sampled UI material
+
+The white uGUI warning is actionable but not a build blocker. The guarded fix is
+only for affected graphics that are actually using Unity's default `UI/Default`
+material/shader.
+
+Recommended manual fix:
+
+1. Select the affected `Graphic` (`Image`, `RawImage`, `Text`, or derived uGUI
+   component) shown by the SDK.
+2. If it uses the built-in/default UI material, assign
+   `Packages/com.vrchat.worlds/Editor/VRCSDK/SDK3/VRCSuperSampledUIMaterial.mat`.
+3. If it uses a project material intentionally, do not replace it silently;
+   consider changing that material's shader to `VRChat/Mobile/Worlds/Supersampled UI`
+   only after checking the material's visual role.
+4. Reopen the SDK Build Panel and confirm the alert is gone, then check UI
+   readability in Build & Test.
+
+### Layer and collision setup
+
+Layer setup and collision matrix setup are project-wide mutations. They are
+required for predictable VRChat physics and unresolved setup blocks builds, but
+the layer setup dialog warns that custom layers may move down the list. After
+running setup, re-check custom layer assignments and any hard-coded layer masks.
+
+## Extraction commands used
+
+Run these from the repository root that contains the local SDK search project:
+
+```bash
+cat unity-project-for-sdk-search/TestProject/Packages/com.vrchat.worlds/package.json
+cat unity-project-for-sdk-search/TestProject/Packages/com.vrchat.base/package.json
+
+grep -RIn --include='*.cs' \
+  -E 'OnGUIError|OnGUIWarning|OnGUIInformation|CreateSceneSetupGUI|Auto Fix' \
+  unity-project-for-sdk-search/TestProject/Packages/com.vrchat.worlds \
+  unity-project-for-sdk-search/TestProject/Packages/com.vrchat.base
+
+grep -RIn --include='*.cs' \
+  -E 'VRC_SpatialAudioSource|VRCSuperSampledUIMaterial|UI/Default|allowRoll|mipmapFilter|RespawnHeightY' \
+  unity-project-for-sdk-search/TestProject/Packages/com.vrchat.worlds \
+  unity-project-for-sdk-search/TestProject/Packages/com.vrchat.base
+```
+
+Coverage rule: every SDK 3.10.4 world Build Panel `OnGUIError`,
+`OnGUIWarning`, and actionable `OnGUIInformation` found by these searches must
+be either cataloged above or tracked as an unresolved SDK finding before the
+skill claims current coverage.

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -458,7 +458,7 @@ Creates a portal to another world.
 
 ## VRC_SpatialAudioSource
 
-Configures VRChat spatial audio for an `AudioSource`. Add it deliberately with each world `AudioSource` to avoid SDK Build Panel warnings; Auto Fix may change authored loudness or range.
+Configures VRChat spatial audio for an `AudioSource`. Add it deliberately with each world `AudioSource` to avoid SDK Build Panel warnings; Auto Fix may change authored loudness or range. For the SDK validation entry and Auto Fix mutations, see [build-validation.md](build-validation.md#audiosource-and-vrc_spatialaudiosource).
 
 ### All Properties
 
@@ -843,6 +843,8 @@ comparison table, and worked setup-helper example, see
 Custom MonoBehaviour scripts are not whitelisted and do not run in the client either way;
 the `EditorOnly` tag and `IEditorOnly` interface are about passing SDK validation cleanly
 and keeping dev-only content out of the upload intentionally.
+For the broader SDK Build Panel validation catalog, see
+[build-validation.md](build-validation.md).
 
 ## See Also
 

--- a/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
+++ b/skills/unity-vrc-world-sdk-3/references/troubleshooting.md
@@ -47,6 +47,10 @@ Common problems encountered during world development and their solutions.
 
 ```
 
+Before using the setup buttons in a mature project, check
+[build-validation.md](build-validation.md#layer-and-collision-setup): layer
+setup can move custom layers and requires layer-mask review.
+
 ### World not found after upload
 
 **Symptom**: Upload succeeded but world doesn't appear
@@ -78,6 +82,10 @@ Common problems encountered during world development and their solutions.
 
 ```
 
+If the cancellation came from SDK Validations, copy the exact red/yellow/white
+message and match it in
+[build-validation.md](build-validation.md#sdk-3104-world-alert-catalog).
+
 ### "Unsupported component" warnings
 
 **Symptom**: SDK validation flags non-whitelisted scripts or components
@@ -85,6 +93,8 @@ Common problems encountered during world development and their solutions.
 **Solution**: Remove them, tag dev-only objects `EditorOnly`, or mark setup-helper
 components with `IEditorOnly` — see
 [components.md](components.md#editor-only-objects-and-components).
+For broader Build Panel alert handling, use
+[build-validation.md](build-validation.md).
 
 ---
 
@@ -492,6 +502,8 @@ VRChat SDK > Show Control Panel
 Builder tab > Validations section
 - Auto-fixable issues have buttons for fixing
 - Follow instructions for manual fixes
+- For exact SDK 3.10.4 red/yellow/white alert meanings and Auto Fix side effects,
+  use references/build-validation.md
 
 ```
 
@@ -585,7 +597,7 @@ Fix: Set Canvas > Render Mode to World Space before adding VRC_UIShape.
 | Error/Issue | Solution |
 |-------------|----------|
 | Missing SceneDescriptor | Add VRCWorld Prefab |
-| Layer Matrix warning | "Setup Layers for VRChat" |
+| Layer Matrix warning | Check `build-validation.md`, then run "Setup Layers for VRChat" and review custom layers |
 | Can't grab Pickup | Add Collider + Rigidbody |
 | Pickup doesn't sync | Add VRC_ObjectSync |
 | Can't sit in Station | Add Collider |
@@ -594,6 +606,7 @@ Fix: Set Canvas > Render Mode to World Space before adding VRC_UIShape.
 | Low FPS | Mirror OFF, bake lights |
 | Doesn't work on Quest | Use Mobile shaders |
 | Late Joiner sync | Apply in OnDeserialization |
+| SDK Build Panel warning | Match exact message in `build-validation.md` |
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/references/upload.md
+++ b/skills/unity-vrc-world-sdk-3/references/upload.md
@@ -123,34 +123,48 @@ Notes:
 3. Check Validations section
 4. Resolve errors (red)
 5. Review warnings (yellow)
+6. Review informational alerts (white) when they have actionable fixes
 ```
 
-### Common Validation Errors
+For copied validation text, red/yellow/white warning questions, or **Auto Fix**
+side-effect checks, use the SDK-backed catalog:
+[build-validation.md](build-validation.md).
 
-| Error | Cause | Solution |
-|-------|-------|----------|
-| Missing SceneDescriptor | No VRCWorld | Add VRCWorld Prefab |
-| Layer setup required | Layers not configured | Click "Setup Layers" |
-| Build size too large | Build is too big | Reduce assets |
-| Script errors | Compilation errors | Fix scripts |
+### Build Panel Alert Handling
+
+| Build Panel color | SDK source level | Build consequence | Required response |
+|---|---|---|---|
+| Red | `OnGUIError` | Blocks Build & Test / Build & Upload | Resolve before building |
+| Yellow | `OnGUIWarning` | Does not block solely by color, but can indicate runtime or compatibility issues | Explain impact and use the safest targeted fix |
+| White / info | `OnGUIInformation` | Does not block; often quality/readability guidance | Explain and offer guarded fixes when actionable |
+
+### Common Validation Alerts
+
+| Alert | Cause | Safe direction |
+|---|---|---|
+| Missing or multiple `VRC_SceneDescriptor` | No descriptor, or more than one descriptor in the scene | Keep exactly one valid descriptor and configure Spawns |
+| Layer/collision setup required | VRChat project layers or collision matrix are not configured | Use the SDK setup buttons, then review custom layers and layer masks |
 | Unsupported component warnings | Non-whitelisted scripts or components in the scene | Remove them, tag dev-only objects `EditorOnly`, or mark setup-helper components with `IEditorOnly` (see [components.md](components.md#editor-only-objects-and-components)) |
-| Missing references | Reference errors | Fix references |
+| `AudioSource` without `VRC_SpatialAudioSource` | World audio source is missing the VRChat spatial audio companion | Add the companion deliberately; preserve existing loudness, 2D/3D intent, and distance curves |
+| Unity built-in UI shader on uGUI graphics | `Image`, `RawImage`, `Text`, or another uGUI `Graphic` uses `UI/Default` | For affected default-material graphics, assign `Packages/com.vrchat.worlds/Editor/VRCSDK/SDK3/VRCSuperSampledUIMaterial.mat` |
+| Spawn below respawn height or too far from origin | Spawn Transform is invalid for the descriptor settings | Move the spawn or adjust Respawn Height so join/respawn works correctly |
+| Oversized textures or bundles | Imported assets exceed SDK size checks | Reduce/import assets intentionally; do not delete assets blindly |
 
-### Auto-Fix Feature
+### Auto Fix policy
 
-```text
-Some issues can be auto-fixed:
+An **Auto Fix** button means the SDK has a fix callback, not that the mutation
+is always safe for the world. Before pressing it, check
+[build-validation.md](build-validation.md) for the exact fields/assets it
+changes and whether it may overwrite authored intent.
 
-Items with "Auto Fix" button:
-- Layer collision matrix
-- Project settings
-- Quality settings
+Common high-risk examples:
 
-Items that can't be auto-fixed:
-- Script errors
-- Missing references
-- Component misconfiguration
-```
+- `AudioSource` fixes can add `VRC_SpatialAudioSource` with SDK defaults; for
+  warning-only additions, prefer Gain `0 dB` and preserve existing range/rolloff.
+- Super-sampled UI fixes can replace a default material or change a project
+  material shader in place; do not replace intentional custom UI materials.
+- Layer/collision setup changes project-wide layer configuration.
+- Texture fixes reserialize importers and trigger reimport.
 
 ---
 

--- a/tests/docs/assembly-definitions-reference.test.sh
+++ b/tests/docs/assembly-definitions-reference.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UDON_DIR="$ROOT_DIR/skills/unity-vrc-udon-sharp"
+SKILL="$UDON_DIR/SKILL.md"
+CHEATSHEET="$UDON_DIR/CHEATSHEET.md"
+EDITOR_REF="$UDON_DIR/references/editor-scripting.md"
+REF="$UDON_DIR/references/assembly-definitions.md"
+CI="$ROOT_DIR/.github/workflows/ci.yml"
+
+require_file() {
+    local path="$1"
+    if [[ ! -f "$path" ]]; then
+        echo "ERROR: missing file: $path" >&2
+        exit 1
+    fi
+}
+
+require_text() {
+    local path="$1"
+    local needle="$2"
+    if ! grep -Fq "$needle" "$path"; then
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    fi
+}
+
+require_any_text() {
+    local path="$1"
+    shift
+    local needle
+    for needle in "$@"; do
+        if grep -Fq "$needle" "$path"; then
+            return 0
+        fi
+    done
+    echo "ERROR: $path does not contain any expected text: $*" >&2
+    exit 1
+}
+
+require_file "$REF"
+
+# Core reference guidance and evidence links
+require_any_text "$REF" "world-only" "simple one-off" "ordinary"
+require_text "$REF" "do not add an asmdef by default"
+require_text "$REF" 'Unity `.asmdef`'
+require_text "$REF" "U# Assembly Definition"
+require_text "$REF" "Source Assembly"
+require_text "$REF" "does not belong to a U# assembly"
+require_text "$REF" "VPM"
+require_text "$REF" "Runtime/Editor"
+require_any_text "$REF" "Editor-only scripts" "editor-only scripts"
+require_text "$REF" "UdonSharpBehaviours"
+require_text "$REF" "Auto Referenced"
+require_text "$REF" "compile reference policy"
+require_text "$REF" "not build inclusion"
+require_any_text "$REF" "prefab-first" "prefab first"
+require_text "$REF" "code-integration API"
+require_text "$REF" "internal runtime code"
+require_text "$REF" "https://udonsharp.docs.vrchat.com/migration/"
+require_text "$REF" "https://docs.unity3d.com/Manual/assembly-definition-file-format.html"
+
+# Entrypoints route asmdef/package work to the reference.
+for path in "$SKILL" "$CHEATSHEET" "$EDITOR_REF"; do
+    require_file "$path"
+    require_text "$path" "assembly-definitions.md"
+done
+
+# SKILL.md discovery surfaces and tables include the new topic.
+require_text "$SKILL" "asmdef"
+require_text "$SKILL" "VPM package"
+require_text "$SKILL" "U# Assembly Definition"
+require_text "$SKILL" "Auto Referenced"
+require_text "$SKILL" 'Unity `.asmdef`'
+require_text "$SKILL" "without matching U# Assembly Definition"
+require_text "$SKILL" "VPM/package/asmdef workflows"
+require_text "$SKILL" "assembly-definitions.md"
+
+# Cheatsheet includes the short decision note.
+require_any_text "$CHEATSHEET" "simple world scripts" "world scripts"
+require_any_text "$CHEATSHEET" "package/asmdef" "U# Assembly Definition"
+require_text "$CHEATSHEET" "Auto Referenced"
+
+# CI docs job runs this smoke test.
+require_text "$CI" "assembly-definitions-reference.test.sh"
+
+echo "PASS: assembly-definitions reference coverage smoke test"

--- a/tests/docs/build-validation-reference.test.sh
+++ b/tests/docs/build-validation-reference.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORLD_SKILL="$ROOT_DIR/skills/unity-vrc-world-sdk-3/SKILL.md"
+UDON_SKILL="$ROOT_DIR/skills/unity-vrc-udon-sharp/SKILL.md"
+REF="$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/build-validation.md"
+
+require_file() {
+    local path="$1"
+    if [[ ! -f "$path" ]]; then
+        echo "ERROR: missing file: $path" >&2
+        exit 1
+    fi
+}
+
+require_text() {
+    local path="$1"
+    local needle="$2"
+    if ! grep -Fq "$needle" "$path"; then
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    fi
+}
+
+require_file "$REF"
+
+# SDK evidence and color/severity model
+require_text "$REF" "Last verified SDK"
+require_text "$REF" 'VRChat Worlds SDK `3.10.4`'
+require_text "$REF" 'Base SDK `3.10.4`'
+require_text "$REF" "OnGUIError"
+require_text "$REF" "OnGUIWarning"
+require_text "$REF" "OnGUIInformation"
+require_text "$REF" "Auto Fix"
+
+# Representative red/yellow/white alert families from the SDK 3.10.4 catalog
+require_text "$REF" "A VRCSceneDescriptor is required to build a World"
+require_text "$REF" "A VRCSceneDescriptor or VRCAvatarDescriptor"
+require_text "$REF" "Multiple Pipeline Managers found in scene. Please remove all but one."
+require_text "$REF" "You can only have a single Pipeline Manager in a Scene"
+require_text "$REF" "SDK V3 is not enabled."
+require_text "$REF" "Multiple pipelines are present. V3 pipeline will take priority"
+require_text "$REF" "Multiple scene descriptors"
+require_text "$REF" "Object Sync cannot share an object with a manually synchronized Udon Behaviour"
+require_text "$REF" "You have Event Handlers in your scene that are not allowed in this build configuration."
+require_text "$REF" 'removes each `VRC_EventHandler` component'
+require_text "$REF" "You must address Layers and Collision Matrix issues before you can build."
+require_text "$REF" "Android texture format not ASTC"
+require_text "$REF" "AudioSource"
+require_text "$REF" "VRC_SpatialAudioSource"
+require_text "$REF" 'Gain `0 dB`'
+require_text "$REF" "Unsupported mobile shader"
+require_text "$REF" "Found one or more UI graphics using Unity's built-in UI shader"
+require_text "$REF" "VRCSuperSampledUIMaterial.mat"
+require_text "$REF" "Billboard particles allow roll"
+require_text "$REF" "Box mipmap filtering"
+require_text "$REF" "Everything looks good"
+
+# Existing entrypoints must route copied validation messages to the catalog.
+for path in \
+    "$WORLD_SKILL" \
+    "$UDON_SKILL" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/CHEATSHEET.md" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/upload.md" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/troubleshooting.md" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/audio-video.md" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/components.md"; do
+    require_file "$path"
+    require_text "$path" "build-validation.md"
+done
+
+echo "PASS: build-validation reference coverage smoke test"


### PR DESCRIPTION
## Summary

Release v2.5.2.

3 PRs since v2.5.1:

- #274 — documentation: SDK Build Panel validation guidance
- #277 — documentation: UdonSharp Assembly Definition guidance for VPM/package workflows
- #279 — maintenance: version bump to v2.5.2

Version bump driver: `release: docs` / `release: maintenance` → patch.

## What changed

### World SDK validation guidance (#274)

- Adds a SDK-backed validation catalog for VRChat World Build Panel alerts.
- Covers red errors, yellow warnings, and actionable informational alerts.
- Includes safe-resolution notes for Auto Fix behavior, super-sampled UI material guidance, and AudioSource/VRC_SpatialAudioSource caution cases.

### UdonSharp Assembly Definition guidance (#277 / #275)

- Adds guidance for Unity `.asmdef` and U# Assembly Definition usage in UdonSharp package workflows.
- Clarifies beginner-safe defaults, VPM package tradeoffs, and `Auto Referenced` decisions.
- Adds a docs smoke test and entrypoint routing so the reference remains discoverable.

## Reporter acknowledgement

- #273 — opened by @niaka3dayo
- #275 — opened by @niaka3dayo

## Merge instructions

Do not squash. Use a plain merge commit so the release draft can see each underlying PR.

## Test plan

- [x] Version bump PR CI passed, including Version Sync.
- [x] `package.json` and the 4 related metadata/frontmatter fields report `2.5.2` on `dev`.
- [ ] Release PR CI passes.
- [ ] Release Drafter draft is rewritten before publication.
- [ ] After publish, `npm view agent-skills-vrc-udon version` reports `2.5.2`.

Part of #278.
