### PR TITLE
ci: automate release and tag pruning to keep latest three

### DIFF
--- a/.github/workflows/prune-releases.yml
+++ b/.github/workflows/prune-releases.yml
@@ -1,0 +1,157 @@
+name: Prune Releases
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: prune-releases
+  cancel-in-progress: false
+
+env:
+  KEEP: "3"
+
+jobs:
+  prune:
+    name: Prune
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune old releases and tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+        run: |
+          set -euo pipefail
+
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Keeping latest $KEEP published releases"
+          if [ -n "$TRIGGER_TAG" ]; then
+            echo "Trigger release tag: $TRIGGER_TAG"
+          else
+            echo "Trigger release tag: <none>"
+          fi
+
+          releases_json="$workdir/releases.json"
+          published_json="$workdir/published.json"
+          keep_tags="$workdir/keep-tags.txt"
+          delete_tags="$workdir/delete-tags.txt"
+
+          gh release list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 100 \
+            --json tagName,isDraft,isPrerelease,publishedAt > "$releases_json"
+
+          jq '[.[]
+            | select(.isDraft == false and .isPrerelease == false and .publishedAt != null)]
+            | sort_by(.publishedAt)
+            | reverse' "$releases_json" > "$published_json"
+
+          jq -r --argjson keep "$KEEP" '.[:$keep][].tagName' "$published_json" > "$keep_tags"
+          jq -r \
+            --argjson keep "$KEEP" \
+            --arg trigger "$TRIGGER_TAG" \
+            '.[$keep:][]
+              | select(.tagName != $trigger)
+              | .tagName' "$published_json" > "$delete_tags"
+
+          echo "Keep releases:"
+          if [ -s "$keep_tags" ]; then
+            sed 's/^/  - /' "$keep_tags"
+          else
+            echo "  <none>"
+          fi
+
+          echo "Delete old published releases:"
+          if [ -s "$delete_tags" ]; then
+            sed 's/^/  - /' "$delete_tags"
+          else
+            echo "  <none>"
+          fi
+
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Deleting release and tag: $tag"
+            gh release delete "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --yes \
+              --cleanup-tag
+          done < "$delete_tags"
+
+          all_release_tags="$workdir/all-release-tags.txt"
+          v_refs="$workdir/v-refs.txt"
+          orphan_tags="$workdir/orphan-tags.txt"
+
+          gh api --paginate "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '.[].tag_name' > "$all_release_tags"
+
+          gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
+            --jq '.[].ref' > "$v_refs"
+
+          : > "$orphan_tags"
+          while IFS= read -r ref; do
+            [ -n "$ref" ] || continue
+            tag="${ref#refs/tags/}"
+            if ! grep -Fxq "$tag" "$all_release_tags"; then
+              printf '%s\n' "$tag" >> "$orphan_tags"
+            fi
+          done < "$v_refs"
+
+          echo "Delete orphan v* tags:"
+          if [ -s "$orphan_tags" ]; then
+            sed 's/^/  - /' "$orphan_tags"
+          else
+            echo "  <none>"
+          fi
+
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Deleting orphan tag: $tag"
+            gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$tag"
+          done < "$orphan_tags"
+
+          oldest_keep_tag="$(tail -n 1 "$keep_tags" || true)"
+          if [ -z "$oldest_keep_tag" ]; then
+            echo "No kept release found; skipping Full Changelog repair"
+            exit 0
+          fi
+
+          body_file="$workdir/body.md"
+          notes_file="$workdir/notes.md"
+          gh release view "$oldest_keep_tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json body \
+            --jq .body > "$body_file"
+
+          changelog_line="$(grep -m 1 -E '^\*\*Full Changelog\*\*: https://github\.com/[^/]+/[^/]+/compare/.+\.\.\..+' "$body_file" || true)"
+          if [ -z "$changelog_line" ]; then
+            echo "No Full Changelog compare line found in $oldest_keep_tag; no edit needed"
+            exit 0
+          fi
+
+          from_tag="${changelog_line#*compare/}"
+          from_tag="${from_tag%%...*}"
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$from_tag" >/dev/null 2>&1; then
+            echo "Full Changelog base tag still exists: $from_tag; no edit needed"
+            exit 0
+          fi
+
+          replacement="*Earlier release notes (pre-$oldest_keep_tag) and their tags have been archived to keep the latest $KEEP releases visible.*"
+          awk -v old="$changelog_line" -v new="$replacement" '
+            $0 == old {
+              print new
+              next
+            }
+            { print }
+          ' "$body_file" > "$notes_file"
+
+          echo "Repairing Full Changelog line in $oldest_keep_tag; missing base tag: $from_tag"
+          gh release edit "$oldest_keep_tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --notes-file "$notes_file"

