### PR TITLE
chore(version): bump to v2.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.2"
+    "version": "2.5.3"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.2"
+    version: "2.5.3"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.2"
+    version: "2.5.3"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.2"
+    version: "2.5.3"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
## 関連Issue

Refs #283

## 背景

#281 の修正を緊急パッチとして配布するため、リリース対象バージョンを v2.5.3 に更新します。

## このPRでやったこと

- `package.json` を 2.5.3 に更新
- `.claude-plugin/marketplace.json` を 2.5.3 に更新
- 3つの skill frontmatter `metadata.version` を 2.5.3 に更新

## 影響範囲

- リリース用メタデータのみ
- skill 本文の動作・ガイダンス変更はありません

## 品質ゲート

- [x] 5箇所の version sync をローカル確認
- [x] `npx skills-ref validate` を全 skill に実行
- [x] `npm pack --dry-run` 通過
- [x] `git diff --check` 通過
