### PR TITLE
fix(hooks): detect multiline synced arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Smoke test validate-udonsharp.sh
         run: bash tests/hooks/validate-udonsharp.test.sh
 
+      - name: Smoke test validate-udonsharp.ps1
+        shell: pwsh
+        run: ./tests/hooks/validate-udonsharp.test.ps1
 
   docs:
     name: Documentation Smoke Tests

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
@@ -36,12 +36,12 @@ if ($FilePath -notmatch '\.cs$') {
 }
 
 # Check if file exists
-if (-not (Test-Path $FilePath)) {
+if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
     Write-Output $Input
     exit 0
 }
 
-$FileContent = Get-Content -Path $FilePath -Raw
+$FileContent = Get-Content -LiteralPath $FilePath -Raw
 
 # Check if this is an UdonSharp file
 if ($FileContent -notmatch 'using UdonSharp|UdonSharpBehaviour') {
@@ -134,6 +134,12 @@ if ($SyncedCount -gt 5) {
 
 # Sync bloat: large synced arrays (int[]/float[] instead of byte[]/short[])
 function Get-BlockCommentMaskedLine([string]$Line, [ref]$InBlockComment) {
+    if (-not $InBlockComment.Value -and
+        $Line.IndexOf('//', [System.StringComparison]::Ordinal) -lt 0 -and
+        $Line.IndexOf('/*', [System.StringComparison]::Ordinal) -lt 0) {
+        return $Line
+    }
+
     $Masked = [System.Text.StringBuilder]::new($Line.Length)
     $Index = 0
 
@@ -165,8 +171,9 @@ function Get-BlockCommentMaskedLine([string]$Line, [ref]$InBlockComment) {
 }
 
 $SyncedArrayFieldPrefixPattern = '^[ \t]*(?:(?:public|private|protected|internal|static|readonly)[ \t]+)*(?:int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(?:=|,|;)'
-$UdonSyncedAttributePrefixPattern = '^[ \t]*\[UdonSynced\][ \t]*'
-$StandaloneUdonSyncedAttributePattern = '^[ \t]*\[UdonSynced\][ \t]*(?://.*)?$'
+$LeadingAttributeGroupsPattern = '^[ \t]*(?<AttributeGroups>(?:\[(?:[^\[\]\r\n]|\[\])*\][ \t]*)+)(?<Remainder>.*)$'
+$AttributeGroupPattern = '\[((?:[^\[\]\r\n]|\[\])*)\]'
+$UdonSyncedInAttributeGroupPattern = '(?:^|,)[ \t]*UdonSynced(?:Attribute)?[ \t]*(?:$|,|\()'
 $PreviousLineHasAttribute = $false
 $InBlockComment = $false
 $FoundSyncedArrayField = $false
@@ -174,6 +181,13 @@ $Reader = [System.IO.StringReader]::new($FileContent)
 
 try {
     while ($null -ne ($Line = $Reader.ReadLine())) {
+        if (-not $InBlockComment -and
+            -not $PreviousLineHasAttribute -and
+            $Line.IndexOf('/*', [System.StringComparison]::Ordinal) -lt 0 -and
+            $Line -notmatch '^[ \t]*\[') {
+            continue
+        }
+
         $MaskedLine = Get-BlockCommentMaskedLine $Line ([ref]$InBlockComment)
 
         if ($PreviousLineHasAttribute -and $MaskedLine -match $SyncedArrayFieldPrefixPattern) {
@@ -182,13 +196,22 @@ try {
         }
 
         $PreviousLineHasAttribute = $false
-        if ($MaskedLine -match $UdonSyncedAttributePrefixPattern) {
-            $Declaration = $MaskedLine -replace $UdonSyncedAttributePrefixPattern, ''
-            if ($Declaration -match $SyncedArrayFieldPrefixPattern) {
+        $AttributeLineMatch = [regex]::Match($MaskedLine, $LeadingAttributeGroupsPattern)
+        if ($AttributeLineMatch.Success) {
+            $HasUdonSyncedAttribute = $false
+            foreach ($AttributeGroupMatch in [regex]::Matches($AttributeLineMatch.Groups['AttributeGroups'].Value, $AttributeGroupPattern)) {
+                if ($AttributeGroupMatch.Groups[1].Value -match $UdonSyncedInAttributeGroupPattern) {
+                    $HasUdonSyncedAttribute = $true
+                    break
+                }
+            }
+
+            $Declaration = $AttributeLineMatch.Groups['Remainder'].Value
+            if ($HasUdonSyncedAttribute -and $Declaration -match $SyncedArrayFieldPrefixPattern) {
                 $FoundSyncedArrayField = $true
                 break
             }
-            if ($MaskedLine -match $StandaloneUdonSyncedAttributePattern) {
+            if ($HasUdonSyncedAttribute -and $Declaration -match '^(?://.*)?$') {
                 $PreviousLineHasAttribute = $true
             }
         }

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
@@ -133,11 +133,9 @@ if ($SyncedCount -gt 5) {
 }
 
 # Sync bloat: large synced arrays (int[]/float[] instead of byte[]/short[])
-if ($FileContent -match '\[UdonSynced\]') {
-    # Check for synced int[]/float[] patterns (UdonSynced on preceding line or same line)
-    if ($FileContent -match '\[UdonSynced\][^\r\n]*\b(int|float)\[\]') {
-        $Warnings += "[UdonSharp] SYNC-BLOAT: Synced int[]/float[] detected. Consider byte[] or short[] if value range allows."
-    }
+$SyncedArrayFieldPattern = '(?m)^[ \t]*\[UdonSynced\][ \t]*(?:\r?\n[ \t]*)?(?:(?:public|private|protected|internal|static|readonly)[ \t]+)*(?:int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*(?:[ \t]*=[^;\r\n]*)?[ \t]*;[ \t]*(?://[^\r\n]*)?\r?$'
+if ($FileContent -match $SyncedArrayFieldPattern) {
+    $Warnings += "[UdonSharp] SYNC-BLOAT: Synced int[]/float[] detected. Consider byte[] or short[] if value range allows."
 }
 
 # NoVariableSync + [UdonSynced] conflict

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1
@@ -133,8 +133,71 @@ if ($SyncedCount -gt 5) {
 }
 
 # Sync bloat: large synced arrays (int[]/float[] instead of byte[]/short[])
-$SyncedArrayFieldPattern = '(?m)^[ \t]*\[UdonSynced\][ \t]*(?:\r?\n[ \t]*)?(?:(?:public|private|protected|internal|static|readonly)[ \t]+)*(?:int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*(?:[ \t]*=[^;\r\n]*)?[ \t]*;[ \t]*(?://[^\r\n]*)?\r?$'
-if ($FileContent -match $SyncedArrayFieldPattern) {
+function Get-BlockCommentMaskedLine([string]$Line, [ref]$InBlockComment) {
+    $Masked = [System.Text.StringBuilder]::new($Line.Length)
+    $Index = 0
+
+    while ($Index -lt $Line.Length) {
+        $HasNextCharacter = $Index + 1 -lt $Line.Length
+        if ($InBlockComment.Value) {
+            if ($HasNextCharacter -and $Line[$Index] -eq '*' -and $Line[$Index + 1] -eq '/') {
+                [void]$Masked.Append('  ')
+                $InBlockComment.Value = $false
+                $Index += 2
+            } else {
+                [void]$Masked.Append(' ')
+                $Index++
+            }
+        } elseif ($HasNextCharacter -and $Line[$Index] -eq '/' -and $Line[$Index + 1] -eq '/') {
+            [void]$Masked.Append($Line.Substring($Index))
+            break
+        } elseif ($HasNextCharacter -and $Line[$Index] -eq '/' -and $Line[$Index + 1] -eq '*') {
+            [void]$Masked.Append('  ')
+            $InBlockComment.Value = $true
+            $Index += 2
+        } else {
+            [void]$Masked.Append($Line[$Index])
+            $Index++
+        }
+    }
+
+    return $Masked.ToString()
+}
+
+$SyncedArrayFieldPrefixPattern = '^[ \t]*(?:(?:public|private|protected|internal|static|readonly)[ \t]+)*(?:int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(?:=|,|;)'
+$UdonSyncedAttributePrefixPattern = '^[ \t]*\[UdonSynced\][ \t]*'
+$StandaloneUdonSyncedAttributePattern = '^[ \t]*\[UdonSynced\][ \t]*(?://.*)?$'
+$PreviousLineHasAttribute = $false
+$InBlockComment = $false
+$FoundSyncedArrayField = $false
+$Reader = [System.IO.StringReader]::new($FileContent)
+
+try {
+    while ($null -ne ($Line = $Reader.ReadLine())) {
+        $MaskedLine = Get-BlockCommentMaskedLine $Line ([ref]$InBlockComment)
+
+        if ($PreviousLineHasAttribute -and $MaskedLine -match $SyncedArrayFieldPrefixPattern) {
+            $FoundSyncedArrayField = $true
+            break
+        }
+
+        $PreviousLineHasAttribute = $false
+        if ($MaskedLine -match $UdonSyncedAttributePrefixPattern) {
+            $Declaration = $MaskedLine -replace $UdonSyncedAttributePrefixPattern, ''
+            if ($Declaration -match $SyncedArrayFieldPrefixPattern) {
+                $FoundSyncedArrayField = $true
+                break
+            }
+            if ($MaskedLine -match $StandaloneUdonSyncedAttributePattern) {
+                $PreviousLineHasAttribute = $true
+            }
+        }
+    }
+} finally {
+    $Reader.Dispose()
+}
+
+if ($FoundSyncedArrayField) {
     $Warnings += "[UdonSharp] SYNC-BLOAT: Synced int[]/float[] detected. Consider byte[] or short[] if value range allows."
 }
 

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
@@ -166,6 +166,46 @@ if awk '
         return line ~ /^[ \t]*((public|private|protected|internal|static|readonly)[ \t]+)*(int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(=|,|;)/
     }
 
+    function find_attribute_group_end(text,    character, position) {
+        position = 2
+        while (position <= length(text)) {
+            if (substr(text, position, 2) == "[]") {
+                position += 2
+                continue
+            }
+
+            character = substr(text, position, 1)
+            if (character == "]") return position
+            position++
+        }
+
+        return 0
+    }
+
+    function parse_leading_attribute_groups(line,    closing_bracket, content, rest) {
+        attribute_group_count = 0
+        attribute_has_udon_synced = 0
+        rest = line
+        sub(/^[ \t]*/, "", rest)
+
+        while (substr(rest, 1, 1) == "[") {
+            closing_bracket = find_attribute_group_end(rest)
+            if (closing_bracket == 0) break
+
+            content = substr(rest, 2, closing_bracket - 2)
+            if (content ~ /(^|,)[ \t]*UdonSynced(Attribute)?[ \t]*($|,|[(])/) {
+                attribute_has_udon_synced = 1
+            }
+
+            attribute_group_count++
+            rest = substr(rest, closing_bracket + 1)
+            sub(/^[ \t]*/, "", rest)
+        }
+
+        attribute_remainder = rest
+        return attribute_group_count
+    }
+
     {
         line = $0
         sub(/\r$/, "", line)
@@ -177,14 +217,12 @@ if awk '
         }
 
         previous_line_has_attribute = 0
-        if (line ~ /^[ \t]*\[UdonSynced\]/) {
-            declaration = line
-            sub(/^[ \t]*\[UdonSynced\][ \t]*/, "", declaration)
-            if (is_synced_array_field_prefix(declaration)) {
+        if (parse_leading_attribute_groups(line) && attribute_has_udon_synced) {
+            if (is_synced_array_field_prefix(attribute_remainder)) {
                 found = 1
                 exit
             }
-            if (line ~ /^[ \t]*\[UdonSynced\][ \t]*(\/\/.*)?$/) {
+            if (attribute_remainder ~ /^(\/\/.*)?$/) {
                 previous_line_has_attribute = 1
             }
         }

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
@@ -134,19 +134,59 @@ fi
 
 # Sync bloat: large synced arrays (int[]/float[] instead of byte[]/short[])
 if awk '
-    function is_synced_array_field(line) {
-        return line ~ /^[ \t]*((public|private|protected|internal|static|readonly)[ \t]+)*(int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*([ \t]*=[^;]*)?[ \t]*;[ \t]*(\/\/.*)?$/
+    function mask_block_comments(line,    masked, position, pair) {
+        masked = ""
+        position = 1
+        while (position <= length(line)) {
+            pair = substr(line, position, 2)
+            if (in_block_comment) {
+                if (pair == "*/") {
+                    masked = masked "  "
+                    in_block_comment = 0
+                    position += 2
+                } else {
+                    masked = masked " "
+                    position++
+                }
+            } else if (pair == "//") {
+                return masked substr(line, position)
+            } else if (pair == "/*") {
+                masked = masked "  "
+                in_block_comment = 1
+                position += 2
+            } else {
+                masked = masked substr(line, position, 1)
+                position++
+            }
+        }
+        return masked
     }
 
-    previous_line_has_attribute && is_synced_array_field($0) { found = 1; exit }
+    function is_synced_array_field_prefix(line) {
+        return line ~ /^[ \t]*((public|private|protected|internal|static|readonly)[ \t]+)*(int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(=|,|;)/
+    }
 
     {
+        line = $0
+        sub(/\r$/, "", line)
+        line = mask_block_comments(line)
+
+        if (previous_line_has_attribute && is_synced_array_field_prefix(line)) {
+            found = 1
+            exit
+        }
+
         previous_line_has_attribute = 0
-        if ($0 ~ /^[ \t]*\[UdonSynced\]/) {
-            declaration = $0
+        if (line ~ /^[ \t]*\[UdonSynced\]/) {
+            declaration = line
             sub(/^[ \t]*\[UdonSynced\][ \t]*/, "", declaration)
-            if (is_synced_array_field(declaration)) { found = 1; exit }
-            if (declaration ~ /^[ \t]*$/) previous_line_has_attribute = 1
+            if (is_synced_array_field_prefix(declaration)) {
+                found = 1
+                exit
+            }
+            if (line ~ /^[ \t]*\[UdonSynced\][ \t]*(\/\/.*)?$/) {
+                previous_line_has_attribute = 1
+            }
         }
     }
 

--- a/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
+++ b/skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.sh
@@ -133,12 +133,26 @@ if [[ "$synced_count" -gt 5 ]]; then
 fi
 
 # Sync bloat: large synced arrays (int[]/float[] instead of byte[]/short[])
-if grep -qE '\[UdonSynced\]' "$file_path" && \
-    grep -qE '(int|float)\[\]' "$file_path"; then
-    # Check if the array declaration is near [UdonSynced]
-    if grep -B1 '(int|float)\[\]' "$file_path" | grep -qE '\[UdonSynced\]'; then
-        warnings+=("[UdonSharp] SYNC-BLOAT: Synced int[]/float[] detected. Consider byte[] or short[] if value range allows.")
-    fi
+if awk '
+    function is_synced_array_field(line) {
+        return line ~ /^[ \t]*((public|private|protected|internal|static|readonly)[ \t]+)*(int|float)[ \t]*\[\][ \t]+[A-Za-z_][A-Za-z0-9_]*([ \t]*=[^;]*)?[ \t]*;[ \t]*(\/\/.*)?$/
+    }
+
+    previous_line_has_attribute && is_synced_array_field($0) { found = 1; exit }
+
+    {
+        previous_line_has_attribute = 0
+        if ($0 ~ /^[ \t]*\[UdonSynced\]/) {
+            declaration = $0
+            sub(/^[ \t]*\[UdonSynced\][ \t]*/, "", declaration)
+            if (is_synced_array_field(declaration)) { found = 1; exit }
+            if (declaration ~ /^[ \t]*$/) previous_line_has_attribute = 1
+        }
+    }
+
+    END { exit found ? 0 : 1 }
+' "$file_path"; then
+    warnings+=("[UdonSharp] SYNC-BLOAT: Synced int[]/float[] detected. Consider byte[] or short[] if value range allows.")
 fi
 
 # NoVariableSync + [UdonSynced] conflict

--- a/tests/hooks/validate-udonsharp.test.ps1
+++ b/tests/hooks/validate-udonsharp.test.ps1
@@ -40,14 +40,19 @@ function Assert-NotContains([string]$Label, [string]$Actual, [string]$Unexpected
 
 try {
     $Cases = @(
-        @{ Label = 'same-line int[]'; Declaration = '[UdonSynced] private int[] values;' },
-        @{ Label = 'preceding-line int[]'; Declaration = "[UdonSynced]`n    private int[] values;" },
-        @{ Label = 'same-line float[]'; Declaration = '[UdonSynced] private float[] values;' },
-        @{ Label = 'preceding-line float[]'; Declaration = "[UdonSynced]`n    private float[] values;" }
+        @{ Label = 'same-line int[]'; Declaration = '[UdonSynced] private int[] values;'; NewLine = "`n" },
+        @{ Label = 'preceding-line int[]'; Declaration = "[UdonSynced]`n    private int[] values;"; NewLine = "`n" },
+        @{ Label = 'same-line float[]'; Declaration = '[UdonSynced] private float[] values;'; NewLine = "`n" },
+        @{ Label = 'preceding-line float[]'; Declaration = "[UdonSynced]`n    private float[] values;"; NewLine = "`n" },
+        @{ Label = 'CRLF same-line declaration'; Declaration = '[UdonSynced] private int[] values;'; NewLine = "`r`n" },
+        @{ Label = 'CRLF preceding-line declaration'; Declaration = "[UdonSynced]`r`n    private float[] values;"; NewLine = "`r`n" },
+        @{ Label = 'multiline initializer'; Declaration = "[UdonSynced] private int[] values =`n        new int[]`n        {`n            1,`n            2`n        };"; NewLine = "`n" },
+        @{ Label = 'attribute with trailing line comment'; Declaration = "[UdonSynced] // Applies to the immediately following physical line.`n    private float[] values;"; NewLine = "`n" },
+        @{ Label = 'multiple declarators'; Declaration = '[UdonSynced] private int[] values, previousValues;'; NewLine = "`n" }
     )
 
     foreach ($Case in $Cases) {
-        $Source = "using UdonSharp;`npublic class Sample : UdonSharpBehaviour`n{`n    $($Case.Declaration)`n}"
+        $Source = "using UdonSharp;$($Case.NewLine)public class Sample : UdonSharpBehaviour$($Case.NewLine){$($Case.NewLine)    $($Case.Declaration)$($Case.NewLine)}"
         Assert-Contains $Case.Label (Invoke-Hook $Source) $SyncBloatWarning
     }
 
@@ -61,6 +66,40 @@ public class Sample : UdonSharpBehaviour
 }
 '@
     Assert-NotContains 'unsynced int[]/float[]' (Invoke-Hook $UnsyncedSource) $SyncBloatWarning
+
+    $CommentedSameLineSource = @'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    /*
+    [UdonSynced] private int[] values;
+    */
+}
+'@
+    Assert-NotContains 'same-line declaration in block comment' (Invoke-Hook $CommentedSameLineSource) $SyncBloatWarning
+
+    $CommentedPrecedingLineSource = @'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    /*
+    [UdonSynced]
+    private float[] values;
+    */
+}
+'@
+    Assert-NotContains 'preceding-line declaration in block comment' (Invoke-Hook $CommentedPrecedingLineSource) $SyncBloatWarning
+
+    $SeparatedAttributeSource = @'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] // The blank line consumes the attribute association.
+
+    private int[] values;
+}
+'@
+    Assert-NotContains 'attribute does not skip a physical line' (Invoke-Hook $SeparatedAttributeSource) $SyncBloatWarning
 
     Write-Output ""
     Write-Output "Summary: $Passed passed, $Failed failed"

--- a/tests/hooks/validate-udonsharp.test.ps1
+++ b/tests/hooks/validate-udonsharp.test.ps1
@@ -11,9 +11,12 @@ $Failed = 0
 
 New-Item -ItemType Directory -Path $TempRoot | Out-Null
 
-function Invoke-Hook([string]$Source) {
-    $FilePath = Join-Path $TempRoot (([guid]::NewGuid().ToString()) + ".cs")
-    Set-Content -Path $FilePath -Value $Source
+function Invoke-Hook([string]$Source, [string]$LeafName = $null) {
+    if (-not $LeafName) {
+        $LeafName = ([guid]::NewGuid().ToString()) + ".cs"
+    }
+    $FilePath = Join-Path $TempRoot $LeafName
+    Set-Content -LiteralPath $FilePath -Value $Source
     $Payload = @{ tool_input = @{ file_path = $FilePath } } | ConvertTo-Json -Compress
     return $Payload | & $Hook 2>&1 | Out-String
 }
@@ -48,12 +51,18 @@ try {
         @{ Label = 'CRLF preceding-line declaration'; Declaration = "[UdonSynced]`r`n    private float[] values;"; NewLine = "`r`n" },
         @{ Label = 'multiline initializer'; Declaration = "[UdonSynced] private int[] values =`n        new int[]`n        {`n            1,`n            2`n        };"; NewLine = "`n" },
         @{ Label = 'attribute with trailing line comment'; Declaration = "[UdonSynced] // Applies to the immediately following physical line.`n    private float[] values;"; NewLine = "`n" },
-        @{ Label = 'multiple declarators'; Declaration = '[UdonSynced] private int[] values, previousValues;'; NewLine = "`n" }
+        @{ Label = 'multiple declarators'; Declaration = '[UdonSynced] private int[] values, previousValues;'; NewLine = "`n" },
+        @{ Label = 'combined attributes on same line'; Declaration = '[UdonSynced, FieldChangeCallback(nameof(Values))] private int[] values;'; NewLine = "`n" },
+        @{ Label = 'combined attributes on preceding line'; Declaration = "[UdonSynced, FieldChangeCallback(nameof(Values))]`n    private float[] values;"; NewLine = "`n" },
+        @{ Label = 'chained attributes on same line'; Declaration = '[UdonSynced][FieldChangeCallback(nameof(Values))] private float[] values;'; NewLine = "`n" },
+        @{ Label = 'chained attributes on preceding line'; Declaration = "[UdonSynced][FieldChangeCallback(nameof(Values))]`n    private int[] values;"; NewLine = "`n" },
+        @{ Label = 'array type inside combined attribute group'; Declaration = '[UdonSynced, Example(typeof(int[]))] private float[] values;'; NewLine = "`n" },
+        @{ Label = 'literal bracket path'; Declaration = '[UdonSynced] private int[] values;'; NewLine = "`n"; LeafName = 'Bracket[1].cs' }
     )
 
     foreach ($Case in $Cases) {
         $Source = "using UdonSharp;$($Case.NewLine)public class Sample : UdonSharpBehaviour$($Case.NewLine){$($Case.NewLine)    $($Case.Declaration)$($Case.NewLine)}"
-        Assert-Contains $Case.Label (Invoke-Hook $Source) $SyncBloatWarning
+        Assert-Contains $Case.Label (Invoke-Hook $Source $Case.LeafName) $SyncBloatWarning
     }
 
     $UnsyncedSource = @'
@@ -66,6 +75,16 @@ public class Sample : UdonSharpBehaviour
 }
 '@
     Assert-NotContains 'unsynced int[]/float[]' (Invoke-Hook $UnsyncedSource) $SyncBloatWarning
+
+    $UnrelatedAttributeSource = @'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [FieldChangeCallback(nameof(Values))]
+    private int[] values;
+}
+'@
+    Assert-NotContains 'FieldChangeCallback-only field' (Invoke-Hook $UnrelatedAttributeSource) $SyncBloatWarning
 
     $CommentedSameLineSource = @'
 using UdonSharp;

--- a/tests/hooks/validate-udonsharp.test.ps1
+++ b/tests/hooks/validate-udonsharp.test.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 5.1
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$Hook = Join-Path $RepoRoot "skills/unity-vrc-udon-sharp/hooks/validate-udonsharp.ps1"
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("validate-udonsharp-" + [guid]::NewGuid())
+$SyncBloatWarning = 'Synced int[]/float[] detected'
+$Passed = 0
+$Failed = 0
+
+New-Item -ItemType Directory -Path $TempRoot | Out-Null
+
+function Invoke-Hook([string]$Source) {
+    $FilePath = Join-Path $TempRoot (([guid]::NewGuid().ToString()) + ".cs")
+    Set-Content -Path $FilePath -Value $Source
+    $Payload = @{ tool_input = @{ file_path = $FilePath } } | ConvertTo-Json -Compress
+    return $Payload | & $Hook 2>&1 | Out-String
+}
+
+function Assert-Contains([string]$Label, [string]$Actual, [string]$Expected) {
+    if ($Actual.Contains($Expected)) {
+        Write-Output "PASS [$Label] contains: $Expected"
+        $script:Passed++
+    } else {
+        Write-Output "FAIL [$Label] missing: $Expected"
+        $script:Failed++
+    }
+}
+
+function Assert-NotContains([string]$Label, [string]$Actual, [string]$Unexpected) {
+    if ($Actual.Contains($Unexpected)) {
+        Write-Output "FAIL [$Label] unexpected: $Unexpected"
+        $script:Failed++
+    } else {
+        Write-Output "PASS [$Label] does not contain: $Unexpected"
+        $script:Passed++
+    }
+}
+
+try {
+    $Cases = @(
+        @{ Label = 'same-line int[]'; Declaration = '[UdonSynced] private int[] values;' },
+        @{ Label = 'preceding-line int[]'; Declaration = "[UdonSynced]`n    private int[] values;" },
+        @{ Label = 'same-line float[]'; Declaration = '[UdonSynced] private float[] values;' },
+        @{ Label = 'preceding-line float[]'; Declaration = "[UdonSynced]`n    private float[] values;" }
+    )
+
+    foreach ($Case in $Cases) {
+        $Source = "using UdonSharp;`npublic class Sample : UdonSharpBehaviour`n{`n    $($Case.Declaration)`n}"
+        Assert-Contains $Case.Label (Invoke-Hook $Source) $SyncBloatWarning
+    }
+
+    $UnsyncedSource = @'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] private byte[] compactValues;
+    private int[] integerValues;
+    private float[] floatValues;
+}
+'@
+    Assert-NotContains 'unsynced int[]/float[]' (Invoke-Hook $UnsyncedSource) $SyncBloatWarning
+
+    Write-Output ""
+    Write-Output "Summary: $Passed passed, $Failed failed"
+    if ($Failed -ne 0) {
+        exit 1
+    }
+} finally {
+    Remove-Item -Path $TempRoot -Recurse -Force
+}

--- a/tests/hooks/validate-udonsharp.test.sh
+++ b/tests/hooks/validate-udonsharp.test.sh
@@ -6,6 +6,7 @@
 #   Case C: jq present, valid .cs with List<T> → existing WARNING on stderr (happy path)
 #   Cases D-H: synced array detection regressions from Issue #307
 #   Cases I-P: field forms, CRLF, and block-comment review regressions
+#   Cases Q-V: combined/chained attribute-group regressions
 
 set -uo pipefail
 
@@ -296,6 +297,60 @@ CSEOF
 run_hook "$CASE_P_FILE" "$TMPROOT/case_P.err"
 P_STDERR=$(cat "$TMPROOT/case_P.err")
 assert_not_contains "P: attribute does not skip a physical line" "$P_STDERR" "$SYNC_BLOAT_WARNING"
+
+# ------------------------------------------------------------
+# Cases Q-V: UdonSynced may share or precede other attribute groups, but an
+# unrelated attribute group must not mark the field as synced.
+# ------------------------------------------------------------
+for case_spec in \
+    "Q:combined attributes on same line:[UdonSynced, FieldChangeCallback(nameof(Values))] private int[] values;" \
+    "R:combined attributes on preceding line:[UdonSynced, FieldChangeCallback(nameof(Values))]|    private float[] values;" \
+    "S:chained attributes on same line:[UdonSynced][FieldChangeCallback(nameof(Values))] private float[] values;" \
+    "T:chained attributes on preceding line:[UdonSynced][FieldChangeCallback(nameof(Values))]|    private int[] values;"
+do
+    case_id=${case_spec%%:*}
+    remainder=${case_spec#*:}
+    case_label=${remainder%%:*}
+    declaration=${remainder#*:}
+    case_file="$TMPROOT/case_${case_id}.cs"
+
+    {
+        echo 'using UdonSharp;'
+        echo 'public class Sample : UdonSharpBehaviour'
+        echo '{'
+        printf '    %s\n' "$declaration" | tr '|' '\n'
+        echo '}'
+    } > "$case_file"
+
+    run_hook "$case_file" "$TMPROOT/case_${case_id}.err"
+    case_stderr=$(cat "$TMPROOT/case_${case_id}.err")
+    assert_contains "$case_id: $case_label warns" "$case_stderr" "$SYNC_BLOAT_WARNING"
+done
+
+CASE_U_FILE="$TMPROOT/case_U.cs"
+cat > "$CASE_U_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [FieldChangeCallback(nameof(Values))]
+    private int[] values;
+}
+CSEOF
+run_hook "$CASE_U_FILE" "$TMPROOT/case_U.err"
+U_STDERR=$(cat "$TMPROOT/case_U.err")
+assert_not_contains "U: FieldChangeCallback-only field does not warn" "$U_STDERR" "$SYNC_BLOAT_WARNING"
+
+CASE_V_FILE="$TMPROOT/case_V.cs"
+cat > "$CASE_V_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced, Example(typeof(int[]))] private float[] values;
+}
+CSEOF
+run_hook "$CASE_V_FILE" "$TMPROOT/case_V.err"
+V_STDERR=$(cat "$TMPROOT/case_V.err")
+assert_contains "V: array type inside combined attribute group warns" "$V_STDERR" "$SYNC_BLOAT_WARNING"
 
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"

--- a/tests/hooks/validate-udonsharp.test.sh
+++ b/tests/hooks/validate-udonsharp.test.sh
@@ -4,6 +4,7 @@
 #   Case A: jq absent  → must exit 0 with stdout = input passthrough
 #   Case B: jq present, file_path missing → must exit 0 cleanly (no abort)
 #   Case C: jq present, valid .cs with List<T> → existing WARNING on stderr (happy path)
+#   Cases D-H: synced array detection regressions from Issue #307
 
 set -uo pipefail
 
@@ -36,6 +37,25 @@ assert_contains() {
         echo "  haystack (truncated): $(printf '%s' "$haystack" | head -c 200)"
         FAIL=$((FAIL + 1))
     fi
+}
+
+assert_not_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "FAIL [$label] unexpected: $needle"
+        echo "  haystack (truncated): $(printf '%s' "$haystack" | head -c 200)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS [$label] does not contain: $needle"
+        PASS=$((PASS + 1))
+    fi
+}
+
+run_hook() {
+    local file_path="$1" stderr_path="$2"
+    local hook_input
+    hook_input="{\"tool_input\":{\"file_path\":\"$file_path\"}}"
+    printf '%s' "$hook_input" | "$HOOK" 2>"$stderr_path" >/dev/null
 }
 
 # ------------------------------------------------------------
@@ -110,6 +130,53 @@ C_STDERR=$(cat "$TMPROOT/case_c.err")
 
 assert_exit "C: happy path → exit 0" 0 "$C_RC"
 assert_contains "C: List<T> WARNING fires" "$C_STDERR" 'Generic collections (List<T>'
+
+# ------------------------------------------------------------
+# Cases D-G: synced int[]/float[] on the same or immediately preceding line
+# ------------------------------------------------------------
+SYNC_BLOAT_WARNING='Synced int[]/float[] detected'
+
+for case_spec in \
+    "D:same-line int[]:[UdonSynced] private int[] values;" \
+    "E:preceding-line int[]:[UdonSynced]|    private int[] values;" \
+    "F:same-line float[]:[UdonSynced] private float[] values;" \
+    "G:preceding-line float[]:[UdonSynced]|    private float[] values;"
+do
+    case_id=${case_spec%%:*}
+    remainder=${case_spec#*:}
+    case_label=${remainder%%:*}
+    declaration=${remainder#*:}
+    case_file="$TMPROOT/case_${case_id}.cs"
+
+    {
+        echo 'using UdonSharp;'
+        echo 'public class Sample : UdonSharpBehaviour'
+        echo '{'
+        printf '    %s\n' "$declaration" | tr '|' '\n'
+        echo '}'
+    } > "$case_file"
+
+    run_hook "$case_file" "$TMPROOT/case_${case_id}.err"
+    case_stderr=$(cat "$TMPROOT/case_${case_id}.err")
+    assert_contains "$case_id: $case_label warns" "$case_stderr" "$SYNC_BLOAT_WARNING"
+done
+
+# ------------------------------------------------------------
+# Case H: ordinary unsynced arrays must not emit the sync-bloat warning
+# ------------------------------------------------------------
+CASE_H_FILE="$TMPROOT/case_H.cs"
+cat > "$CASE_H_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] private byte[] compactValues;
+    private int[] integerValues;
+    private float[] floatValues;
+}
+CSEOF
+run_hook "$CASE_H_FILE" "$TMPROOT/case_H.err"
+H_STDERR=$(cat "$TMPROOT/case_H.err")
+assert_not_contains "H: unsynced int[]/float[] do not warn" "$H_STDERR" "$SYNC_BLOAT_WARNING"
 
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"

--- a/tests/hooks/validate-udonsharp.test.sh
+++ b/tests/hooks/validate-udonsharp.test.sh
@@ -5,6 +5,7 @@
 #   Case B: jq present, file_path missing → must exit 0 cleanly (no abort)
 #   Case C: jq present, valid .cs with List<T> → existing WARNING on stderr (happy path)
 #   Cases D-H: synced array detection regressions from Issue #307
+#   Cases I-P: field forms, CRLF, and block-comment review regressions
 
 set -uo pipefail
 
@@ -177,6 +178,124 @@ CSEOF
 run_hook "$CASE_H_FILE" "$TMPROOT/case_H.err"
 H_STDERR=$(cat "$TMPROOT/case_H.err")
 assert_not_contains "H: unsynced int[]/float[] do not warn" "$H_STDERR" "$SYNC_BLOAT_WARNING"
+
+# ------------------------------------------------------------
+# Cases I-J: CRLF input must match same-line and preceding-line declarations
+# ------------------------------------------------------------
+CASE_I_FILE="$TMPROOT/case_I.cs"
+printf '%s\r\n' \
+    'using UdonSharp;' \
+    'public class Sample : UdonSharpBehaviour' \
+    '{' \
+    '    [UdonSynced] private int[] values;' \
+    '}' > "$CASE_I_FILE"
+run_hook "$CASE_I_FILE" "$TMPROOT/case_I.err"
+I_STDERR=$(cat "$TMPROOT/case_I.err")
+assert_contains "I: CRLF same-line declaration warns" "$I_STDERR" "$SYNC_BLOAT_WARNING"
+
+CASE_J_FILE="$TMPROOT/case_J.cs"
+printf '%s\r\n' \
+    'using UdonSharp;' \
+    'public class Sample : UdonSharpBehaviour' \
+    '{' \
+    '    [UdonSynced]' \
+    '    private float[] values;' \
+    '}' > "$CASE_J_FILE"
+run_hook "$CASE_J_FILE" "$TMPROOT/case_J.err"
+J_STDERR=$(cat "$TMPROOT/case_J.err")
+assert_contains "J: CRLF preceding-line declaration warns" "$J_STDERR" "$SYNC_BLOAT_WARNING"
+
+# ------------------------------------------------------------
+# Cases K-M: valid declaration prefixes need not end on the first line
+# ------------------------------------------------------------
+CASE_K_FILE="$TMPROOT/case_K.cs"
+cat > "$CASE_K_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] private int[] values =
+        new int[]
+        {
+            1,
+            2
+        };
+}
+CSEOF
+run_hook "$CASE_K_FILE" "$TMPROOT/case_K.err"
+K_STDERR=$(cat "$TMPROOT/case_K.err")
+assert_contains "K: multiline initializer warns" "$K_STDERR" "$SYNC_BLOAT_WARNING"
+
+CASE_L_FILE="$TMPROOT/case_L.cs"
+cat > "$CASE_L_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] // Applies to the immediately following physical line.
+    private float[] values;
+}
+CSEOF
+run_hook "$CASE_L_FILE" "$TMPROOT/case_L.err"
+L_STDERR=$(cat "$TMPROOT/case_L.err")
+assert_contains "L: attribute with trailing line comment warns" "$L_STDERR" "$SYNC_BLOAT_WARNING"
+
+CASE_M_FILE="$TMPROOT/case_M.cs"
+cat > "$CASE_M_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] private int[] values, previousValues;
+}
+CSEOF
+run_hook "$CASE_M_FILE" "$TMPROOT/case_M.err"
+M_STDERR=$(cat "$TMPROOT/case_M.err")
+assert_contains "M: multiple declarators warn" "$M_STDERR" "$SYNC_BLOAT_WARNING"
+
+# ------------------------------------------------------------
+# Cases N-P: block comments do not contain declarations for this rule, and
+# an attribute applies to exactly the immediately following physical line.
+# ------------------------------------------------------------
+CASE_N_FILE="$TMPROOT/case_N.cs"
+cat > "$CASE_N_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    /*
+    [UdonSynced] private int[] values;
+    */
+}
+CSEOF
+run_hook "$CASE_N_FILE" "$TMPROOT/case_N.err"
+N_STDERR=$(cat "$TMPROOT/case_N.err")
+assert_not_contains "N: same-line declaration in block comment does not warn" "$N_STDERR" "$SYNC_BLOAT_WARNING"
+
+CASE_O_FILE="$TMPROOT/case_O.cs"
+cat > "$CASE_O_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    /*
+    [UdonSynced]
+    private float[] values;
+    */
+}
+CSEOF
+run_hook "$CASE_O_FILE" "$TMPROOT/case_O.err"
+O_STDERR=$(cat "$TMPROOT/case_O.err")
+assert_not_contains "O: preceding-line declaration in block comment does not warn" "$O_STDERR" "$SYNC_BLOAT_WARNING"
+
+CASE_P_FILE="$TMPROOT/case_P.cs"
+cat > "$CASE_P_FILE" <<'CSEOF'
+using UdonSharp;
+public class Sample : UdonSharpBehaviour
+{
+    [UdonSynced] // The blank line consumes the attribute association.
+
+    private int[] values;
+}
+CSEOF
+run_hook "$CASE_P_FILE" "$TMPROOT/case_P.err"
+P_STDERR=$(cat "$TMPROOT/case_P.err")
+assert_not_contains "P: attribute does not skip a physical line" "$P_STDERR" "$SYNC_BLOAT_WARNING"
 
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Related issue

Closes #307

## Why this is needed

The sync-bloat warning missed the common form where `[UdonSynced]` appears on the physical line before an `int[]` or `float[]` field. The two platform hooks also needed matching behavior and regression coverage.

## What changed

- Detect same-line and immediately preceding-line synced `int[]` and `float[]` fields.
- Cover LF and CRLF input, multiline initializers, trailing line comments, multiple declarators, combined attribute groups, and chained attribute groups.
- Keep unsynced arrays, unrelated attributes, block-commented declarations, and attributes separated by a physical line from producing this warning.
- Add a PowerShell real-hook suite to CI so both implementations run against the same behavior.
- Use `-LiteralPath` in the PowerShell hook; the suite verifies a file named `Bracket[1].cs` so wildcard characters are treated literally.

## Validation and performance

- Bash syntax: hook and test suite pass.
- Bash real-hook suite: 25/25 passed in 1.58 seconds.
- PowerShell real-hook suite in Docker: 20/20 passed in 3.79 seconds, including container startup.
- Documentation smoke tests: both pass.
- Package dry run: 73 files, 335.1 kB package, 1.2 MB unpacked.
- Version consistency: every published surface matches 2.5.5.
- `git diff --check`: clean.

## Scope and known limitations

Detection remains intentionally heuristic. Rare attribute-target or nested-argument syntax may not be classified perfectly, and comment delimiters inside C# literals can affect comment stripping. These low-severity cases are accepted for this fix and are not redesigned here.

## Quality gate

- [x] Independent final review: CRITICAL 0, HIGH 0, MEDIUM 0, MUST 0
- [x] Bash syntax
- [x] Bash real-hook suite
- [x] PowerShell real-hook suite
- [x] Documentation smoke tests
- [x] Package dry run
- [x] Version consistency
