### PR TITLE
fix(skill): correct layer name preservation claims in layers reference

### DIFF
--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -177,7 +177,7 @@ ApplyConfigurationChanges() after batched configuration changes.
 | 14 | PickupNoEnvironment | Pickups that pass through walls |
 | 17 | Walkthrough | Walk-through objects |
 | 18 | MirrorReflection | Mirror only |
-| **22-31** | **User** | **Available for custom use** |
+| **22-31** | **User** | **Custom use (names become user0-user9 at runtime)** |
 
 ### Layer Masks (Udon)
 
@@ -185,6 +185,8 @@ ApplyConfigurationChanges() after batched configuration changes.
 // Get layer mask
 int playerMask = 1 << 9;
 int envMask = 1 << LayerMask.NameToLayer("Environment");
+// NameToLayer is safe only for VRChat-defined names.
+// User layers 22-31 are user0-user9 at runtime; use numbers.
 
 // Multiple layers
 int combined = (1 << 9) | (1 << 11);

--- a/skills/unity-vrc-world-sdk-3/references/layers.md
+++ b/skills/unity-vrc-world-sdk-3/references/layers.md
@@ -17,9 +17,11 @@ VRChat uses Unity's layer system to organize GameObjects, control collisions, an
 | 0 | Default | General objects |
 | 1 | TransparentFX | Transparent effects |
 | 2 | Ignore Raycast | Ignored by Raycast |
-| 3 | - | Unused |
+| 3 | Item | VRChat items placed by users; moved to Default at upload |
 | 4 | Water | Water surfaces |
 | 5 | UI | Unity UI |
+| 6 | reserved6 | Reserved by VRChat - do not use |
+| 7 | reserved7 | Reserved by VRChat - do not use |
 
 ### VRChat-Specific Layers
 
@@ -36,15 +38,33 @@ VRChat uses Unity's layer system to organize GameObjects, control collisions, an
 | 16 | StereoRight | Stereo right eye |
 | 17 | Walkthrough | Walk-through objects |
 | 18 | MirrorReflection | Mirror reflection |
-| 19 | reserved2 | Reserved |
-| 20 | reserved3 | Reserved |
-| 21 | reserved4 | Reserved |
+| 19 | InternalUI | VRChat menu, nameplates, debug panels - do not use |
+| 20 | HardwareObjects | Controller/tracker models in-game - do not use |
+| 21 | reserved4 | Reserved; objects on it move to Default at upload |
+
+Layers 19/20 were previously named reserved2/reserved3 - VRChat has renamed
+runtime layers before, which is another reason not to rely on layer names in
+scripts.
 
 ---
 
 ## User Layers (22-31)
 
