### PR TITLE
fix(udon-sharp): distinguish runtime public field serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Check layers runtime exception and evidence boundary
         run: bash tests/docs/layers-reference-contract.test.sh
 
+      - name: Check runtime public field serialization guidance
+        run: bash tests/docs/runtime-public-field-serialization-reference.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -271,6 +271,15 @@ SendCustomNetworkEvent(NetworkEventTarget.Owner, "MethodName");
 public void _ApplyLocalPreview() { }
 ```
 
+### Public field serialization
+
+| Need | Declaration |
+|------|-------------|
+| Editor-time DI/bake/autowire value must persist into a Scene/Prefab | `[HideInInspector] public` — add a comment explaining the persistence reason |
+| Runtime-only value accessed by another behaviour | `[System.NonSerialized] public` — assign it at runtime |
+
+`[HideInInspector]` changes Inspector visibility only; it does not disable Unity serialization. `[System.NonSerialized]` keeps the field public for runtime access while excluding it from Scene/Prefab serialization. Use this for runtime-only state.
+
 ---
 
 ## NetworkCallable (SDK 3.8.1+)

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -55,6 +55,10 @@ compiler constraints, use `unity-vrc-world-sdk-3` and read
 4. **Sync Minimization** — Every synced variable costs bandwidth (see data budget in `udonsharp-sync-selection.md`). Derive what you can locally; sync only the source of truth.
 5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()` **for state-change reactions; for hot-path or periodic work, see [Event Dispatch & Cross-Behaviour Call Cost Tiers](references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers)**.
 
+### Public fields: Inspector visibility is not persistence policy
+
+`[HideInInspector]` only hides a public field from the Inspector; Unity still serializes it. Use `[HideInInspector] public` when Editor-time DI, baking, or autowiring must persist the value into a Scene/Prefab. Use `[System.NonSerialized] public` for a runtime-only value that another UdonBehaviour must access through direct access or `SetProgramVariable`. When `[HideInInspector]` is intentional, leave a comment explaining why the value must be persisted.
+
 ## Common Mistakes (NEVER List)
 
 These constraints cause either **compile-time failures** or **silent runtime failures**. Check this list before writing any UdonSharp code.

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -20,6 +20,20 @@ UdonSharp transpiles C# source to Udon Assembly, which runs on VRChat's UdonVM. 
 - **Checked arithmetic**: UdonVM runs with overflow checking enabled by default. Operations that would silently wrap in standard C# will behave as checked.
 - **No JIT**: There is no just-in-time compilation. All method dispatch is interpreted.
 
+### Inspector visibility vs. Unity serialization
+
+`[HideInInspector]` hides a public field from the Inspector but does not disable Unity serialization. Use `[HideInInspector] public` when Editor-time wiring produces a value that must be persisted into a Scene or Prefab. Use `[System.NonSerialized] public` when another UdonBehaviour needs runtime-only access through direct access or `SetProgramVariable`; these values should be assigned by runtime code rather than loaded from the Scene/Prefab.
+
+```csharp
+// Positive example: editor-time wiring is intentionally persisted.
+[HideInInspector] public GameObject bakedTarget; // Editor-time wiring; value must be persisted into a Scene or Prefab.
+
+// Runtime-only example: another behaviour fills this value before a callback.
+[System.NonSerialized] public int selectedIndex = -1;
+```
+
+If `[HideInInspector]` is intentional, comment the persistence reason next to the declaration. Do not use it as a substitute for `[System.NonSerialized]` on temporary runtime state.
+
 ---
 
 ## Supported Features

--- a/skills/unity-vrc-udon-sharp/references/patterns-performance.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-performance.md
@@ -1033,7 +1033,7 @@ public class ManagedVideoLoader : UdonSharpBehaviour
     // ("ScheduledUrl"). Use FIELD_SCHEDULED_URL when calling SetProgramVariable from
     // custom code to avoid silent mismatches.
     public const string FIELD_SCHEDULED_URL = "ScheduledUrl";
