### PR TITLE
docs(udonsharp): add NetworkCallable namespace guidance

### DIFF
--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -271,6 +271,8 @@ SendCustomNetworkEvent(NetworkEventTarget.Owner, "MethodName");
 
 ## NetworkCallable (SDK 3.8.1+)
 
+Requires `using VRC.SDK3.UdonNetworkCalling;` in scripts that declare `[NetworkCallable]` methods.
+
 ```csharp
 // Method must have [NetworkCallable] attribute
 [NetworkCallable]

--- a/skills/unity-vrc-udon-sharp/assets/templates/UndoableGameManager.cs
+++ b/skills/unity-vrc-udon-sharp/assets/templates/UndoableGameManager.cs
@@ -1,6 +1,7 @@
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.UdonNetworkCalling;
 using VRC.Udon.Common.Interfaces;
 
 /// <summary>

--- a/skills/unity-vrc-udon-sharp/references/networking-bandwidth.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-bandwidth.md
@@ -343,7 +343,11 @@ For multiplayer games, the recommended design is **"only the owner modifies stat
 
 ### Code Example: Owner-Centric GameManager
 
+This example uses `[NetworkCallable]`, so full scripts need `using VRC.SDK3.UdonNetworkCalling;`.
+
 ```csharp
+using VRC.SDK3.UdonNetworkCalling;
+
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class GameManager : UdonSharpBehaviour
 {

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -728,6 +728,8 @@ public void OnButtonPressed()
 
 The `[NetworkCallable]` attribute added in **SDK 3.8.1** enables sending **up to 8 parameters** with network events.
 
+`NetworkCallableAttribute` is in the `VRC.SDK3.UdonNetworkCalling` namespace. Add `using VRC.SDK3.UdonNetworkCalling;` to full scripts that use `[NetworkCallable]`.
+
 ### [NetworkCallable] Attribute
 
 Methods callable over the network require the `[NetworkCallable]` attribute:
@@ -736,6 +738,7 @@ Methods callable over the network require the `[NetworkCallable]` attribute:
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.UdonNetworkCalling;
 using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -131,12 +131,15 @@ public class ArrayHelpers : UdonSharpBehaviour
 
 ## NetworkCallable Patterns (SDK 3.8.1+)
 
+`[NetworkCallable]` requires `using VRC.SDK3.UdonNetworkCalling;` in scripts that declare network-callable methods.
+
 ### Basic Parameterized RPC
 
 ```csharp
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
+using VRC.SDK3.UdonNetworkCalling;
 using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
@@ -167,6 +170,8 @@ public class NetworkCallableBasic : UdonSharpBehaviour
 ### Damage System with NetworkCallable
 
 ```csharp
+using VRC.SDK3.UdonNetworkCalling;
+
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class DamageReceiver : UdonSharpBehaviour
 {
@@ -231,6 +236,8 @@ public class DamageReceiver : UdonSharpBehaviour
 ### Chat System
 
 ```csharp
+using VRC.SDK3.UdonNetworkCalling;
+
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class ChatSystem : UdonSharpBehaviour
 {

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -48,9 +48,10 @@ BaseGimmick[] all = GetComponents<BaseGimmick>();   // plural form also works
 
 Before SDK 3.8.1, network events had no parameter support. Callers had to pre-load synced variables and call `RequestSerialization()` before sending an event, creating race conditions.
 
-`[NetworkCallable]` adds up to 8 typed parameters per network call, eliminating the pre-serialization pattern.
+`[NetworkCallable]` adds up to 8 typed parameters per network call, eliminating the pre-serialization pattern. The attribute lives in `VRC.SDK3.UdonNetworkCalling`.
 
 ```csharp
+using VRC.SDK3.UdonNetworkCalling;
 using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -520,6 +520,8 @@ public override void OnDeserialization()
 
 ## NetworkCallable Issues (SDK 3.8.1+)
 
+`[NetworkCallable]` requires `using VRC.SDK3.UdonNetworkCalling;`. If Unity reports `The type or namespace name 'NetworkCallable' could not be found`, add that using to the script.
+
 ### "Method 'X' is not network callable"
 
 **Symptoms:**
@@ -1749,7 +1751,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 | Heap out of memory | Reuse arrays, avoid string concat in loops |
 | Proxy issues | Reimport script, refresh component |
 | Low FPS | Disable unused Update(), cache components |
-| **NetworkCallable not working** | Add `[NetworkCallable]`, make public |
+| **NetworkCallable not working** | Add `using VRC.SDK3.UdonNetworkCalling;`, add `[NetworkCallable]`, make public |
 | **PlayerData empty** | Wait for `OnPlayerRestored` first |
 | **OnContactEnter not firing** | UdonBehaviour must be on same GameObject |
 | **Contact player is null** | Check `contactSender.isValid`, then `contactSender.usage` before accessing `contactSender.player` |

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -69,7 +69,7 @@ For longer data in Continuous mode, consider splitting across multiple fields or
 
 ## NetworkCallable (SDK 3.8.1+)
 
-Parameterized network events. Supports sending up to 8 parameters.
+Parameterized network events. Supports sending up to 8 parameters. `NetworkCallableAttribute` is in `VRC.SDK3.UdonNetworkCalling`; add `using VRC.SDK3.UdonNetworkCalling;` in scripts that declare `[NetworkCallable]` methods.
 
 ```csharp
 [NetworkCallable]

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -72,6 +72,8 @@ For longer data in Continuous mode, consider splitting across multiple fields or
 Parameterized network events. Supports sending up to 8 parameters. `NetworkCallableAttribute` is in `VRC.SDK3.UdonNetworkCalling`; add `using VRC.SDK3.UdonNetworkCalling;` in scripts that declare `[NetworkCallable]` methods.
 
 ```csharp
+using VRC.SDK3.UdonNetworkCalling;
+
 [NetworkCallable]
 public void TakeDamage(int damage, int attackerId)
 {


### PR DESCRIPTION
## 関連Issue

Closes #297

## 背景

`[NetworkCallable]` は `VRC.SDK3.UdonNetworkCalling` 名前空間にあるため、該当 using がないサンプルやテンプレートをコピーすると `The type or namespace name 'NetworkCallable' could not be found` になります。

## このPRでやったこと

- `networking.md` の NetworkCallable セクションに必要 namespace を明記し、フルサンプルへ using を追加
- `UndoableGameManager.cs` など、コピペされやすいテンプレート/フル例へ `using VRC.SDK3.UdonNetworkCalling;` を追加
- CHEATSHEET、rules、troubleshooting、関連 reference に近接注記を追加

## 影響範囲

- `skills/unity-vrc-udon-sharp` のドキュメント、ルール、テンプレートのみ
- 依存追加・実行処理変更なし

## 品質ゲート

- [x] NetworkCallable namespace 漏れ検出: `.cs` テンプレート missing 0、フル/クラス例 missing 0
- [x] `git diff --check`
- [x] Markdown fence balance check
- [x] `bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh`
- [x] `bash tests/hooks/validate-udonsharp.test.sh`（6 passed, 0 failed）
- [x] `bash tests/docs/build-validation-reference.test.sh`
- [x] `bash tests/docs/assembly-definitions-reference.test.sh`
- [x] symlink integrity check
- [x] `npm pack --dry-run`
- [x] version sync check（2.5.4）
- [x] skill-judge: A / 112
- [x] 独立レビュー: CRITICAL/HIGH/MUST 0

## スコープ外

- `SKILL.md` description への `UdonNetworkCalling` キーワード追加は今回の出荷ブロッカーではないため未対応
- Unity/C# LSP コンパイルはこの worktree に Unity 環境がないため未実行。ただし変更は using 追加と docs 注記のみ
