### PR TITLE
chore(version): bump to v2.5.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.4"
+    "version": "2.5.5"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.4"
+    version: "2.5.5"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.4"
+    version: "2.5.5"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -19,7 +19,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.4"
+    version: "2.5.5"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
## Related Issue

Refs #299

## Background

Release v2.5.5 needs the repository source-of-truth version fields bumped on `dev` before opening the `dev` → `main` release PR.

## Changes

- Bumped `package.json` to 2.5.5.
- Bumped `.claude-plugin/marketplace.json` metadata version to 2.5.5.
- Bumped the three distributed/maintenance skill frontmatter versions to 2.5.5.

## Impact

- Version metadata only.
- No runtime, documentation-content, or package file-list changes.

## Quality Gate

- [x] `git diff --check`
- [x] Version sync check for all 5 source-of-truth fields
- [x] Symlink integrity check
- [x] `bash -n skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh`
- [x] `bash tests/hooks/validate-udonsharp.test.sh` (6 passed, 0 failed)
- [x] `bash tests/docs/build-validation-reference.test.sh`
- [x] `bash tests/docs/assembly-definitions-reference.test.sh`
- [x] `npm pack --dry-run`

## Notes for Reviewers

This is the mechanical Step 1 version bump required by `CLAUDE.md` Release Guide before the release PR.
