### PR TITLE
Release v2.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.2"
+    "version": "2.5.3"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.2"
+    version: "2.5.3"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.2"
+    version: "2.5.3"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -1,21 +1,18 @@
 ---
 name: unity-vrc-udon-sharp
-description: >
-    UdonSharp (C# to Udon Assembly) scripting skill for VRChat world development.
-    Use this skill when writing, reviewing, or debugging UdonSharp C# code.
-    Covers compile constraints (List<T>/async/await/try/catch/LINQ blocked),
-    network sync (UdonSynced, RequestSerialization, FieldChangeCallback, NetworkCallable),
-    persistence (PlayerData/PlayerObject), Dynamics (PhysBones, Contacts,
-    VRCTween, VRCPhysBoneCollider Udon access), Web Loading, DataList/DataDictionary
-    capacity APIs, VRAM management (texture lifecycle, Dispose vs Destroy),
-    asmdef / Assembly Definition / U# Assembly Definition guidance, VPM package
-    workflow boundaries, Auto Referenced tradeoffs, and event handling. SDK 3.7.1 - 3.10.4 coverage.
-    Triggers on: UdonSharp, Udon, VRC SDK, UdonBehaviour, UdonSynced,
-    NetworkCallable, VRCPlayerApi, SendCustomEvent, PlayerData, PhysBones,
-    VRCTween, Box Contacts, Global Avatar PhysBone Colliders, VRCPhysBoneCollider,
-    DataList capacity, DataDictionary EnsureCapacity, synced variables, asmdef,
-    Assembly Definition, U# Assembly Definition, VPM package, Auto Referenced,
-    VRChat world scripting, C# to Udon.
+description: >-
+    UdonSharp scripting skill for VRChat world development. Use when writing,
+    reviewing, debugging, or migrating UdonSharp C# / UdonBehaviour code for SDK
+    3.7.1-3.10.4. Covers Udon compile constraints such as List<T>, async/await,
+    try/catch, and LINQ; networking with UdonSynced, RequestSerialization,
+    FieldChangeCallback, and NetworkCallable; PlayerData / PlayerObject
+    persistence; PhysBones, Contacts, VRCTween, and VRCPhysBoneCollider access;
+    DataList / DataDictionary capacity APIs; Web Loading; VRAM and texture
+    lifecycle; asmdef / U# Assembly Definition guidance; VPM package boundaries;
+    Auto Referenced tradeoffs; and event handling. Triggers on UdonSharp, Udon,
+    VRC SDK, UdonBehaviour, VRCPlayerApi, SendCustomEvent, synced variables,
+    Box Contacts, Global Avatar PhysBone Colliders, DataList capacity,
+    DataDictionary EnsureCapacity, VRChat world scripting, and C# to Udon.
 license: MIT
 metadata:
     author: niaka3dayo

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.2"
+    version: "2.5.3"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
## Pre-flight checklist (Step 1 must be done BEFORE this PR is opened)

- [x] **Version bumped on `dev`** via a separate `chore(version): bump to v2.5.3` PR, already merged.
  Verify with `node -p "require('./package.json').version"` on `dev` — it must equal the target version.
- [x] All 5 version fields are in sync (Version Sync CI checks this; verified locally too):
  - `package.json` → `.version`
  - `.claude-plugin/marketplace.json` → `.metadata.version`
  - `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
  - `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
  - `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`

## Summary

Release v2.5.3 — emergency patch for the UdonSharp skill metadata description limit.

**2 PRs since v2.5.2:**

- #282 — `fix`: keep `unity-vrc-udon-sharp` description within Agent Skills spec
- #284 — `chore`: bump version metadata to v2.5.3

**Version bump driver**: `release: fix` → patch.

## What changed

### `unity-vrc-udon-sharp` (#282)

- Shortened the skill frontmatter `description` to satisfy the Agent Skills 1024 character limit.
- Preserved important activation keywords while fixing Codex CLI skill loading compatibility.

### Version metadata (#284)

- Updated all package and skill metadata versions to 2.5.3.

## Reporter acknowledgement

- #281 was reported by @tetradice with a Codex CLI error log. The release notes include explicit thanks.

## Merge instructions

**DO NOT SQUASH** — use a plain merge commit so Release Drafter sees each underlying PR.

## Test plan

- [x] CI green on #282
- [x] CI green on #284
- [x] `skills-ref validate` confirmed for affected skills
- [x] Release notes draft approved before publishing
- [ ] CI green on this release PR
- [ ] Release Drafter draft body reflects the merged PRs
- [ ] After publish: `npm view agent-skills-vrc-udon version` returns 2.5.3

## Release impact

`release: fix` → patch bump.