--- a/.github/workflows/prune-releases.yml
+++ b/.github/workflows/prune-releases.yml
@@ -91,13 +91,20 @@ jobs:
           gh api --paginate "repos/$GITHUB_REPOSITORY/releases" \
             --jq '.[].tag_name' > "$all_release_tags"
 
-          gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
+          gh api --paginate "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
             --jq '.[].ref' > "$v_refs"
 
           : > "$orphan_tags"
           while IFS= read -r ref; do
             [ -n "$ref" ] || continue
             tag="${ref#refs/tags/}"
+            case "$tag" in
+              v[0-9]*) ;;
+              *)
+                echo "Skipping non-version tag: $tag"
+                continue
+                ;;
+            esac
             if ! grep -Fxq "$tag" "$all_release_tags"; then
               printf '%s\n' "$tag" >> "$orphan_tags"
             fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ Changelogs are automated by Release Drafter. **Version numbers must be bumped ma
    - The `published` event triggers `publish.yml`.
    - `publish.yml` reads the tag, runs `npm version "$VERSION" --allow-same-version` (no-op if Step 1 was done correctly), syncs to SKILL.md / marketplace.json again as a safety net, and runs `npm publish --provenance`.
    - Uses the `npm-publish` environment (requires `NPM_TOKEN` secret).
+   - After publishing, `.github/workflows/prune-releases.yml` automatically keeps only the latest 3 published releases and their tags. Run it manually from Actions with `workflow_dispatch` if pruning needs to be retried.
 
 ### Version resolution (label-driven)
 


### PR DESCRIPTION
## Summary

Releases and tags currently accumulate forever (7 releases / 7 tags as of this PR). Repository policy is to keep only the latest 3 published releases. This PR automates the existing manual pruning routine as a GitHub Actions workflow.

## Changes

- **`.github/workflows/prune-releases.yml`** (new): runs on `release: published` and `workflow_dispatch`.
  1. Keeps the newest `KEEP: 3` published releases (drafts and prereleases excluded); deletes older ones with their tags via `gh release delete --cleanup-tag`. The triggering release is defensively excluded from deletion.
  2. Deletes orphan `v*` tags that no remaining release (drafts included) references.
  3. Repairs the oldest surviving release's `**Full Changelog**` compare link when its base tag was just deleted, replacing it with an archive notice — so no 404 links remain.
  - No third-party actions: plain `gh` + `GITHUB_TOKEN` with `permissions: contents: write` only, `concurrency` guard, `set -euo pipefail`, idempotent early-exits, and per-item audit logging.
- **`CLAUDE.md`**: Release Guide notes that pruning is automated and can be re-run via `workflow_dispatch`.

## Verification

- `bash -n` on the extracted step script: OK.
- Read-only dry-run against the live API: selection yields keep = v2.5.3/v2.5.2/v2.5.1, delete = v2.5.0/v2.4.0/v2.3.0/v2.2.0 (matches policy). No delete/edit commands were executed.
- The changelog-repair regex matches the actual Release Drafter body format (verified against v2.5.1, whose base tag v2.5.0 will be pruned on first run).
- First real execution will be the next release's publish event; the run log lists every keep/delete decision for audit.

Closes #290