### PR TITLE
fix(world-sdk): update Steam Audio section to shipped default

### DIFF
--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -212,41 +212,50 @@ public class VoiceZone : UdonSharpBehaviour
 
 ## Steam Audio Integration
 
-> **Status**: Open Beta since March 2025. Not yet the default audio system.
+> **Status**: Shipped default. Steam Audio replaced ONSP as the spatializer for every player on every platform in
+> VRChat client release **2025.4.2** ([December 3, 2025, Build 1768](https://docs.vrchat.com/docs/vrchat-202542)).
+> This is a client version, not an SDK version — no SDK upgrade is involved.
 
-### ONSP → Steam Audio Transition
+### Steam Audio Replaced ONSP
 
-VRChat is migrating its spatial audio backend from **ONSP (Oculus Native Spatializer Plugin)** to **Steam Audio (Valve/Improbable)**.
+VRChat's spatial audio backend is **Steam Audio** (Valve). It replaced **ONSP (Oculus Native Spatializer Plugin)**,
+ending the open beta that ran from March 2025. There is no client toggle and no world descriptor setting: Steam Audio
+is always active, on PC and Android alike.
 
-| Aspect | ONSP (current default) | Steam Audio (Open Beta) |
-|--------|----------------------|-------------------------|
-| Spatializer | HRTF-based (Oculus) | HRTF-based (Steam Audio) |
-| Reverb | Basic | Room acoustics (future) |
-| Occlusion | None | Physics-based (future) |
-| Opt-in | — | World descriptor setting |
+| Aspect | Current behavior |
+|--------|------------------|
+| Spatializer | Steam Audio, all platforms |
+| Creator opt-in / opt-out | None; always active |
+| `VRC_SpatialAudioSource` semantics | Unchanged (Gain / Near / Far / Volumetric Radius) |
+| Room reverb | Not exposed to world creators |
+| Physics-based occlusion | Not exposed to world creators |
+| Legacy `ONSPAudioSource` components | Deprecated; the Build Panel converts them to `VRC_SpatialAudioSource` |
 
-The initial Steam Audio release is designed to **match ONSP behavior**. Advanced features (room reverb, occlusion) are not yet available to world creators and will come in later releases.
+The switch was engineered to match ONSP behavior rather than change it, so **no world required migration work**.
+VRChat does caution that things "sound a little different" than under ONSP — the two backends are not
+sample-identical, so a world tuned by ear under ONSP is worth a listening pass.
 
-### What Changes for World Creators
+Advanced Steam Audio capabilities such as room acoustics and physics-based occlusion are **not available to world
+creators**. VRChat describes them as options the switch makes possible in the future, not shipped features.
 
-For the initial release, behavior is intentionally preserved:
+### What This Means for World Creators
 
 ```text
-Initial Steam Audio release:
-├── Same Near/Far attenuation curves as ONSP
+Since client 2025.4.2:
 ├── Same VRC_SpatialAudioSource property semantics
-├── Same Gain/Volumetric Radius behavior
-└── No new required configuration
+├── Same Gain / Near / Far / Volumetric Radius behavior
+├── No new required configuration
+└── No spatializer choice to make — Steam Audio is the only backend
 ```
 
-When Steam Audio becomes the default, existing worlds should continue to work without modification. The transition is designed to be transparent.
+Worlds built and tuned under ONSP continue to work without modification.
 
 ### Current Udon Audio APIs
 
-All existing player voice APIs remain compatible under Steam Audio. These are the APIs to use for dynamic voice zone control:
+All player voice APIs are unchanged under Steam Audio. These are the APIs to use for dynamic voice zone control:
 
 ```csharp
-// VRCPlayerApi voice control — compatible with both ONSP and Steam Audio
+// VRCPlayerApi voice control
 player.SetVoiceGain(float gain);              // 0-24 dB, default 15
 player.SetVoiceDistanceNear(float distance);  // Default: 0
 player.SetVoiceDistanceFar(float distance);   // Default: 25
@@ -254,11 +263,11 @@ player.SetVoiceVolumetricRadius(float radius); // Default: 0
 player.SetVoiceLowpass(bool enabled);         // Default: true
 ```
 
-These APIs control per-player voice spatialization and remain the correct way to implement voice zones regardless of which audio backend is active.
+These APIs control per-player voice spatialization and remain the correct way to implement voice zones.
 
-### Migration Checklist
+### Audio Audit Checklist
 
-When Steam Audio becomes the default (no action required before then):
+Steam Audio needs no migration work. These are the checks worth running when auditing a world's audio:
 
 ```text
 VRC_SpatialAudioSource components:
@@ -267,34 +276,29 @@ VRC_SpatialAudioSource components:
 □ Warning-only additions use Gain = 0 dB and keep 2D/3D intent unchanged
 □ Verify Near/Far values still achieve the intended effect
 □ Check Gain values — especially sources touched by SDK Auto Fix
-□ Volumetric Radius sources (waterfalls, crowds) should behave identically
+□ Volumetric Radius sources (waterfalls, crowds) behave as intended
 
 Reverb zones:
 □ Unity Reverb Zones are unaffected (they are separate from the spatializer)
 □ Audio Mixer reverb effects are unaffected
-□ Steam Audio room reverb is a future feature — no setup needed now
+□ Steam Audio room reverb is not exposed to creators — there is nothing to configure
 
 Audio occlusion:
-□ No occlusion was applied by ONSP — none is applied by Steam Audio initially
-□ If you implemented manual occlusion (e.g., volume scripting), it continues to work
-□ Physics-based occlusion via Steam Audio is a future feature
-
-Testing in Open Beta:
-□ Opt in via the VRChat client beta settings
-□ Walk through your world and compare audio to ONSP behavior
-□ Pay special attention to wide Volumetric Radius sources
+□ The spatializer applies no occlusion
+□ Manual occlusion (for example, volume scripting) continues to work
+□ Physics-based occlusion via Steam Audio is not exposed to creators
 ```
 
-### Opting Into the Beta
+### Inspecting Audio In-Client
 
-To test your world under Steam Audio before it becomes the default:
+The in-client **Audio Sources** debug page lists every active `AudioSource` in the world. Its `VRC/SAS` column shows
+whether a source has a `VRC_SpatialAudioSource` and whether it was converted to Steam Audio — use it to catch sources
+that never received a spatial audio component.
 
-1. Open VRChat client settings
-2. Navigate to **Audio** settings
-3. Enable the **Steam Audio Open Beta** toggle
-4. Re-enter your world and test audio
-
-No world-side changes are required to test in the beta.
+Open the debug menu from the button at the bottom of the Quick Menu Settings page. By default only the world author
+can open the Audio Sources page; enable **World Debugging** in the world's settings on the VRChat website to let
+others see it. See the official
+[World Debug Views](https://creators.vrchat.com/worlds/udon/world-debug-views/) documentation for the full column list.
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -219,27 +219,45 @@ public class VoiceZone : UdonSharpBehaviour
 ### Steam Audio Replaced ONSP
 
 VRChat's spatial audio backend is **Steam Audio** (Valve). It replaced **ONSP (Oculus Native Spatializer Plugin)**,
-ending the open beta that ran from March 2025. There is no client toggle and no world descriptor setting: Steam Audio
-is always active, on every platform.
+ending the open beta. There is no world descriptor setting for the spatializer and the release notes describe no
+opt-out: Steam Audio is shipped to all players on every platform.
 
 | Aspect | Current behavior |
 |--------|------------------|
-| Spatializer | Steam Audio, all platforms |
+| Spatializer (in VRChat) | Steam Audio, all platforms |
+| Spatializer (Unity Play Mode) | ClientSim still emulates through ONSP as of SDK 3.10.4 |
 | Creator opt-in / opt-out | None; always active |
 | `VRC_SpatialAudioSource` authoring | Unchanged; VRChat converts the component to Steam Audio at load time |
 | Player voice | Deliberately **not** a 1:1 conversion — see [Player Voice Changed Audibly](#player-voice-changed-audibly) |
-| Room reverb | Not exposed to world creators |
-| Physics-based occlusion | Not exposed to world creators |
-| Legacy `ONSPAudioSource` components | Deprecated; the Build Panel flags them and Auto Fix converts them (see [build-validation.md](build-validation.md#audiosource-and-vrc_spatialaudiosource)) |
+| Room reverb, occlusion, reflections | Not available; gated behind a future world SDK update |
+| Legacy `ONSPAudioSource` components | Deprecated; Build Panel flags, Auto Fix converts — see below |
 
 A runtime conversion layer keeps existing content working: author with `VRC_SpatialAudioSource` exactly as before
-and VRChat converts it under the hood when the world loads. **Most worlds need no changes, but the conversion is not
-guaranteed to be inaudible.** VRChat names three symptoms worth checking: audio levels changing drastically, falloff
-curves not being respected, and ranges not applying the same
+and VRChat converts it under the hood when the world loads. Most content came through unchanged — VRChat reported
+that "almost all content will work without any adjustments" after two months of open beta — but the conversion is
+not guaranteed to be inaudible
 ([Developer Update, December 4, 2025](https://ask.vrchat.com/t/developer-update-4-december-2025/47243)).
 
-Advanced Steam Audio capabilities such as room reverb and physics-based occlusion are **not available to world
-creators**. VRChat describes them as options the switch makes possible in the future, not shipped features.
+That update also draws a line that matters when triaging a complaint. Three symptoms are **functional bugs VRChat
+wants reported**, not things to tune around: audio levels changing drastically, falloff curves not being respected,
+and ranges not applying the same. Separately, some differences are expected and are the creator's to absorb:
+direction and audible distance cues, and minor shifts in tonality, EQ, or mixing.
+
+VRChat also added a server-side tuning path in
+[2025.4.2p1](https://docs.vrchat.com/docs/vrchat-202542p1), so parts of the audio experience can change without a
+client update. A world tuned by ear is worth re-checking occasionally rather than treated as settled.
+
+Advanced Steam Audio capabilities are **not available to world creators**: "Certain aspects of Steam Audio will
+require an update to our world SDK ... Until then, features like occlusion, reflections, audio raytracing, etc. will
+not be available." No timeline has been announced.
+
+Do not install the Steam Audio Unity package into a world project to reach those features. No Steam Audio component
+appears on the [allowlisted world components](https://creators.vrchat.com/worlds/whitelisted-world-components/) list,
+and components outside that list do not work in uploaded worlds. VRChat staff have stated that no Steam Audio
+components are supported and that the package should not be installed into world SDK projects.
+
+For the `ONSPAudioSource` Build Panel warning, what Auto Fix copies, and the listening check it calls for, see
+[build-validation.md](build-validation.md#audiosource-and-vrc_spatialaudiosource).
 
 ### What This Means for World Creators
 
@@ -248,11 +266,12 @@ Since client 2025.4.2:
 ├── Author with VRC_SpatialAudioSource exactly as before — same properties, same Inspector
 ├── VRChat converts the component to Steam Audio when the world loads
 ├── No new required configuration and no spatializer to choose
-└── Verify by ear: levels, falloff, and range can land differently than under ONSP
+└── Judge the result in-client (Build & Test or an uploaded instance), not in Unity Play Mode
 ```
 
-Most worlds built under ONSP work without modification. Worlds that were tuned tightly by ear are the ones most
-likely to need a pass.
+**Unity Play Mode is not a valid place to judge Steam Audio behavior.** ClientSim emulates `VRC_SpatialAudioSource`
+through ONSP — `ClientSimSpatialAudioHelper` derives from `ONSPAudioSource` in SDK 3.10.4, and the SDK still ships
+the Oculus spatializer plugins. What you hear in the editor is the old backend.
 
 ### Current Udon Audio APIs
 
@@ -283,13 +302,17 @@ the old result.
 
 ### Audio Audit Checklist
 
-Run these checks to find the sources that need adjustment:
+Run these checks if the world sounds different after the switch:
 
 ```text
-Symptoms VRChat named as needing adjustment:
+Report to VRChat as bugs — do not tune around these:
 □ Audio levels changed drastically compared to how the world sounded under ONSP
 □ Falloff curves are not being respected
 □ Ranges are not applying the same
+
+Expected differences — absorb these in your own tuning:
+□ Direction and audible distance cues differ
+□ Minor shifts in tonality, EQ, or mixing
 
 VRC_SpatialAudioSource components:
 □ Every AudioSource has a companion VRC_SpatialAudioSource, so the SDK Build Panel has no bare-AudioSource warning
@@ -310,15 +333,18 @@ In-client listening pass:
 □ Use the Audio Sources debug page (next section) to spot sources without a spatial audio component
 ```
 
-Reverb and occlusion need no checks: Unity Reverb Zones and Audio Mixer effects are separate from the spatializer and
-are unaffected, the spatializer applies no occlusion of its own, manual occlusion such as volume scripting continues
-to work, and Steam Audio's own reverb and occlusion are not exposed to creators.
+Reverb and occlusion need no checks of their own:
+
+- Unity Reverb Zones and Audio Mixer effects are not part of the spatializer swap
+- The spatializer applies no occlusion of its own
+- Manual occlusion, such as volume scripting, continues to work
+- Steam Audio's own reverb and occlusion are not exposed to creators
 
 ### Inspecting Audio In-Client
 
-The in-client **Audio Sources** debug page lists every active `AudioSource` in the world. Its `VRC/SAS` column shows
-whether a source has a `VRC_SpatialAudioSource` and whether it was converted to Steam Audio — use it to catch sources
-that never received a spatial audio component.
+The in-client **Audio Sources** debug page (added in client 2026.1.2) lists every active `AudioSource` in the world.
+Its `VRC/SAS` column shows whether a source has a `VRC_SpatialAudioSource` and whether it was converted to Steam
+Audio — use it to catch sources that never received a spatial audio component.
 
 Open it with the **Toggle Debug UI** button at the bottom of the Quick Menu Settings page. By default only the world
 author can open the Audio Sources page; enable **World Debugging** in the world's settings on the VRChat website to

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -275,7 +275,8 @@ not aim for a 1:1 conversion** from ONSP:
 - Falloff curves differ slightly
 - EQ and compressor tuning changed
 - Source-directionality was added — a speaker's orientation relative to the listener now affects what you hear
-- Client 2025.4.2p1 applied further tuning to voice falloff and compression
+- Client [2025.4.2p1](https://docs.vrchat.com/docs/vrchat-202542p1) applied further tuning to voice falloff and
+  compression
 
 Treat voice-zone values tuned before 2025.4.2 as a starting point to re-verify by ear, not as settings that reproduce
 the old result.
@@ -299,7 +300,8 @@ VRC_SpatialAudioSource components:
 □ Volumetric Radius sources (waterfalls, crowds) behave as intended
 
 Voice zones:
-□ Re-verify SetVoiceGain / SetVoiceDistanceNear / SetVoiceDistanceFar values by ear
+□ Re-verify every VRCPlayerApi voice setter the world calls by ear — SetVoiceGain, SetVoiceDistanceNear,
+  SetVoiceDistanceFar, SetVoiceVolumetricRadius, SetVoiceLowpass
 □ Account for source-directionality — a speaker facing away now sounds different
 
 In-client listening pass:

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -226,14 +226,17 @@ is always active, on PC and Android alike.
 |--------|------------------|
 | Spatializer | Steam Audio, all platforms |
 | Creator opt-in / opt-out | None; always active |
-| `VRC_SpatialAudioSource` semantics | Unchanged (Gain / Near / Far / Volumetric Radius) |
+| `VRC_SpatialAudioSource` authoring | Unchanged; VRChat converts the component to Steam Audio at load time |
+| Player voice | Deliberately **not** a 1:1 conversion — see [Player Voice Changed Audibly](#player-voice-changed-audibly) |
 | Room reverb | Not exposed to world creators |
 | Physics-based occlusion | Not exposed to world creators |
 | Legacy `ONSPAudioSource` components | Deprecated; the Build Panel converts them to `VRC_SpatialAudioSource` |
 
-The switch was engineered to match ONSP behavior rather than change it, so **no world required migration work**.
-VRChat does caution that things "sound a little different" than under ONSP — the two backends are not
-sample-identical, so a world tuned by ear under ONSP is worth a listening pass.
+A runtime conversion layer keeps existing content working: author with `VRC_SpatialAudioSource` exactly as before
+and VRChat converts it under the hood when the world loads. **Most worlds need no changes, but the conversion is not
+guaranteed to be inaudible.** VRChat names three symptoms worth checking: audio levels changing drastically, falloff
+curves not being respected, and ranges not applying the same
+([Developer Update, December 4, 2025](https://ask.vrchat.com/t/developer-update-4-december-2025/47243)).
 
 Advanced Steam Audio capabilities such as room acoustics and physics-based occlusion are **not available to world
 creators**. VRChat describes them as options the switch makes possible in the future, not shipped features.
@@ -242,17 +245,18 @@ creators**. VRChat describes them as options the switch makes possible in the fu
 
 ```text
 Since client 2025.4.2:
-├── Same VRC_SpatialAudioSource property semantics
-├── Same Gain / Near / Far / Volumetric Radius behavior
-├── No new required configuration
-└── No spatializer choice to make — Steam Audio is the only backend
+├── Author with VRC_SpatialAudioSource exactly as before — same properties, same Inspector
+├── VRChat converts the component to Steam Audio when the world loads
+├── No new required configuration and no spatializer to choose
+└── Verify by ear: levels, falloff, and range can land differently than under ONSP
 ```
 
-Worlds built and tuned under ONSP continue to work without modification.
+Most worlds built under ONSP work without modification. Worlds that were tuned tightly by ear are the ones most
+likely to need a pass.
 
 ### Current Udon Audio APIs
 
-All player voice APIs are unchanged under Steam Audio. These are the APIs to use for dynamic voice zone control:
+The `VRCPlayerApi` voice setters are unchanged and remain the way to implement voice zones:
 
 ```csharp
 // VRCPlayerApi voice control
@@ -263,13 +267,29 @@ player.SetVoiceVolumetricRadius(float radius); // Default: 0
 player.SetVoiceLowpass(bool enabled);         // Default: true
 ```
 
-These APIs control per-player voice spatialization and remain the correct way to implement voice zones.
+### Player Voice Changed Audibly
+
+The API surface is unchanged, but what it sounds like is not. Voice is the one area where VRChat **deliberately did
+not aim for a 1:1 conversion** from ONSP:
+
+- Falloff curves differ slightly
+- EQ and compressor tuning changed
+- Source-directionality was added — a speaker's orientation relative to the listener now affects what you hear
+- Client 2025.4.2p1 applied further tuning to voice falloff and compression
+
+Treat voice-zone values tuned before 2025.4.2 as a starting point to re-verify by ear, not as settings that reproduce
+the old result.
 
 ### Audio Audit Checklist
 
-Steam Audio needs no migration work. These are the checks worth running when auditing a world's audio:
+Most worlds need no changes. Run these checks to catch the ones that do:
 
 ```text
+Symptoms VRChat named as needing adjustment:
+□ Audio levels changed drastically compared to how the world sounded under ONSP
+□ Falloff curves are not being respected
+□ Ranges are not applying the same
+
 VRC_SpatialAudioSource components:
 □ Every AudioSource has a companion VRC_SpatialAudioSource, so the SDK Build Panel has no bare-AudioSource warning
 □ Existing VRC_SpatialAudioSource values were preserved unless the design required a change
@@ -277,6 +297,10 @@ VRC_SpatialAudioSource components:
 □ Verify Near/Far values still achieve the intended effect
 □ Check Gain values — especially sources touched by SDK Auto Fix
 □ Volumetric Radius sources (waterfalls, crowds) behave as intended
+
+Voice zones:
+□ Re-verify SetVoiceGain / SetVoiceDistanceNear / SetVoiceDistanceFar values by ear
+□ Account for source-directionality — a speaker facing away now sounds different
 
 Reverb zones:
 □ Unity Reverb Zones are unaffected (they are separate from the spatializer)

--- a/skills/unity-vrc-world-sdk-3/references/audio-video.md
+++ b/skills/unity-vrc-world-sdk-3/references/audio-video.md
@@ -220,7 +220,7 @@ public class VoiceZone : UdonSharpBehaviour
 
 VRChat's spatial audio backend is **Steam Audio** (Valve). It replaced **ONSP (Oculus Native Spatializer Plugin)**,
 ending the open beta that ran from March 2025. There is no client toggle and no world descriptor setting: Steam Audio
-is always active, on PC and Android alike.
+is always active, on every platform.
 
 | Aspect | Current behavior |
 |--------|------------------|
@@ -230,7 +230,7 @@ is always active, on PC and Android alike.
 | Player voice | Deliberately **not** a 1:1 conversion — see [Player Voice Changed Audibly](#player-voice-changed-audibly) |
 | Room reverb | Not exposed to world creators |
 | Physics-based occlusion | Not exposed to world creators |
-| Legacy `ONSPAudioSource` components | Deprecated; the Build Panel converts them to `VRC_SpatialAudioSource` |
+| Legacy `ONSPAudioSource` components | Deprecated; the Build Panel flags them and Auto Fix converts them (see [build-validation.md](build-validation.md#audiosource-and-vrc_spatialaudiosource)) |
 
 A runtime conversion layer keeps existing content working: author with `VRC_SpatialAudioSource` exactly as before
 and VRChat converts it under the hood when the world loads. **Most worlds need no changes, but the conversion is not
@@ -238,7 +238,7 @@ guaranteed to be inaudible.** VRChat names three symptoms worth checking: audio 
 curves not being respected, and ranges not applying the same
 ([Developer Update, December 4, 2025](https://ask.vrchat.com/t/developer-update-4-december-2025/47243)).
 
-Advanced Steam Audio capabilities such as room acoustics and physics-based occlusion are **not available to world
+Advanced Steam Audio capabilities such as room reverb and physics-based occlusion are **not available to world
 creators**. VRChat describes them as options the switch makes possible in the future, not shipped features.
 
 ### What This Means for World Creators
@@ -282,7 +282,7 @@ the old result.
 
 ### Audio Audit Checklist
 
-Most worlds need no changes. Run these checks to catch the ones that do:
+Run these checks to find the sources that need adjustment:
 
 ```text
 Symptoms VRChat named as needing adjustment:
@@ -302,16 +302,15 @@ Voice zones:
 □ Re-verify SetVoiceGain / SetVoiceDistanceNear / SetVoiceDistanceFar values by ear
 □ Account for source-directionality — a speaker facing away now sounds different
 
-Reverb zones:
-□ Unity Reverb Zones are unaffected (they are separate from the spatializer)
-□ Audio Mixer reverb effects are unaffected
-□ Steam Audio room reverb is not exposed to creators — there is nothing to configure
-
-Audio occlusion:
-□ The spatializer applies no occlusion
-□ Manual occlusion (for example, volume scripting) continues to work
-□ Physics-based occlusion via Steam Audio is not exposed to creators
+In-client listening pass:
+□ Walk the world in-client and confirm sources match their intended tuning
+□ Pay attention to wide Volumetric Radius sources and 2D/BGM loudness
+□ Use the Audio Sources debug page (next section) to spot sources without a spatial audio component
 ```
+
+Reverb and occlusion need no checks: Unity Reverb Zones and Audio Mixer effects are separate from the spatializer and
+are unaffected, the spatializer applies no occlusion of its own, manual occlusion such as volume scripting continues
+to work, and Steam Audio's own reverb and occlusion are not exposed to creators.
 
 ### Inspecting Audio In-Client
 
@@ -319,10 +318,11 @@ The in-client **Audio Sources** debug page lists every active `AudioSource` in t
 whether a source has a `VRC_SpatialAudioSource` and whether it was converted to Steam Audio — use it to catch sources
 that never received a spatial audio component.
 
-Open the debug menu from the button at the bottom of the Quick Menu Settings page. By default only the world author
-can open the Audio Sources page; enable **World Debugging** in the world's settings on the VRChat website to let
-others see it. See the official
-[World Debug Views](https://creators.vrchat.com/worlds/udon/world-debug-views/) documentation for the full column list.
+Open it with the **Toggle Debug UI** button at the bottom of the Quick Menu Settings page. By default only the world
+author can open the Audio Sources page; enable **World Debugging** in the world's settings on the VRChat website to
+let others see it — users already in the instance must rejoin before the page becomes available to them. See the
+official [World Debug Views](https://creators.vrchat.com/worlds/udon/world-debug-views/) documentation for the full
+column list.
 
 ---
 


### PR DESCRIPTION
Closes #324

## Problem

`skills/unity-vrc-world-sdk-3/references/audio-video.md` described Steam Audio as an opt-in open beta with ONSP as the current default. Steam Audio replaced ONSP as the spatializer for every player on every platform in VRChat client release 2025.4.2 (December 3, 2025, Build 1768), so the beta framing, the future-tense migration language, and the client beta opt-in steps were all stale — roughly eight months out of date.

## Verification

Every claim in the rewritten section traces to a primary source:

| Claim | Source |
|---|---|
| Steam Audio is the default on all platforms since 2025.4.2 | [Release notes](https://docs.vrchat.com/docs/vrchat-202542): "Up until now, VRChat has used ONSP as our audio spatializer" / "Steam Audio is for everyone, on every platform" |
| Runtime conversion layer; most content works unchanged | [Developer Update, December 4, 2025](https://ask.vrchat.com/t/developer-update-4-december-2025/47243): "almost all content will work without any adjustments" |
| Three symptoms are bugs to report, not to tune around | Same update: "This includes audio levels changing drastically, falloff curves not being respected, or ranges not applying the same" — stated in the context of functional bugs |
| Direction/distance cues and tonality shifts are expected | Same update: "Things will sound different in some scenarios however, for example direction and audible distance cues, or minor shifts in tonality, EQ or mixing" |
| Voice was deliberately not a 1:1 conversion | Same update: "this was the one place where we intentionally did not aim for a 1:1 conversion from ONSP ... slightly different falloff curves, different EQ and compressor tuning, as well as adding source-directionality" |
| Reverb/occlusion/reflections gated behind a world SDK update | Same update: "Certain aspects of Steam Audio will require an update to our world SDK ... Until then, features like occlusion, reflections, audio raytracing, etc. will not be available" |
| Server-side audio tuning without a client update | [2025.4.2p1](https://docs.vrchat.com/docs/vrchat-202542p1): "we have added a system that allows us to tweak some parts of the audio experience server-side, without needing a new update" |
| Steam Audio components are unsupported in world projects | No Steam Audio component on the [allowlist](https://creators.vrchat.com/worlds/whitelisted-world-components/) ("Components that are not in this list will not work"), plus VRChat staff on [feedback](https://feedback.vrchat.com/udon/p/1768-steam-audio-component-regression): "no Steam Audio components are supported and you should not install Steam Audio into world SDK projects" |
| ClientSim still uses ONSP in Play Mode | Local SDK 3.10.4: `ClientSimSpatialAudioHelper : ONSPAudioSource` in `com.vrchat.worlds/Integrations/ClientSim/Runtime/Helpers/`, and `com.vrchat.base/Integrations/OculusSpatializer/` still ships x64, Android arm32/arm64, and macOS binaries |
| Audio Sources debug page and its VRC/SAS column | [World Debug Views](https://creators.vrchat.com/worlds/udon/world-debug-views/): "VRC/SAS: Whether or not the source has a `VRC_SpatialAudioSource`, and whether it has been converted to Steam Audio" / "Other users need to rejoin the world to be able to access this debug view after you enable World Debugging" |
| ONSP is deprecated | SDK Build Panel warning text `Found audio source(s) using ONSP, this is deprecated...` (`VRCSdkControlPanelWorldBuilder.cs:542-556`), already documented in `build-validation.md` |
| Reverb/occlusion still not creator-facing as of today | All 2026 release notes (2026.1.1 through the 2026.3.1 open beta) checked; the only Steam Audio mentions are the 2026.1.2 debug page and near-field enhancements. [Roadmap](https://creators.vrchat.com/roadmap/) lists "Replace ONSP with Steam Audio" as Complete with no follow-on audio entries |

## Changes

- Status line, comparison table, and prose describe current behavior instead of a pending transition
- Beta opt-in steps replaced with the in-client Audio Sources debug page, which is how creators actually inspect Steam Audio state today
- Migration checklist reframed as an audit checklist, split into bugs to report versus differences to absorb
- Added: the runtime conversion layer, the voice non-1:1 conversion and what changed, the Play Mode/ClientSim caveat, the do-not-install-Steam-Audio warning, and the server-side tuning path
- Fixed the Steam Audio attribution (it is Valve's, not "Valve/Improbable")

Section heading is unchanged, so the `#steam-audio-integration` anchor used by the file's table of contents still resolves. No sub-anchor in the repo pointed at the renamed subsections.

## Test plan

- [x] `tests/docs/*.test.sh` — all 6 documentation smoke tests pass
- [x] `tests/hooks/validate-udonsharp.test.sh` passes
- [x] `npm pack --dry-run` still includes `audio-video.md`
- [x] All added external links return HTTP 200
- [x] UTF-8, LF, final newline, no trailing whitespace (EditorConfig)
- [x] Doc-sync: no reference file added or removed, so README skill tables and template rule paths are unaffected

## Note on the wiki

The Issue cites the community wiki as a second source. It should not be treated as one here: its infobox reports Steam Audio as Live at 2025.3.4 Build 1726 (October 24, 2025), and the 2025.3.4 release notes contain no Steam Audio entry at all. The client release notes and the Developer Update are the sources this PR relies on.