-    [HideInInspector] public VRCUrl ScheduledUrl;
+    [System.NonSerialized] public VRCUrl ScheduledUrl;
 
     public void RequestLoad(VRCUrl url)
     {
@@ -1047,7 +1047,7 @@ public class ManagedVideoLoader : UdonSharpBehaviour
     /// </summary>
     public void _OnScheduledLoad()
     {
-        if (ScheduledUrl == null) return;
+        if (ScheduledUrl == null || string.IsNullOrEmpty(ScheduledUrl.Get())) return;
         Debug.Log($"[ManagedVideoLoader] Loading URL: {ScheduledUrl}");
         // Perform the actual VRCUrl load here (e.g. videoPlayer.LoadURL(ScheduledUrl)).
     }
@@ -1058,7 +1058,7 @@ public class ManagedVideoLoader : UdonSharpBehaviour
 - `_intervalSeconds` defaults to 5.05 s. Do not set it below 5.0.
 - If two behaviours call `ScheduleLoad` in the same frame, only the first starts the drain loop; the second is queued and will fire after 5.05 s.
 - The queue depth is 16 by default. Increase `MaxQueueDepth` if the world can have more concurrent requesters than that.
-- `ScheduledUrl` on the consumer must be declared `public` (not `[HideInInspector]` alone) for `SetProgramVariable` to write it; the `[HideInInspector]` attribute hides it from the Inspector while keeping it accessible to the scheduler.
+- `ScheduledUrl` on the consumer must be declared `[System.NonSerialized] public`: the scheduler writes it at runtime via `SetProgramVariable`, and the value must not be persisted in a Scene/Prefab. The guard also rejects both a `null` reference and the SDK's empty `VRCUrl` value.
 - **`SetProgramVariable` field-name contract**: The scheduler writes to the field named `"ScheduledUrl"` by string at runtime. If the consumer renames that field, `SetProgramVariable` silently no-ops and the callback receives `null`. Always keep the field name in sync with the string literal in `_DrainNext`.
 
 ---

--- a/skills/unity-vrc-udon-sharp/references/patterns-ui.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-ui.md
@@ -320,7 +320,7 @@ public class DynamicPlayerList : UdonSharpBehaviour
     [Tooltip("Prefix for generated button names")]
     [SerializeField] private string buttonPrefix = "PlayerBtn_";
 
-    [HideInInspector] public int selectedIndex = -1; // Written by ButtonHandler before _OnPlayerButtonClicked
+    [System.NonSerialized] public int selectedIndex = -1; // Written by ButtonHandler before _OnPlayerButtonClicked
 
     private GameObject[] _activeButtons = new GameObject[0];
 
@@ -1134,7 +1134,7 @@ public class FingerTouchCanvas : UdonSharpBehaviour
     /// The pointer index (0 = left, 1 = right, 2 = desktop) that last triggered an event.
     /// Listeners can read this to determine which pointer fired the event.
     /// </summary>
-    [HideInInspector] public int lastPointerIndex;
+    [System.NonSerialized] public int lastPointerIndex;
 
     // Per-pointer state (index 0 = left, 1 = right, 2 = desktop)
     private bool[] _isPressed = new bool[3];
@@ -1590,7 +1590,7 @@ public class AppManager : UdonSharpBehaviour
     // ownership-transfer code path only.
     // -2 = no pending operation, -1 = pending close, >= 0 = pending open index
     private int _pendingOpenIndex = -2;
-    [HideInInspector] public int selectedIndex = -1; // Written by ButtonHandler before _OnIconButtonClicked
+    [System.NonSerialized] public int selectedIndex = -1; // Written by ButtonHandler before _OnIconButtonClicked
 
     /// <summary>
     /// Synced property: when the synced value changes, trigger a transition.

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -402,8 +402,8 @@ public class DataProcessor : UdonSharpBehaviour
     [SerializeField] private ProcessMediator _mediator;
 
     // Public result fields — written before SendCustomEvent fires
-    [HideInInspector] public bool ResultSuccess;
-    [HideInInspector] public string[] ResultData;
+    [System.NonSerialized] public bool ResultSuccess;
+    [System.NonSerialized] public string[] ResultData;
 
     public void Process(string[] inputLines)
     {
@@ -554,8 +554,8 @@ using UnityEngine;
 public class CancellableTimer : UdonSharpBehaviour
 {
     // Written by the factory before the delay is scheduled.
-    [HideInInspector] public UdonSharpBehaviour CallbackTarget;
-    [HideInInspector] public string              CallbackMethod;
+    [System.NonSerialized] public UdonSharpBehaviour CallbackTarget;
+    [System.NonSerialized] public string              CallbackMethod;
 
     /// <summary>
     /// Called by SendCustomEventDelayedSeconds on this behaviour.

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -1250,6 +1250,20 @@ EditorUtility.SetDirty(behaviour);
 
 ```
 
+### Runtime-only public field keeps an Inspector value
+
+**Cause:** `[HideInInspector] public` hides a field but still allows Unity to serialize it. That is correct for Editor-time DI, baking, or autowiring that must persist into a Scene/Prefab, but it is the wrong declaration for temporary runtime state.
+
+**Solution:** Use `[System.NonSerialized] public` when another UdonBehaviour fills or reads the field at runtime. This is the correct declaration for runtime-only public state. If the field is set with `SetProgramVariable`, keep it public and keep the exact string name in sync; the attribute controls Unity serialization, not runtime accessibility.
+
+```csharp
+// Editor-time value: deliberately persisted while hidden from the Inspector.
+[HideInInspector] public GameObject bakedTarget; // Explain the persistence reason.
+
+// Runtime-only value: assigned by another behaviour before its callback.
+[System.NonSerialized] public int selectedIndex = -1;
+```
+
 ---
 
 ### "The associated script cannot be loaded"

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -382,8 +382,8 @@ public class ResourceIndex : UdonSharpBehaviour
     }
 
     // Result fields written by GetUrlIndex / GetInnerIndex — read immediately after the call
-    [HideInInspector] public int LastUrlIndex   = -1;
-    [HideInInspector] public int LastInnerIndex = -1;
+    [System.NonSerialized] public int LastUrlIndex   = -1;
+    [System.NonSerialized] public int LastInnerIndex = -1;
 
     /**
      * Searches for resourceId and returns true if found.

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -107,6 +107,10 @@ Prefer `private` methods. Public methods slow down Udon's method lookup.
 
 See [`Event Dispatch & Cross-Behaviour Call Cost Tiers`](../references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers) for the full method-visibility tier table.
 
+### Public field serialization
+
+`[HideInInspector] public` hides a field from the Inspector but keeps Unity serialization enabled. Use it when Editor-time DI, baking, or autowiring must persist the value into a Scene/Prefab. Use `[System.NonSerialized] public` for a runtime-only field that another UdonBehaviour accesses through direct access or `SetProgramVariable`. If `[HideInInspector]` is intentional, comment the persistence reason next to the declaration.
+
 ### 6. Recursive Methods
 
 The `[RecursiveMethod]` attribute is required for recursive calls.

--- a/tests/docs/runtime-public-field-serialization-reference.test.sh
+++ b/tests/docs/runtime-public-field-serialization-reference.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UDON_DIR="$ROOT_DIR/skills/unity-vrc-udon-sharp"
+SKILL="$UDON_DIR/SKILL.md"
+RULES="$UDON_DIR/rules/udonsharp-constraints.md"
+CONSTRAINTS="$UDON_DIR/references/constraints.md"
+TROUBLESHOOTING="$UDON_DIR/references/troubleshooting.md"
+CHEATSHEET="$UDON_DIR/CHEATSHEET.md"
+UTILITIES="$UDON_DIR/references/patterns-utilities.md"
+PERFORMANCE="$UDON_DIR/references/patterns-performance.md"
+UI="$UDON_DIR/references/patterns-ui.md"
+WEB_LOADING="$UDON_DIR/references/web-loading-advanced.md"
+
+require_text() {
+    local path="$1"
+    local needle="$2"
+    if ! grep -Fq -- "$needle" "$path"; then
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    fi
+}
+
+forbid_text() {
+    local path="$1"
+    local needle="$2"
+    if grep -Fq -- "$needle" "$path"; then
+        echo "ERROR: $path contains obsolete text: $needle" >&2
+        exit 1
+    fi
+}
+
+require_count() {
+    local path="$1"
+    local needle="$2"
+    local expected="$3"
+    local actual
+    actual="$( (grep -F -- "$needle" "$path" || true) | wc -l | tr -d '[:space:]')"
+    if [ "$actual" -ne "$expected" ]; then
+        echo "ERROR: $path contains $actual copies of '$needle'; expected $expected" >&2
+        exit 1
+    fi
+}
+
+# The runtime-only examples must not imply Unity/Prefab persistence. Keep this
+# scoped to the named fields; a valid, intentional HideInInspector example is
+# required below and is deliberately not blanket-banned.
+require_count "$UTILITIES" '[System.NonSerialized] public bool ResultSuccess' 1
+require_count "$UTILITIES" '[System.NonSerialized] public string[] ResultData' 1
+require_count "$UTILITIES" '[System.NonSerialized] public UdonSharpBehaviour CallbackTarget' 1
+require_count "$UTILITIES" '[System.NonSerialized] public string              CallbackMethod' 1
+require_count "$PERFORMANCE" '[System.NonSerialized] public VRCUrl ScheduledUrl' 1
+require_count "$UI" '[System.NonSerialized] public int selectedIndex' 2
+require_count "$UI" '[System.NonSerialized] public int lastPointerIndex' 1
+require_count "$WEB_LOADING" '[System.NonSerialized] public int LastUrlIndex' 1
+require_count "$WEB_LOADING" '[System.NonSerialized] public int LastInnerIndex' 1
+
+for path in "$UTILITIES" "$PERFORMANCE" "$UI" "$WEB_LOADING"; do
+    for field in ResultSuccess ResultData CallbackTarget CallbackMethod ScheduledUrl selectedIndex lastPointerIndex LastUrlIndex LastInnerIndex; do
+        # The exact declaration is checked above; this catches an accidental
+        # reintroduction of the old attribute on the affected examples.
+        if grep -F "[HideInInspector] public" "$path" | grep -Fq -- "$field"; then
+            echo "ERROR: runtime-only field $field still uses HideInInspector in $path" >&2
+            exit 1
+        fi
+    done
+done
+
+# Entry-point and reference documentation must distinguish persistence from
+# runtime-only cross-behaviour access.
+for path in "$SKILL" "$RULES" "$CONSTRAINTS" "$TROUBLESHOOTING" "$CHEATSHEET"; do
+    require_text "$path" 'HideInInspector'
+    require_text "$path" 'System.NonSerialized'
+    require_text "$path" 'Scene/Prefab'
+    require_text "$path" 'runtime-only'
+done
+
+# A positive example protects legitimate editor-time wiring; this is not an
+# "all HideInInspector is forbidden" contract.
+require_text "$CONSTRAINTS" '[HideInInspector] public GameObject bakedTarget'
+require_text "$CONSTRAINTS" 'Editor-time wiring'
+require_text "$CONSTRAINTS" 'must be persisted into a Scene or Prefab'
+
+# The scheduler contract must handle both a null VRCUrl and the SDK's empty
+# VRCUrl representation, while retaining the public SetProgramVariable name.
+require_text "$PERFORMANCE" 'if (ScheduledUrl == null || string.IsNullOrEmpty(ScheduledUrl.Get())) return;'
+require_text "$PERFORMANCE" 'SetProgramVariable("ScheduledUrl", url)'
+forbid_text "$PERFORMANCE" 'not [HideInInspector] alone'
+forbid_text "$PERFORMANCE" 'while keeping it accessible to the scheduler'
+
+echo "PASS: runtime public field serialization contract"


### PR DESCRIPTION
Closes #337

This updates the public-field examples and the guidance around Unity serialization. Runtime-only examples now use `[System.NonSerialized] public`, while `[HideInInspector] public` remains the documented choice when editor-time wiring must be persisted.

`ManagedVideoLoader` now rejects both a null `VRCUrl` and the SDK's empty URL value. The scheduler still writes `ScheduledUrl` before firing the callback.

### Issue coverage

| #337 requirement | Status | Evidence |
| --- | --- | --- |
| Convert the ten runtime-only public fields | COVERED | `patterns-utilities.md`, `patterns-performance.md`, `patterns-ui.md`, and `web-loading-advanced.md`; the targeted contract test checks all ten declarations and rejects the old attribute on those fields. |
| Distinguish persisted editor wiring from runtime-only access | COVERED | `SKILL.md`, `rules/udonsharp-constraints.md`, `references/constraints.md`, `references/troubleshooting.md`, and `CHEATSHEET.md`. |
| Preserve an intentional `HideInInspector` use case | COVERED | The `bakedTarget` example in `references/constraints.md` records why the value must persist in the Scene/Prefab. |
| Reject null and empty `ScheduledUrl` values | VERIFIED | Exact guard contract test plus the Play Mode Udon VM probe below. |
| Keep the normal scheduler path unchanged | VERIFIED | `SetProgramVariable("ScheduledUrl", url)` still precedes the callback, and the valid URL path was exercised on an initialized backing behaviour. |
| Verify Unity serialization and runtime access | VERIFIED | A temporary probe generated distinct target/caller Udon programs, entered Play Mode, initialized both backing `UdonBehaviour`s, and verified runtime `SetProgramVariable`, typed caller-to-target access, serialization, initializer defaults, and null/empty/valid URL handling. |
| Scene migration, CHANGELOG, SDK version table, README, and template bodies | INTENTIONALLY NOT CHANGED | No change is required for package structure, SDK coverage, or release-history policy. Existing documentation and package checks pass. |

### Unity evidence

- Unity `2022.3.22f1 (887be4894c44)`
- `com.vrchat.worlds 3.10.4` and `com.vrchat.base 3.10.4`
- A distinct `Issue337CallerProbe : UdonSharpBehaviour` compiled with typed `target.directValue` access.
- Both target and caller program assets and exported entry points were confirmed before entering Play Mode.
- `SetProgramVariable` and caller access ran on initialized backing `UdonBehaviour`s, not the editor proxy reflection helper.
- The final independent rerun completed with exit code 0 and emitted `ISSUE337_RUNTIME_ACCESS_PASS`, `ISSUE337_GUARD_PASS`, and `ISSUE337_PROBE_PASS`.
- Probe source hashes matched the Windows-local execution copy during review. The temporary probe is not part of this PR.

### Checks

- Targeted contract test: RED on `origin/dev` before implementation, then GREEN.
- All `tests/docs/*.test.sh` checks: PASS.
- Bash and BusyBox hook suites: PASS.
- All 129 changed C# code blocks passed `validate-udonsharp.sh` (warnings are existing rule diagnostics only).
- `npm pack --dry-run`: PASS.
- GitHub required checks: PASS.
