### PR TITLE
chore(version): bump to v3.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.5.5"
+    "version": "2.6.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "2.6.0"
+    "version": "3.0.0"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.5"
+    version: "2.6.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.6.0"
+    version: "3.0.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "2.5.5",
+  "version": "2.6.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.5"
+    version: "2.6.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.6.0"
+    version: "3.0.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.5.5"
+    version: "2.6.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "2.6.0"
+    version: "3.0.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
## Summary

Synchronize the five package version fields for the public v3.0.0 release. This PR changes only the version values in the five listed files and keeps the Layer documentation and all other functionality unchanged.

### Changed files

- `package.json`
- `skills/unity-vrc-udon-sharp/SKILL.md`
- `skills/unity-vrc-world-sdk-3/SKILL.md`
- `.claude/skills/unity-vrc-skills-renovator/SKILL.md`
- `.claude-plugin/marketplace.json`

## 概要

公開 v3.0.0 に向けて、5ファイルのバージョン値を `2.5.5` から `3.0.0` に同期しました。Layer の記述やその他の機能は変更していません。

## Verification / 検証

- Version Sync: PASS（5つの値が `3.0.0` で一致）
- `quick_validate.py`（`unity-vrc-udon-sharp`）: PASS
- `quick_validate.py`（`unity-vrc-world-sdk-3`）: PASS
- `npm pack --dry-run`: PASS（`skills/`、`templates/`、`LICENSE`、`README.md` を確認）
- `git diff --check`: PASS
- symlink 検査: PASS（なし）
- `origin/dev...HEAD` の差分: 指定5ファイルの版番号置換のみ

Closes #321