-**Available for custom use**: Names and collision settings are preserved.
+The **collision matrix** you configure for layers 22-31 IS preserved in
+uploaded worlds.
+
+Layer **names are NOT preserved**: at runtime the VRChat client overrides them
+to `user0`-`user9` (layer 22 = `user0`, ... layer 31 = `user9`).
+
+> **Note: This contradicts the official documentation (verified by runtime
+> testing).** The official docs state that VRChat "will not override the name
+> and collision matrix" of layers 22-31. Runtime observation (2026-07) shows
+> layer *names* ARE overridden to `user0`-`user9`; only the collision matrix is
+> preserved. See [Issue #286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286)
+> (includes a layer-dump script and full runtime output) and
+> [this independent report](https://ask.vrchat.com/t/user-defined-unity-layers-raycasts-ignored-by-vrchat/47933).
+> If official docs or client behavior change, re-verify with the layer-dump
+> script in #286.
 
 | Layer # | Suggested Use |
 |---------|---------------|
@@ -59,6 +79,28 @@ VRChat uses Unity's layer system to organize GameObjects, control collisions, an
 | 30 | Custom purpose 9 |
 | 31 | Custom purpose 10 |
 
+Naming user layers in the editor is fine for organization, but **scripts must
+reference user layers by number or bitmask** - never by name.
+
+`LayerMask.NameToLayer("YourCustomName")` returns the correct layer in the
+editor and ClientSim, but returns `-1` in the live client because the name was
+overridden. Masks built from that result silently match nothing. This "works
+in ClientSim, breaks in the live client" divergence is the failure mode
+reported in Issue #286.
+
+```csharp
+// ✅ Safe: reference user layers by number
+private const int LAYER_PROJECTILES = 25;
+int projectileMask = 1 << LAYER_PROJECTILES;
+
+// ❌ Breaks in the live client: custom layer names are overridden to user0-user9
+int broken = LayerMask.NameToLayer("Projectiles"); // returns -1 at runtime
+```
+
+Layer 31 is named `user9` at runtime, but the official docs recommend avoiding
+it because Unity Editor preview mechanics use it. Suggested usable range:
+22-30.
+
 ### Commonly Used Custom Layers
 
 ```text
@@ -67,6 +109,9 @@ Layer 23: "LocalOnly" - Local-only objects
 Layer 24: "TriggerZone" - Trigger zones only
 Layer 25: "Projectiles" - Projectiles
 ```
+
+These names are editor-side organization only; scripts should still use layer
+numbers or bitmasks.
 
 ---
 
@@ -187,6 +232,10 @@ Physics.IgnoreLayerCollision(22, 11, true); // Disable collision between Layer 2
 
 ## Layer Masks in Udon
 
+`LayerMask.NameToLayer` and `LayerMask.GetMask` are only safe with
+**VRChat-defined layer names** that are verified present at runtime. For user
+layers 22-31, always use numeric constants.
+
 ### Getting Layer Masks
 
 ```csharp
@@ -246,6 +295,7 @@ void Start()
 ✅ Use User Layers:
 - When custom collision settings are needed
 - For specific Raycast filtering
+- Reference user layers from scripts by number or constants
 ```
 
 ### Prohibited Actions
@@ -255,6 +305,7 @@ void Start()
 - Renaming VRChat reserved layers
 - Using Player/PlayerLocal layers (VRChat exclusive)
 - Enabling unnecessary collisions
+- Referencing user layers (22-31) by name in scripts
 ```
 
 ---
@@ -269,6 +320,7 @@ void Start()
 | Pickup falls through floor | Using PickupNoEnvironment | Change to Pickup |
 | Object not visible in mirror | Layer settings | Check MirrorReflection |
 | Raycast not detecting | Layer mask | Use correct mask |
+| Works in ClientSim only | Custom layer name lookup | Use layer numbers |
 
 ### Debugging Layer Issues
 
@@ -296,7 +348,7 @@ Debug.Log($"Layers {layerA} and {layerB} collision: {willCollide}");
 14 = PickupNoEnvironment
 17 = Walkthrough
 18 = MirrorReflection
-22-31 = User Layers (custom)
+22-31 = User Layers (collision kept; names become user0-user9 — use numbers)
 ```
 
 ### Common Operations

--- a/skills/unity-vrc-world-sdk-3/references/layers.md
+++ b/skills/unity-vrc-world-sdk-3/references/layers.md
@@ -77,16 +77,18 @@ to `user0`-`user9` (layer 22 = `user0`, ... layer 31 = `user9`).
 | 28 | Custom purpose 7 |
 | 29 | Custom purpose 8 |
 | 30 | Custom purpose 9 |
-| 31 | Custom purpose 10 |
+| 31 | Avoid - Unity Editor preview uses it (see note below) |
 
 Naming user layers in the editor is fine for organization, but **scripts must
 reference user layers by number or bitmask** - never by name.
 
 `LayerMask.NameToLayer("YourCustomName")` returns the correct layer in the
 editor and ClientSim, but returns `-1` in the live client because the name was
-overridden. Masks built from that result silently match nothing. This "works
-in ClientSim, breaks in the live client" divergence is the failure mode
-reported in Issue #286.
+overridden. Feeding `-1` into a shift does not fail loudly: C# masks the shift
+count to its low 5 bits, so `1 << -1` evaluates to `1 << 31` and the mask
+silently targets layer 31 instead of your layer. This "works in ClientSim,
+breaks in the live client" divergence is the failure mode reported in
+Issue #286.
 
 ```csharp
 // ✅ Safe: reference user layers by number
@@ -95,6 +97,7 @@ int projectileMask = 1 << LAYER_PROJECTILES;
 
 // ❌ Breaks in the live client: custom layer names are overridden to user0-user9
 int broken = LayerMask.NameToLayer("Projectiles"); // returns -1 at runtime
+int brokenMask = 1 << broken; // == 1 << 31: wrong layer, no error raised
 ```
 
 Layer 31 is named `user9` at runtime, but the official docs recommend avoiding


### PR DESCRIPTION
## Summary

Fixes the incorrect claim in `references/layers.md` that layer 22-31 names and collision settings are both preserved in uploaded worlds. Runtime testing (see #286) shows the VRChat client overrides user layer names to `user0`-`user9`; only the collision matrix is preserved. As a result, `LayerMask.NameToLayer()` / `GetMask()` with custom layer names work in ClientSim but silently fail in the live client.

## Changes

- **User Layers (22-31) section rewritten**: collision matrix is preserved, names are not. Added a callout documenting the contradiction with the official docs (observation date, evidence links to #286 and an independent forum report, and a re-verification recipe using the layer-dump script from #286).
- **Script guidance**: reference user layers by number or bitmask, never by name. Added a ✅/❌ code example. `NameToLayer` remains safe for VRChat-defined names (Player, Environment, Pickup, etc.), which is now stated explicitly in the Layer Masks section.
- **Stale table entries refreshed** against the official docs and the runtime dump: Layer 3 (Item, moved to Default at upload), 6/7 (reserved6/7), 19 (InternalUI), 20 (HardwareObjects), 21 (objects moved to Default at upload). Added a note that 19/20 were previously reserved2/reserved3 — VRChat has renamed runtime layers before.
- **Layer 31**: named `user9` at runtime, but the official docs say to avoid it (Unity Editor preview mechanics). Suggested usable range 22-30.
- **Troubleshooting / Quick Reference / Best Practices** updated to match, plus a two-line note in CHEATSHEET.md.

## Verification

- All layer table entries cross-checked against https://creators.vrchat.com/worlds/layers/ and the runtime layer dump in #286 (they agree except the 22-31 name claim, which the callout documents).
- `markdownlint-cli2` error set on changed files is a strict subset of the `dev` baseline (one pre-existing error removed, none added).
- `git diff --check` clean; changes limited to `skills/unity-vrc-world-sdk-3/references/layers.md` and `skills/unity-vrc-world-sdk-3/CHEATSHEET.md`.
- Independent review pass covering correctness, internal consistency, UdonSharp validity of code examples, and legacy-text removal (`grep` for the old preserved claims returns nothing).

Closes #286

## Doc sync

Reference content change only — no skill/rule/template counts changed, so README tables and `templates/*.md` need no updates.