### PR TITLE
Release v3.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "3.0.1"
+    "version": "3.0.2"
   },
   "plugins": [
     {

--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -25,7 +25,7 @@ Any change to these paths requires a documentation sync check:
 
 ## What NOT to Update
 
-- `CHANGELOG.md` — managed by Release Drafter, not manual edits
+- `CHANGELOG.md` — GitHub Releases are the canonical release history. Keep this file as a historical archive through v1.2.0; later releases are not backfilled.
 
 ## What to Update Together (Release Flow)
 

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.1"
+    version: "3.0.2"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -73,6 +73,17 @@
   color: "cfd3d7"
   description: "Duplicate of another issue"
 
+- name: "Status: In Progress"
+  color: "FBCA04"
+  description: "Work in progress - do not start"
+
+# --- Pull Request ---
+- name: "PR: Release"
+  color: "ededed"
+
+- name: "PR: Skills"
+  color: "ededed"
+
 # --- Release Drafter ---
 - name: "release: breaking"
   color: "b60205"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Check network event hardening and SDK coverage
         run: bash tests/docs/network-event-hardening.test.sh
 
+      - name: Check repository governance contracts
+        run: bash tests/docs/repository-governance-contract.test.sh
+
       - name: Check Skill metadata routing contract
         run: bash tests/docs/skill-routing-contract.test.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+> GitHub Releases are the canonical release history. This file is a historical archive through v1.2.0; later releases are not backfilled here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ main ──sync PR──> dev (when the ancestry check fails)
 dev ──version-bump PR──> dev ──release PR──> main ──Release Drafter draft──> publish ──> npm
 ```
 
-Changelogs are automated by Release Drafter. **Version numbers must be bumped manually on `dev` before opening the release PR** (see Step 2 below). `publish.yml` does run `npm version "$VERSION" --no-git-tag-version` in the CI runner as a safety net, but those edits are not committed back, so the git tree's source-of-truth must be kept current by hand.
+GitHub Release notes are drafted by Release Drafter, and GitHub Releases are the canonical release history. `CHANGELOG.md` is a historical archive through v1.2.0; later releases are not backfilled. **Version numbers must be bumped manually on `dev` before opening the release PR** (see Step 2 below). `publish.yml` does run `npm version "$VERSION" --no-git-tag-version` in the CI runner as a safety net, but those edits are not committed back, so the git tree's source-of-truth must be kept current by hand.
 
 ### Step-by-step
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,5 +18,5 @@ Published packages include [npm provenance attestation](https://docs.npmjs.com/g
 
 | Version | Supported |
 |---------|-----------|
-| 2.x     | Yes       |
-| 1.x and older | No  |
+| 3.x     | Yes       |
+| 2.x and older | No  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.1"
+    version: "3.0.2"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -667,9 +667,9 @@ public class PoolInteractTakeOwnership : UdonSharpBehaviour
 
 Use Tier 1 by default. Use Tier 2 when the interaction conceptually transfers ownership of the pool to the interacting player — for example, per-player ammo pools or individual draw-card decks. Mixing both patterns in one world is fine when each pool's role is different; Tier framing applies per-pool, not globally.
 
-### VRCObjectPool vs VRCInstantiate
+### VRCObjectPool vs runtime Object.Instantiate
 
-| | VRCObjectPool | VRCInstantiate |
+| | VRCObjectPool | runtime Object.Instantiate |
 |---|---|---|
 | **Sync** | Network-synchronized across all players | Local only — not synced |
 | **Ownership** | Managed by pool owner; spawned object ownership must be set manually | No ownership concept |
@@ -681,11 +681,11 @@ Use Tier 1 by default. Use Tier 2 when the interaction conceptually transfers ow
 
 ```text
 Does every player need to see the spawned object?
-├── No  --> VRCInstantiate (local, no sync overhead)
+├── No  --> runtime Object.Instantiate (local, no sync overhead)
 └── Yes --> VRCObjectPool (synchronized, ownership-aware)
          Does the object need to be reused frequently?
          ├── Yes --> VRCObjectPool (pooling avoids repeated allocation)
-         └── No  --> VRCObjectPool still preferred over VRCInstantiate for synced objects
+         └── No  --> VRCObjectPool still preferred over runtime Object.Instantiate for synced objects
 ```
 
 ## VRCObjectSync

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -1192,7 +1192,7 @@ void Update()
 
 ## Object Pooling
 
-Runtime-instantiated objects are never network-synced (`VRCInstantiate` results are local-only). Use object pooling — pre-placed GameObjects for synced objects, or a pool built once in `Start()` for local-only objects (see patterns-networking.md).
+Runtime-instantiated objects are never network-synced (`Object.Instantiate` results are local-only). Use object pooling — pre-placed GameObjects for synced objects, or a pool built once in `Start()` for local-only objects (see patterns-networking.md).
 
 For full implementations, see:
 - Simple pool: [patterns-networking.md](patterns-networking.md#object-pooling)

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -21,7 +21,7 @@ public class SimplePool : UdonSharpBehaviour
         pool = new GameObject[poolSize];
         for (int i = 0; i < poolSize; i++)
         {
-            pool[i] = VRCInstantiate(prefab);
+            pool[i] = Object.Instantiate(prefab);
             pool[i].transform.SetParent(poolParent);
             pool[i].SetActive(false);
         }

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.1"
+    version: "3.0.2"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -11,7 +11,7 @@ Read the following Rules before writing any UdonSharp code:
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md`** — Ownership, Sync Modes, RequestSerialization, NetworkCallable
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md`** — Sync Pattern Decision Tree, Data Budget, Minimization
 
-Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, authorize `NetworkCalling.CallingPlayer` separately from receiver ownership, and never use instance master as a security or access-control boundary.
+Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, confirm `NetworkCalling.InNetworkCall` before reading `NetworkCalling.CallingPlayer`, authorize the caller separately from receiver ownership, and never use instance master as a security or access-control boundary.
 
 ## Skills
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -11,7 +11,7 @@ Read the following Rules before writing any UdonSharp code:
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md`** — Ownership, Sync Modes, RequestSerialization, NetworkCallable
 - **`skills/unity-vrc-udon-sharp/rules/udonsharp-sync-selection.md`** — Sync Pattern Decision Tree, Data Budget, Minimization
 
-Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, authorize `NetworkCalling.CallingPlayer` separately from receiver ownership, and never use instance master as a security or access-control boundary.
+Networking rule: a parameterless `public` method without a leading `_` is a legacy network entry. Prefix local-only/custom public methods with `_`, expose only intentional entries with `[NetworkCallable]`, confirm `NetworkCalling.InNetworkCall` before reading `NetworkCalling.CallingPlayer`, authorize the caller separately from receiver ownership, and never use instance master as a security or access-control boundary.
 
 ## Skills
 

--- a/tests/docs/network-event-hardening.test.sh
+++ b/tests/docs/network-event-hardening.test.sh
@@ -462,6 +462,7 @@ require_text "$README_ZH_CN" '不要将实例 Master 作为安全或访问控制
 require_text "$README_ZH_TW" '不要將執行個體 Master 當成安全或存取控制邊界。'
 for path in "$AGENTS_TEMPLATE" "$CLAUDE_TEMPLATE" "$GEMINI_TEMPLATE"; do
     require_text "$path" 'never use instance master as a security or access-control boundary.'
+    require_text "$path" 'confirm `NetworkCalling.InNetworkCall` before reading `NetworkCalling.CallingPlayer`'
 done
 
 # Do not make stronger sender-security claims than the official documentation.

--- a/tests/docs/network-event-hardening.test.sh
+++ b/tests/docs/network-event-hardening.test.sh
@@ -151,6 +151,9 @@ require_text "$RULE" "**SDK Coverage**: 3.7.1 - 3.10.4"
 # Historical, version-specific evidence must not be rewritten as current coverage.
 require_text "$API_REF" "observed in the SDK 3.10.3 Udon wrapper symbols"
 
+# Deprecated UdonSharp API names must not remain in the packaged skill.
+forbid_text "$UDON_DIR" 'VRCInstantiate'
+
 # Exact normative contracts: replacing any sentence with its inverse must fail.
 LEGACY_SENTENCE='A parameterless public UdonSharp method whose name does not start with `_` remains exposed to legacy `SendCustomNetworkEvent` calls even without `[NetworkCallable]`.'
 UNDERSCORE_SENTENCE='A leading underscore blocks legacy network calls to a public method.'

--- a/tests/docs/repository-governance-contract.test.sh
+++ b/tests/docs/repository-governance-contract.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SECURITY="$ROOT_DIR/SECURITY.md"
+CHANGELOG="$ROOT_DIR/CHANGELOG.md"
+DOC_SYNC="$ROOT_DIR/.claude/rules/doc-sync.md"
+CLAUDE="$ROOT_DIR/CLAUDE.md"
+LABELS="$ROOT_DIR/.github/labels.yml"
+LABEL_SYNC="$ROOT_DIR/.github/workflows/label-sync.yml"
+
+require_text() {
+    local path="$1" needle="$2"
+    grep -Fq "$needle" "$path" || {
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    }
+}
+
+forbid_text() {
+    local path="$1" needle="$2"
+    if grep -Fq "$needle" "$path"; then
+        echo "ERROR: $path contains forbidden text: $needle" >&2
+        exit 1
+    fi
+}
+
+require_text "$SECURITY" '| 3.x     | Yes       |'
+require_text "$SECURITY" '| 2.x and older | No  |'
+forbid_text "$SECURITY" '| 2.x     | Yes       |'
+
+CANONICAL='GitHub Releases are the canonical release history'
+ARCHIVE='historical archive through v1.2.0'
+NO_BACKFILL='later releases are not backfilled'
+for path in "$CHANGELOG" "$DOC_SYNC" "$CLAUDE"; do
+    require_text "$path" "$CANONICAL"
+    require_text "$path" "$ARCHIVE"
+    require_text "$path" "$NO_BACKFILL"
+done
+require_text "$CHANGELOG" '[1.2.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.2.0'
+require_text "$CHANGELOG" '[1.0.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.0.0'
+forbid_text "$DOC_SYNC" 'CHANGELOG.md` — managed by Release Drafter, not manual edits'
+require_text "$LABEL_SYNC" 'delete-other-labels: true'
+
+label_block() {
+    local label="$1"
+    awk -v label="$label" '
+        $0 == "- name: \"" label "\"" { found = 1; print; next }
+        found && /^- name:/ { exit }
+        found { print }
+    ' "$LABELS"
+}
+
+RELEASE_LABEL="$(label_block 'PR: Release')"
+SKILLS_LABEL="$(label_block 'PR: Skills')"
+STATUS_LABEL="$(label_block 'Status: In Progress')"
+require_text <(printf '%s\n' "$RELEASE_LABEL") 'color: "ededed"'
+require_text <(printf '%s\n' "$SKILLS_LABEL") 'color: "ededed"'
+require_text <(printf '%s\n' "$STATUS_LABEL") 'color: "FBCA04"'
+require_text <(printf '%s\n' "$STATUS_LABEL") 'description: "Work in progress - do not start"'
+for block in "$RELEASE_LABEL" "$SKILLS_LABEL"; do
+    if grep -Fq 'description:' <<<"$block"; then
+        echo "ERROR: PR labels must omit descriptions" >&2
+        exit 1
+    fi
+done
+
+echo 'PASS: repository governance contracts'


### PR DESCRIPTION
## Pre-flight checklist

- [x] `dev` contains the current `main` history.
- [x] Version 3.0.2 was merged into `dev` through #335.
- [x] All five version fields resolve to 3.0.2.

## Summary

Release v3.0.2 updates obsolete UdonSharp instantiation guidance and aligns the repository's distributed instructions and release governance.

**4 PRs since v3.0.1:**

- #331 — `chore`: synchronize `main` into `dev`
- #332 — `docs`: align repository governance before the next SDK release
- #334 — `fix`: replace deprecated `VRCInstantiate` guidance
- #335 — `chore`: bump the five canonical version fields to 3.0.2

**Version bump driver**: `release: fix` → patch.

## What changed

### UdonSharp references (#334)

- Replace the obsolete `VRCInstantiate` wrapper with `Object.Instantiate` in the API comparison, networking guidance, and object-pooling example.
- Reject future uses of the obsolete wrapper in the packaged UdonSharp Skill.

### Repository and distributed guidance (#332)

- Align the supported-version and release-history policies.
- Add the network-call context guard to the distributed Claude and Codex templates.
- Add focused governance contracts to Documentation Smoke Tests.

## Reporter acknowledgement

Issue #333 was reported by @nomlasvrc, including the exact locations and the original deprecation commit. Thank you for the precise report.

## Merge instructions

**DO NOT SQUASH** — use a plain merge commit so Release Drafter sees each underlying PR.

## Post-merge

1. Confirm the Release Drafter draft for v3.0.2.
2. Rewrite it as concise bilingual release notes and obtain approval before publishing.
3. Publish the GitHub Release and verify the npm package.

## Test plan

- [x] Symlink Integrity
- [x] Hook Scripts
- [x] Documentation Smoke Tests
- [x] Markdown Links
- [x] npm Pack Test
- [x] EditorConfig
- [x] Version Sync
- [x] Release Drafter draft body reflects the merged PRs
- [x] After publish: `npm view agent-skills-vrc-udon version` returns 3.0.2

## Release impact

`release: fix` → patch bump.



