### PR TITLE
fix(skill): keep UdonSharp description within spec

### DIFF
--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -1,21 +1,18 @@
 ---
 name: unity-vrc-udon-sharp
-description: >
-    UdonSharp (C# to Udon Assembly) scripting skill for VRChat world development.
-    Use this skill when writing, reviewing, or debugging UdonSharp C# code.
-    Covers compile constraints (List<T>/async/await/try/catch/LINQ blocked),
-    network sync (UdonSynced, RequestSerialization, FieldChangeCallback, NetworkCallable),
-    persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts,
-    VRCTween, VRCPhysBoneCollider Udon access), Web Loading, DataList/DataDictionary
-    capacity APIs, VRAM management (texture lifecycle, Dispose vs Destroy),
-    asmdef / Assembly Definition / U# Assembly Definition guidance, VPM package
-    workflow boundaries, Auto Referenced tradeoffs, and event handling. SDK 3.7.1 - 3.10.4 coverage.
-    Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
-    NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
-    VRCTween, Box Contacts, Global Avatar PhysBone Colliders, VRCPhysBoneCollider,
-    DataList capacity, DataDictionary EnsureCapacity, synced variables, asmdef,
-    Assembly Definition, U# Assembly Definition, VPM package, Auto Referenced,
-    VRChat world scripting, C# to Udon.
+description: >-
+    UdonSharp scripting skill for VRChat world development. Use when writing,
+    reviewing, debugging, or migrating UdonSharp C# / UdonBehaviour code for SDK
+    3.7.1-3.10.4. Covers Udon compile constraints such as List<T>, async/await,
+    try/catch, and LINQ; networking with UdonSynced, RequestSerialization,
+    FieldChangeCallback, and NetworkCallable; PlayerData / PlayerObject
+    persistence; PhysBones, Contacts, VRCTween, and VRCPhysBoneCollider access;
+    DataList / DataDictionary capacity APIs; Web Loading; VRAM and texture
+    lifecycle; asmdef / U# Assembly Definition guidance; VPM package boundaries;
+    Auto Referenced tradeoffs; and event handling. Triggers on UdonSharp, Udon,
+    VRC SDK, UdonBehaviour, VRCPlayerApi, SendCustomEvent, synced variables,
+    Box Contacts, Global Avatar PhysBone Colliders, DataList capacity,
+    DataDictionary EnsureCapacity, VRChat world scripting, and C# to Udon.
 license: MIT
 metadata:
     author: niaka3dayo


### PR DESCRIPTION
## 関連Issue

Closes #281

## 背景

`unity-vrc-udon-sharp` の frontmatter `description` が Agent Skills 仕様の 1024 文字上限を超えており、Codex CLI で skill 読み込みエラーになる問題がありました。

## このPRでやったこと

- `unity-vrc-udon-sharp` の `description` を 1024 文字以内に短縮
- YAML folded style を `>-` にして、parse 後の末尾改行を含めない形に変更
- activation に必要な主要 keyword は維持

## 影響範囲

- `skills/unity-vrc-udon-sharp/SKILL.md` の frontmatter のみ
- skill 本文・参照ファイル・テンプレートの動作変更はありません

## 品質ゲート

- [x] YAML parse 後の description length 確認: `unity-vrc-udon-sharp` 876 chars
- [x] `npx skills-ref validate` による全 skill 検証
- [x] npm package smoke test で packaged skill の description length / validate を確認
- [x] ローカルCI相当チェック通過
- [x] skill-judge focus check: 118/120 (A)
- [x] code-reviewer 再レビュー: CRITICAL / HIGH / MUST 指摘ゼロ
