### PR TITLE
chore(version): bump to v3.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.0"
+    version: "3.0.1"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.0"
+    version: "3.0.1"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.0"
+    version: "3.0.1"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
Pre-release version bump for Step 3 of the release flow.

v3.0.1 is a patch release: the only content change since v3.0.0 is #325 (`release: fix`), which corrects the stale Steam Audio section reported in #324.

All five version fields moved together:

- `package.json` → `.version`
- `.claude-plugin/marketplace.json` → `.metadata.version`
- `skills/unity-vrc-udon-sharp/SKILL.md` → frontmatter `metadata.version`
- `skills/unity-vrc-world-sdk-3/SKILL.md` → frontmatter `metadata.version`
- `.claude/skills/unity-vrc-skills-renovator/SKILL.md` → frontmatter `metadata.version`