### PR TITLE
docs: align repository governance before the next SDK release

### DIFF
--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -25,7 +25,7 @@ Any change to these paths requires a documentation sync check:
 
 ## What NOT to Update
 
-- `CHANGELOG.md` — managed by Release Drafter, not manual edits
+- `CHANGELOG.md` — GitHub Releases are the canonical release history. Keep this file as a historical archive through v1.2.0; later releases are not backfilled.
 
 ## What to Update Together (Release Flow)
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -73,6 +73,17 @@
   color: "cfd3d7"
   description: "Duplicate of another issue"
 
+# --- Pull Request ---
+- name: "PR: Release"
+  color: "ededed"
+
+- name: "PR: Skills"
+  color: "ededed"
+
+- name: "Status: In Progress"
+  color: "FBCA04"
+  description: "Work in progress - do not start"
+
 # --- Release Drafter ---
 - name: "release: breaking"
   color: "b60205"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -73,16 +73,16 @@
   color: "cfd3d7"
   description: "Duplicate of another issue"
 
+- name: "Status: In Progress"
+  color: "FBCA04"
+  description: "Work in progress - do not start"
+
 # --- Pull Request ---
 - name: "PR: Release"
   color: "ededed"
 
 - name: "PR: Skills"
   color: "ededed"
-
-- name: "Status: In Progress"
-  color: "FBCA04"
-  description: "Work in progress - do not start"
 
 # --- Release Drafter ---
 - name: "release: breaking"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Check network event hardening and SDK coverage
         run: bash tests/docs/network-event-hardening.test.sh
 
