### PR TITLE
fix(udon-sharp): replace deprecated VRCInstantiate guidance

### DIFF
--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -667,9 +667,9 @@ public class PoolInteractTakeOwnership : UdonSharpBehaviour
 
 Use Tier 1 by default. Use Tier 2 when the interaction conceptually transfers ownership of the pool to the interacting player — for example, per-player ammo pools or individual draw-card decks. Mixing both patterns in one world is fine when each pool's role is different; Tier framing applies per-pool, not globally.
 
-### VRCObjectPool vs VRCInstantiate
+### VRCObjectPool vs runtime Object.Instantiate
 
-| | VRCObjectPool | VRCInstantiate |
+| | VRCObjectPool | runtime Object.Instantiate |
 |---|---|---|
 | **Sync** | Network-synchronized across all players | Local only — not synced |
 | **Ownership** | Managed by pool owner; spawned object ownership must be set manually | No ownership concept |
@@ -681,11 +681,11 @@ Use Tier 1 by default. Use Tier 2 when the interaction conceptually transfers ow
 
 ```text
 Does every player need to see the spawned object?
-├── No  --> VRCInstantiate (local, no sync overhead)
+├── No  --> runtime Object.Instantiate (local, no sync overhead)
 └── Yes --> VRCObjectPool (synchronized, ownership-aware)
          Does the object need to be reused frequently?
          ├── Yes --> VRCObjectPool (pooling avoids repeated allocation)
-         └── No  --> VRCObjectPool still preferred over VRCInstantiate for synced objects
+         └── No  --> VRCObjectPool still preferred over runtime Object.Instantiate for synced objects
 ```
 
 ## VRCObjectSync

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1192,7 +1192,7 @@ void Update()
 
 ## Object Pooling
 
-Runtime-instantiated objects are never network-synced (`VRCInstantiate` results are local-only). Use object pooling — pre-placed GameObjects for synced objects, or a pool built once in `Start()` for local-only objects (see patterns-networking.md).
+Runtime-instantiated objects are never network-synced (`Object.Instantiate` results are local-only). Use object pooling — pre-placed GameObjects for synced objects, or a pool built once in `Start()` for local-only objects (see patterns-networking.md).
 
 For full implementations, see:
 - Simple pool: [patterns-networking.md](patterns-networking.md#object-pooling)

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -21,7 +21,7 @@ public class SimplePool : UdonSharpBehaviour
         pool = new GameObject[poolSize];
         for (int i = 0; i < poolSize; i++)
         {
-            pool[i] = VRCInstantiate(prefab);
+            pool[i] = Object.Instantiate(prefab);
             pool[i].transform.SetParent(poolParent);
             pool[i].SetActive(false);
         }

--- a/tests/docs/network-event-hardening.test.sh
+++ b/tests/docs/network-event-hardening.test.sh
@@ -151,6 +151,9 @@ require_text "$RULE" "**SDK Coverage**: 3.7.1 - 3.10.4"
 # Historical, version-specific evidence must not be rewritten as current coverage.
 require_text "$API_REF" "observed in the SDK 3.10.3 Udon wrapper symbols"
 
+# Deprecated UdonSharp API names must not remain in the packaged skill.
+forbid_text "$UDON_DIR" 'VRCInstantiate'
+
 # Exact normative contracts: replacing any sentence with its inverse must fail.
 LEGACY_SENTENCE='A parameterless public UdonSharp method whose name does not start with `_` remains exposed to legacy `SendCustomNetworkEvent` calls even without `[NetworkCallable]`.'
 UNDERSCORE_SENTENCE='A leading underscore blocks legacy network calls to a public method.'


### PR DESCRIPTION
## Related Issue

Closes #333

## Background

`VRCInstantiate` has been obsolete since 2021, and the current SDK directs callers to `Object.Instantiate`. The deprecated name remained in three public UdonSharp references.

## Changes

- replace the deprecated wrapper in the API comparison, networking guidance, and object-pooling example
- reject future `VRCInstantiate` references in the packaged UdonSharp Skill

## Impact

- `unity-vrc-udon-sharp` reference guidance and examples
- Documentation Smoke Tests

## Quality Gate

- [x] RED confirmed against the previous reference content
- [x] all six Documentation Smoke Tests pass
- [x] `npm pack --dry-run` passes
- [x] independent review found no issues
- [x] `skill-judge`: 113/120, Grade A