+      - name: Check repository governance contracts
+        run: bash tests/docs/repository-governance-contract.test.sh
+
       - name: Check Skill metadata routing contract
         run: bash tests/docs/skill-routing-contract.test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+> GitHub Releases are the canonical release history. This file is a historical archive through v1.2.0; later releases are not backfilled here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ main ──sync PR──> dev (when the ancestry check fails)
 dev ──version-bump PR──> dev ──release PR──> main ──Release Drafter draft──> publish ──> npm
 ```
 
-Changelogs are automated by Release Drafter. **Version numbers must be bumped manually on `dev` before opening the release PR** (see Step 2 below). `publish.yml` does run `npm version "$VERSION" --no-git-tag-version` in the CI runner as a safety net, but those edits are not committed back, so the git tree's source-of-truth must be kept current by hand.
+GitHub Release notes are drafted by Release Drafter, and GitHub Releases are the canonical release history. `CHANGELOG.md` is a historical archive through v1.2.0; later releases are not backfilled. **Version numbers must be bumped manually on `dev` before opening the release PR** (see Step 2 below). `publish.yml` does run `npm version "$VERSION" --no-git-tag-version` in the CI runner as a safety net, but those edits are not committed back, so the git tree's source-of-truth must be kept current by hand.
 
 ### Step-by-step
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,5 +18,5 @@ Published packages include [npm provenance attestation](https://docs.npmjs.com/g
 
 | Version | Supported |
 |---------|-----------|
-| 2.x     | Yes       |
-| 1.x and older | No  |
+| 3.x     | Yes       |
+| 2.x and older | No  |

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -11,7 +11,7 @@ Read the following Rules before writing any UdonSharp code:
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md`** — Ownership, Sync Modes, RequestSerialization, NetworkCallable
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md`** — Sync Pattern Decision Tree, Data Budget, Minimization
 
-Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, authorize `NetworkCalling.CallingPlayer` separately from receiver ownership, and never use instance master as a security or access-control boundary.
+Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, confirm `NetworkCalling.InNetworkCall` before reading `NetworkCalling.CallingPlayer`, authorize the caller separately from receiver ownership, and never use instance master as a security or access-control boundary.
 
 ## Skills
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -11,7 +11,7 @@ Read the following Rules before writing any UdonSharp code:
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md`** — Ownership, Sync Modes, RequestSerialization, NetworkCallable
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md`** — Sync Pattern Decision Tree, Data Budget, Minimization
 
-Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, authorize `NetworkCalling.CallingPlayer` separately from receiver ownership, and never use instance master as a security or access-control boundary.
+Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, confirm `NetworkCalling.InNetworkCall` before reading `NetworkCalling.CallingPlayer`, authorize the caller separately from receiver ownership, and never use instance master as a security or access-control boundary.
 
 ## Skills
 

--- a/tests/docs/network-event-hardening.test.sh
+++ b/tests/docs/network-event-hardening.test.sh
@@ -462,6 +462,7 @@ require_text "$README_ZH_CN" '不要将实例 Master 作为安全或访问控制
 require_text "$README_ZH_TW" '不要將執行個體 Master 當成安全或存取控制邊界。'
 for path in "$AGENTS_TEMPLATE" "$CLAUDE_TEMPLATE" "$GEMINI_TEMPLATE"; do
     require_text "$path" 'never use instance master as a security or access-control boundary.'
+    require_text "$path" 'confirm `NetworkCalling.InNetworkCall` before reading `NetworkCalling.CallingPlayer`'
 done
 
 # Do not make stronger sender-security claims than the official documentation.

--- a/tests/docs/repository-governance-contract.test.sh
+++ b/tests/docs/repository-governance-contract.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SECURITY="$ROOT_DIR/SECURITY.md"
+CHANGELOG="$ROOT_DIR/CHANGELOG.md"
+DOC_SYNC="$ROOT_DIR/.claude/rules/doc-sync.md"
+CLAUDE="$ROOT_DIR/CLAUDE.md"
+LABELS="$ROOT_DIR/.github/labels.yml"
+LABEL_SYNC="$ROOT_DIR/.github/workflows/label-sync.yml"
+
+require_text() {
+    local path="$1" needle="$2"
+    grep -Fq "$needle" "$path" || {
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    }
+}
+
+forbid_text() {
+    local path="$1" needle="$2"
+    if grep -Fq "$needle" "$path"; then
+        echo "ERROR: $path contains forbidden text: $needle" >&2
+        exit 1
+    fi
+}
+
+require_text "$SECURITY" '| 3.x     | Yes       |'
+require_text "$SECURITY" '| 2.x and older | No  |'
+forbid_text "$SECURITY" '| 2.x     | Yes       |'
+
+CANONICAL='GitHub Releases are the canonical release history'
+ARCHIVE='historical archive through v1.2.0'
+NO_BACKFILL='later releases are not backfilled'
+for path in "$CHANGELOG" "$DOC_SYNC" "$CLAUDE"; do
+    require_text "$path" "$CANONICAL"
+    require_text "$path" "$ARCHIVE"
+    require_text "$path" "$NO_BACKFILL"
+done
+require_text "$CHANGELOG" '[1.2.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.2.0'
+require_text "$CHANGELOG" '[1.0.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.0.0'
+forbid_text "$DOC_SYNC" 'CHANGELOG.md` — managed by Release Drafter, not manual edits'
+require_text "$LABEL_SYNC" 'delete-other-labels: true'
+
+label_block() {
+    local label="$1"
+    awk -v label="$label" '
+        $0 == "- name: \"" label "\"" { found = 1; print; next }
+        found && /^- name:/ { exit }
+        found { print }
+    ' "$LABELS"
+}
+
+RELEASE_LABEL="$(label_block 'PR: Release')"
+SKILLS_LABEL="$(label_block 'PR: Skills')"
+STATUS_LABEL="$(label_block 'Status: In Progress')"
+require_text <(printf '%s\n' "$RELEASE_LABEL") 'color: "ededed"'
+require_text <(printf '%s\n' "$SKILLS_LABEL") 'color: "ededed"'
+require_text <(printf '%s\n' "$STATUS_LABEL") 'color: "FBCA04"'
+require_text <(printf '%s\n' "$STATUS_LABEL") 'description: "Work in progress - do not start"'
+for block in "$RELEASE_LABEL" "$SKILLS_LABEL"; do
+    if grep -Fq 'description:' <<<"$block"; then
+        echo "ERROR: PR labels must omit descriptions" >&2
+        exit 1
+    fi
+done
+
+echo 'PASS: repository governance contracts'


### PR DESCRIPTION
Closes #330

## Summary

Align repository governance documentation before the next stable SDK update without documenting preview APIs or changing the current SDK support range.

- Update the supported-version policy in `SECURITY.md`.
- Make GitHub Releases canonical and keep `CHANGELOG.md` as the historical archive through v1.2.0.
- Preserve the live PR/status label metadata in `.github/labels.yml`.
- Add the network-call context guard to the distributed Claude and Codex templates.
- Add focused governance contracts and run them in the Documentation Smoke Tests job.

## Testing

- `tests/docs/*.test.sh` (including the public-method audit)
- `tests/hooks/validate-udonsharp.test.sh`
- BusyBox validator portability test
- Bash syntax check, symlink check, version sync, and `npm pack --dry-run`
- `editorconfig-checker`, PowerShell, and local lychee were not installed; their required GitHub checks remain enabled.
