### PR TITLE
feat(docs)!: narrow SDK support to verified stable target

### DIFF
--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -21,7 +21,7 @@ Any change to these paths requires a documentation sync check:
 2. **Rule paths**: Do `templates/*.md` reference valid rule file paths under `skills/*/rules/`?
 3. **Hook references**: If hooks were added/removed/renamed, are they listed in README.md Hooks section?
 4. **SDK support policy**: If the active target changes, synchronize the stable-only verification gate, historical boundary, and SDK Versions section across all five READMEs.
-5. **Community contributors**: Keep the contributor handles, Issue links, and descriptions synchronized across all five READMEs; only include accepted, confirmed, or implemented Issue-originated contributions. When the census changes, refresh `tests/docs/fixtures/community-contributor-census.json` and the contract-test expectations from a new all-Issue query.
+5. **Community contributors**: Keep the contributor handles, Issue links, and descriptions synchronized across all five READMEs; include only external GitHub Issue reporters whose contributions were accepted, confirmed, or implemented. Exclude maintainer and bot accounts, invalid/duplicate/wontfix/spam Issues, and PR-only contributors. When the census changes, refresh `tests/docs/fixtures/community-contributor-census.json` and the contract-test expectations from a new all-Issue query.
 6. **Structure tree**: If directories were added/removed, update the Structure section in README.md and CLAUDE.md
 
 ## What NOT to Update

--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -8,7 +8,7 @@ Any change to these paths requires a documentation sync check:
 
 | Changed Path | Check These Docs |
 |---|---|
-| `skills/*/SKILL.md` | README.md Skills section, README.ja.md Skills section |
+| `skills/*/SKILL.md` | All five README Skills/support/contributor sections |
 | `skills/*/rules/*.md` | README.md Rules section, `templates/CLAUDE.md`, `templates/AGENTS.md`, `templates/GEMINI.md` |
 | `skills/*/hooks/*` | README.md Hooks section |
 | `skills/*/references/*.md` | README.md Skills section (reference count/list) |
@@ -17,11 +17,12 @@ Any change to these paths requires a documentation sync check:
 
 ## What to Check
 
-1. **Skill tables**: Do README.md and README.ja.md list all skills with correct rule/reference/template counts?
+1. **Skill tables**: Do all five README files list all skills with correct rule/reference/template counts?
 2. **Rule paths**: Do `templates/*.md` reference valid rule file paths under `skills/*/rules/`?
 3. **Hook references**: If hooks were added/removed/renamed, are they listed in README.md Hooks section?
-4. **SDK version table**: If SDK version support changed, update the SDK Versions section
-5. **Structure tree**: If directories were added/removed, update the Structure section in README.md and CLAUDE.md
+4. **SDK support policy**: If the active target changes, synchronize the stable-only verification gate, historical boundary, and SDK Versions section across all five READMEs.
+5. **Community contributors**: Keep the contributor handles, Issue links, and descriptions synchronized across all five READMEs; only include accepted, confirmed, or implemented Issue-originated contributions. When the census changes, refresh `tests/docs/fixtures/community-contributor-census.json` and the contract-test expectations from a new all-Issue query.
+6. **Structure tree**: If directories were added/removed, update the Structure section in README.md and CLAUDE.md
 
 ## What NOT to Update
 
@@ -43,7 +44,7 @@ committed back, so the source-of-truth must be kept current by hand:
 ## Checklist (run mentally before committing)
 
 - [ ] README.md skill/rule/hook tables match the actual `skills/` directory contents
-- [ ] README.ja.md is in sync with README.md (same structure, translated content)
-- [ ] All other README translations (README.zh-CN.md, etc.) are flagged for update if they exist
+- [ ] All README translations are in sync with README.md (same structure, translated content)
+- [ ] Stable-only SDK policy and Community Contributors census are synchronized across all five READMEs
 - [ ] `templates/*.md` rule paths are valid (no broken references)
 - [ ] CLAUDE.md Structure section reflects current directory layout

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -44,12 +44,12 @@ A guide for renovating (filling knowledge, refreshing, and improving quality of)
 
 ### Phase 1: Current State Analysis
 
-1. **Check the current SDK version support for each skill**
+1. **Check the active and verified SDK target for each skill**
 
 ```text
 Read: skills/unity-vrc-udon-sharp/SKILL.md
 Read: skills/unity-vrc-world-sdk-3/SKILL.md
-→ Check the "Supported SDK version" line in each file
+→ Check the "Active support / last verified" line in each file
 ```
 
 2. **Check the file list for each skill**

--- a/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md
@@ -71,10 +71,10 @@ minor: Bug fixes, small changes
 
 ### Checkpoints for Next Update
 
-1. **Check the last supported version for each skill**
+1. **Check the active and verified target for each skill**
    ```
-   unity-vrc-udon-sharp/SKILL.md "Supported SDK version" line
-   unity-vrc-world-sdk-3/SKILL.md "Supported SDK version" line
+   unity-vrc-udon-sharp/SKILL.md "Active support / last verified" line
+   unity-vrc-world-sdk-3/SKILL.md "Active support / last verified" line
    ```
 
 2. **Check for new versions on the official releases page**

--- a/.claude/skills/unity-vrc-skills-renovator/references/skill-structure.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/skill-structure.md
@@ -34,8 +34,8 @@ unity-vrc-udon-sharp/
     ├── troubleshooting.md      # Troubleshooting
     ├── web-loading.md          # String/Image download, VRCJson
     ├── editor-scripting.md     # Editor scripting
-    ├── persistence.md          # Persistence guide (SDK 3.7.4+)
-    └── dynamics.md             # Dynamics guide (SDK 3.10.0+)
+    ├── persistence.md          # Persistence guide (introduced in SDK 3.7.4)
+    └── dynamics.md             # Dynamics guide (introduced in SDK 3.10.0)
 ```
 
 ### Role of Each File
@@ -118,11 +118,15 @@ Knowledge / Rules / Enforcement must always reflect the same facts:
 
 ### Unified Version Notation
 
-At the beginning of each file:
+At the beginning of each active reference file:
 
 ```markdown
-**Supported SDK versions**: 3.7.1 - 3.X.X (as of XXXX-XX)
+**Active support / last verified**: SDK 3.10.4
+**Historical version notes**: Older version numbers record feature introductions or migration facts only; they are not supported or validation targets.
 ```
+
+Keep accurate feature-introduction versions in the body, but never present the historical range as an active support promise. This boundary describes the Skill, not VRChat's own SDK policy.
+From v4.0.0 onward, select the latest stable SDK only after this repository verifies it; a new stable release does not change the active target automatically.
 
 For SDK-specific features:
 

--- a/.claude/skills/unity-vrc-skills-renovator/references/update-checklist.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/update-checklist.md
@@ -2,7 +2,13 @@
 
 ## Phase 1: Current State Assessment
 
-- [ ] Check SDK version support for each skill
+- [ ] Check the active and verified SDK target for each skill
+  ```text
+  Active support / last verified: SDK 3.10.4
+  ```
+- [ ] Keep older version numbers only as historical migration information
+- [ ] Confirm the active-versus-historical boundary is explicit and does not attribute the cutoff to VRChat
+- [ ] For a new stable release, verify it in this repository before moving the active target
   ```text
   Read: skills/unity-vrc-udon-sharp/SKILL.md
   Read: skills/unity-vrc-world-sdk-3/SKILL.md
@@ -132,7 +138,7 @@ Classify collected information:
 ## Phase 4: Update unity-vrc-udon-sharp
 
 ### Priority 1: SKILL.md
-- [ ] Update SDK version support
+- [ ] Update the active SDK support declaration and preserve useful historical version notes
 - [ ] Add new feature summary
 - [ ] Update resource list
 
@@ -163,7 +169,7 @@ Classify collected information:
 ## Phase 5: Update unity-vrc-world-sdk-3
 
 ### Priority 1: SKILL.md
-- [ ] Update SDK version support
+- [ ] Update the active SDK support declaration and preserve useful historical version notes
 - [ ] Add new feature summary
 
 ### Priority 2: components.md

--- a/.claude/skills/unity-vrc-skills-renovator/references/update-checklist.md
+++ b/.claude/skills/unity-vrc-skills-renovator/references/update-checklist.md
@@ -12,7 +12,7 @@
   ```text
   Read: skills/unity-vrc-udon-sharp/SKILL.md
   Read: skills/unity-vrc-world-sdk-3/SKILL.md
-  → Find the "Supported SDK version" line
+  → Find the "Active support / last verified" line
   ```
 
 - [ ] Check the file list for update targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Check network event hardening and SDK coverage
         run: bash tests/docs/network-event-hardening.test.sh
 
+      - name: Check SDK active support policy
+        run: bash tests/docs/sdk-support-policy.test.sh
+
+      - name: Check community contributor acknowledgements
+        run: bash tests/docs/community-contributors.test.sh
+
       - name: Check repository governance contracts
         run: bash tests/docs/repository-governance-contract.test.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ When reporting issues, please specify the SDK version.
 
 **Active and verified target**: SDK 3.10.4.
 
-References to SDK 3.7.1-3.10.3 are historical migration information only; they are not supported or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy.
+References to SDK 3.7.1-3.10.3 are historical migration information only; they are not supported or validation targets for either distributed Skill. This support boundary applies to both distributed Skills and is not a statement about VRChat's own SDK policy.
 
 From v4.0.0 onward, the policy is latest stable SDK only. Support moves to a new stable release only after this repository verifies it; a new stable release is not supported automatically.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,13 @@ See [LICENSE](LICENSE) for details.
 
 ## VRChat SDK Versions
 
-When reporting issues, please specify the SDK version. This project covers SDK 3.7.1 - 3.10.4.
+When reporting issues, please specify the SDK version.
+
+**Active and verified target**: SDK 3.10.4.
+
+References to SDK 3.7.1-3.10.3 are historical migration information only; they are not supported or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy.
+
+From v4.0.0 onward, the policy is latest stable SDK only. Support moves to a new stable release only after this repository verifies it; a new stable release is not supported automatically.
 
 ## Language
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 [English](README.md) | **日本語** | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -132,9 +132,9 @@ UdonSharpスクリプティングのコアスキルです。コンパイル制�
 |------|---------|
 | **制約** | Udon runtimeで使用不可なC#機能と代替手段（`List<T>` &rarr; `DataList`、`async` &rarr; `SendCustomEventDelayedSeconds`）、Editorで評価される初期化子との境界 |
 | **ネットワーキング** | オーナーシップモデル、Manual/Continuousシンク、FieldChangeCallback、アンチパターン |
-| **NetworkCallable** | SDK 3.8.1以降のパラメータ付きネットワークイベント（最大8引数） |
-| **パーシスタンス** | SDK 3.7.4以降のPlayerData/PlayerObject API |
-| **ダイナミクス** | SDK 3.10.0以降のPhysBones、Contacts、ワールド向けVRC Constraints |
+| **NetworkCallable** | SDK 3.8.1で導入されたパラメータ付きネットワークイベント（最大8引数） |
+| **パーシスタンス** | SDK 3.7.4で導入されたPlayerData/PlayerObject API |
+| **ダイナミクス** | SDK 3.10.0で導入されたPhysBones、Contacts、ワールド向けVRC Constraints |
 | **Webローディング** | 文字列・画像ダウンロード、VRCJson、VRCUrlの制約 |
 | **テンプレート** | 17種のテンプレート（インタラクション、同期パターン、永続化、エディタユーティリティなど） |
 
@@ -211,19 +211,25 @@ Bash版の検証には `jq` が必要です。利用できない場合は入力�
 
 ## SDKバージョン
 
+**現在のサポート対象 / 最終検証済み**: VRChat SDK 3.10.4
+
+v4.0.0以降は最新の安定版SDKのみをサポートし、新しい安定版への切り替えはこのリポジトリで検証してから行います。安定版になっただけで自動的にサポート対象へ追加することはありません。現在の最終検証済みは3.10.4です。
+
+以下の表には、移行時の参考になる機能追加の履歴を残しています。SDK 3.7.1〜3.10.3は履歴情報のみで、このSkillのサポート対象・検証対象ではありません。これはSkill自身のサポート範囲であり、VRChatのSDK方針を示すものではありません。
+
 | SDKバージョン | 主な機能 | ステータス |
 |:-----------:|:-------------|:------:|
-| **3.7.1** | `StringBuilder`、`Regex`、`System.Random` | サポート済み |
-| **3.7.4** | Persistence API（PlayerData / PlayerObject） | サポート済み |
-| **3.7.6** | マルチプラットフォームビルド＆パブリッシュ（PC + Android） | サポート済み |
-| **3.8.0** | PhysBone依存関係ソート、Force Kinematic On Remote | サポート済み |
-| **3.8.1** | `[NetworkCallable]` パラメータ付きイベント、`Others`/`Self` ターゲット | サポート済み |
-| **3.9.0** | Camera Dolly API、Auto Hold Pickup | サポート済み |
-| **3.10.0** | ワールド向けVRChat Dynamics（PhysBones、Contacts、VRC Constraints） | サポート済み |
-| **3.10.1** | バグ修正、安定性の向上 | サポート済み |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | サポート済み |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（アバター）、Mirror 描画タイミング修正 | サポート済み |
-| **3.10.4** | VRCTween、Box形状のContacts、Global Avatar PhysBone Colliders、ワールドの`VRCPhysBoneCollider` Udonアクセス、DataList/DataDictionary容量API | 最新安定版 |
+| **3.7.1** | `StringBuilder`、`Regex`、`System.Random` | 履歴 |
+| **3.7.4** | Persistence API（PlayerData / PlayerObject） | 履歴 |
+| **3.7.6** | マルチプラットフォームビルド＆パブリッシュ（PC + Android） | 履歴 |
+| **3.8.0** | PhysBone依存関係ソート、Force Kinematic On Remote | 履歴 |
+| **3.8.1** | `[NetworkCallable]` パラメータ付きイベント、`Others`/`Self` ターゲット | 履歴 |
+| **3.9.0** | Camera Dolly API、Auto Hold Pickup | 履歴 |
+| **3.10.0** | ワールド向けVRChat Dynamics（PhysBones、Contacts、VRC Constraints） | 履歴 |
+| **3.10.1** | バグ修正、安定性の向上 | 履歴 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones修正、シェーダー時間グローバル | 履歴 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（アバター）、Mirror 描画タイミング修正 | 履歴 |
+| **3.10.4** | VRCTween、Box形状のContacts、Global Avatar PhysBone Colliders、ワールドの`VRCPhysBoneCollider` Udonアクセス、DataList/DataDictionary容量API | 現行サポート / 最終検証済み |
 
 > **注意**: 公開前に、VRChatが現在サポートしているSDKバージョンをプロジェクトで使用していることを確認してください。
 
@@ -238,6 +244,21 @@ Bash版の検証には `jq` が必要です。利用できない場合は入力�
 | VRChatフォーラム（Q&A） | https://ask.vrchat.com/ |
 | VRChat Canny（バグ・機能要望） | https://feedback.vrchat.com/ |
 | VRChat コミュニティGitHub | https://github.com/vrchat-community |
+
+---
+
+<h2 id="community-contributors">コミュニティからの貢献</h2>
+
+具体的なIssueを立て、検証や修正方針まで一緒に詰めてくださった皆さんに感謝します。
+
+- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject検索の代替、パフォーマンスの使い分け、疑似複数部屋のパターン、イベントの記載、ネットワークイベントの認可 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
+- [@Guribo](https://github.com/Guribo) — オーナーシップ移譲のタイミングとネットワークのアンチパターン検証 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
+- [@haru0416-dev](https://github.com/haru0416-dev) — インストーラーの更新整合性とjqなし環境での検証 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
+- [@Yodokoro](https://github.com/Yodokoro) — レイヤーの挙動、NetworkCallableの案内、空間音声の設定 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
+- [@tetradice](https://github.com/tetradice) — Agent Skillのメタデータ互換性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
+- [@owlboy](https://github.com/owlboy) — Steam Audioのドキュメント修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
+- [@nomlasvrc](https://github.com/nomlasvrc) — 非推奨のVRCInstantiateの整理 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
+- [@ureishi](https://github.com/ureishi) — UdonSharpのフィールド・シリアライズ挙動とSDK 3.10.4の知識 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
 
 ---
 
@@ -264,7 +285,7 @@ Bash版の検証には `jq` が必要です。利用できない場合は入力�
 - コンテンツは**「現状のまま」**提供されており、いかなる保証もありません。[LICENSE](LICENSE) をご確認ください。
 - これは個人プロジェクトです。**誤り、古くなった情報、または不完全な内容が含まれる可能性があります。** 常に[VRChat公式ドキュメント](https://creators.vrchat.com/)で確認してください。
 - このリポジトリが原因で生じた問題（ビルドエラー、アップロード拒否、予期しないワールドの動作など）について、作者は一切責任を負いません。
-- SDKカバレッジ（3.7.1〜3.10.4）は最終更新時点のものです。新しいVRChatリリースで動作が変わる可能性があります。
+- 現在のSDKサポート対象は、最終検証済みの3.10.4のみです。古いバージョンの行は移行時の履歴情報であり、そのSDKの検証や修正を約束するものではありません。新しいVRChatリリースで動作が変わる可能性があります。
 
 ### AI支援による作成
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -258,7 +258,7 @@ v4.0.0以降は最新の安定版SDKのみをサポートし、新しい安定�
 - [@tetradice](https://github.com/tetradice) — Agent Skillのメタデータ互換性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
 - [@owlboy](https://github.com/owlboy) — Steam Audioのドキュメント修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
 - [@nomlasvrc](https://github.com/nomlasvrc) — 非推奨のVRCInstantiateの整理 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharpのフィールド・シリアライズ挙動とSDK 3.10.4の知識 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
+- [@ureishi](https://github.com/ureishi) — UdonSharpのフィールド・シリアライズ挙動、SDK 3.10.4の知識、配列コールバックの注意点 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -258,7 +258,7 @@ v4.0.0부터는 최신 안정 SDK만 지원하며, 새 안정 버전으로의 �
 - [@tetradice](https://github.com/tetradice) — Agent Skill 메타데이터 호환성 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
 - [@owlboy](https://github.com/owlboy) — Steam Audio 문서 수정 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
 - [@nomlasvrc](https://github.com/nomlasvrc) — 더 이상 권장되지 않는 VRCInstantiate 정리 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp 필드와 직렬화 동작, 그리고 SDK 3.10.4 지식 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
+- [@ureishi](https://github.com/ureishi) — UdonSharp 필드와 직렬화 동작, SDK 3.10.4 지식, 배열 콜백의 주의점 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | **한국어**
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="에이전트 스킬" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="라이선스" />
@@ -132,9 +132,9 @@ UdonSharp 스크립팅 핵심 스킬. 컴파일 제약, 네트워킹, 이벤트,
 |------|------|
 | **제약** | Udon runtime에서 차단된 C# 기능과 대안 (`List<T>` → `DataList`, `async` → `SendCustomEventDelayedSeconds`), Editor 필드 초기화 경계 |
 | **네트워킹** | Ownership 모델, Manual/Continuous 동기화, FieldChangeCallback, 안티패턴 |
-| **NetworkCallable** | SDK 3.8.1+ 매개변수화된 네트워크 이벤트 (최대 8개 인수) |
-| **Persistence** | SDK 3.7.4+ PlayerData/PlayerObject API |
-| **Dynamics** | SDK 3.10.0+ PhysBones, Contacts, VRC Constraints for Worlds |
+| **NetworkCallable** | SDK 3.8.1에서 도입된 매개변수화된 네트워크 이벤트 (최대 8개 인수) |
+| **Persistence** | SDK 3.7.4에서 도입된 PlayerData/PlayerObject API |
+| **Dynamics** | SDK 3.10.0에서 도입된 PhysBones, Contacts, VRC Constraints for Worlds |
 | **웹 로딩** | String/Image 다운로드, VRCJson, VRCUrl 제약 |
 | **템플릿** | 17개 템플릿 (인터랙션, 동기화 패턴, 지속성, 에디터 유틸리티 등) |
 
@@ -211,19 +211,25 @@ validation skipped (JQ_UNAVAILABLE)`을 출력합니다.
 
 ## SDK 버전
 
+**현재 지원 / 마지막 검증**: VRChat SDK 3.10.4
+
+v4.0.0부터는 최신 안정 SDK만 지원하며, 새 안정 버전으로의 지원 전환은 이 저장소에서 검증한 뒤에만 진행합니다. 안정 버전이 되었다는 이유만으로 자동 지원하지 않습니다. 현재 마지막으로 검증한 대상은 3.10.4입니다.
+
+아래 표에는 마이그레이션에 참고할 수 있는 기능 도입 이력을 남겨 두었습니다. SDK 3.7.1-3.10.3 항목은 과거 기록일 뿐이며, 이 Skill의 지원 또는 검증 대상이 아닙니다. 이는 이 Skill의 지원 범위이며 VRChat 자체의 SDK 정책을 뜻하지 않습니다.
+
 | SDK 버전 | 주요 기능 | 상태 |
 |:--------:|:----------|:----:|
-| **3.7.1** | `StringBuilder`, `Regex`, `System.Random` | 지원 |
-| **3.7.4** | Persistence API (PlayerData / PlayerObject) | 지원 |
-| **3.7.6** | 멀티 플랫폼 빌드 & 퍼블리시 (PC + Android) | 지원 |
-| **3.8.0** | PhysBone 종속성 정렬, Force Kinematic On Remote | 지원 |
-| **3.8.1** | `[NetworkCallable]` 매개변수화된 이벤트, `Others`/`Self` 타겟 | 지원 |
-| **3.9.0** | Camera Dolly API, Auto Hold pickup | 지원 |
-| **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | 지원 |
-| **3.10.1** | 버그 수정, 안정성 개선 | 지원 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 지원 |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (아바타), Mirror 렌더 순서 수정 | 지원 |
-| **3.10.4** | VRCTween, Box형 Contacts, Global Avatar PhysBone Colliders, 월드 `VRCPhysBoneCollider` Udon 접근, DataList/DataDictionary 용량 API | 최신 안정 버전 |
+| **3.7.1** | `StringBuilder`, `Regex`, `System.Random` | 과거 기록 |
+| **3.7.4** | Persistence API (PlayerData / PlayerObject) | 과거 기록 |
+| **3.7.6** | 멀티 플랫폼 빌드 & 퍼블리시 (PC + Android) | 과거 기록 |
+| **3.8.0** | PhysBone 종속성 정렬, Force Kinematic On Remote | 과거 기록 |
+| **3.8.1** | `[NetworkCallable]` 매개변수화된 이벤트, `Others`/`Self` 타겟 | 과거 기록 |
+| **3.9.0** | Camera Dolly API, Auto Hold pickup | 과거 기록 |
+| **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | 과거 기록 |
+| **3.10.1** | 버그 수정, 안정성 개선 | 과거 기록 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones 수정, 셰이더 시간 글로벌 변수 | 과거 기록 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (아바타), Mirror 렌더 순서 수정 | 과거 기록 |
+| **3.10.4** | VRCTween, Box형 Contacts, Global Avatar PhysBone Colliders, 월드 `VRCPhysBoneCollider` Udon 접근, DataList/DataDictionary 용량 API | 현재 지원 / 마지막 검증 |
 
 > **참고**: 게시하기 전에 프로젝트에서 VRChat이 현재 지원하는 SDK 버전을 사용하고 있는지 확인하세요.
 
@@ -238,6 +244,21 @@ validation skipped (JQ_UNAVAILABLE)`을 출력합니다.
 | VRChat Forums (Q&A) | https://ask.vrchat.com/ |
 | VRChat Canny (버그/기능 요청) | https://feedback.vrchat.com/ |
 | VRChat Community GitHub | https://github.com/vrchat-community |
+
+---
+
+<h2 id="community-contributors">커뮤니티 기여자</h2>
+
+구체적인 Issue를 제보하고 검증과 수정 방향을 함께 다듬어 주신 분들께 감사드립니다.
+
+- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject 조회 대안, 성능 선택지, 재사용 가능한 방 패턴, 이벤트 문서 보완과 네트워크 이벤트 권한 부여 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
+- [@Guribo](https://github.com/Guribo) — 소유권 이전 시점과 네트워크 안티패턴 검증 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
+- [@haru0416-dev](https://github.com/haru0416-dev) — 설치 프로그램 업그레이드 일관성과 jq가 없는 환경의 안전한 검증 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
+- [@Yodokoro](https://github.com/Yodokoro) — 레이어 동작, NetworkCallable 안내, 공간 음향 설정 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
+- [@tetradice](https://github.com/tetradice) — Agent Skill 메타데이터 호환성 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
+- [@owlboy](https://github.com/owlboy) — Steam Audio 문서 수정 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
+- [@nomlasvrc](https://github.com/nomlasvrc) — 더 이상 권장되지 않는 VRCInstantiate 정리 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
+- [@ureishi](https://github.com/ureishi) — UdonSharp 필드와 직렬화 동작, 그리고 SDK 3.10.4 지식 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
 
 ---
 
@@ -264,7 +285,7 @@ validation skipped (JQ_UNAVAILABLE)`을 출력합니다.
 - 콘텐츠는 어떠한 보증 없이 **"있는 그대로"** 제공됩니다. [LICENSE](LICENSE)를 참조하세요.
 - 이것은 개인 프로젝트입니다. **오류, 오래된 정보, 불완전한 내용이 있을 수 있습니다.** 반드시 [공식 VRChat 문서](https://creators.vrchat.com/)와 대조하여 확인하세요.
 - 이 리포지토리로 인해 발생하는 문제(빌드 오류, 업로드 거부, 예상치 못한 월드 동작 등)에 대해 저자는 어떠한 책임도 지지 않습니다.
-- SDK 지원 범위(3.7.1 - 3.10.4)는 마지막 업데이트 시점을 반영합니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
+- 현재 지원하는 SDK는 마지막으로 검증한 3.10.4뿐입니다. 이전 버전 항목은 마이그레이션을 위한 역사적 정보이며, 해당 SDK를 검증하거나 수정한다는 약속이 아닙니다. 새로운 VRChat 릴리스에 따라 동작이 변경될 수 있습니다.
 
 ### AI 지원 제작
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ This project has benefited from people who took the time to file concrete Issues
 - [@tetradice](https://github.com/tetradice) — Agent Skill metadata compatibility ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
 - [@owlboy](https://github.com/owlboy) — Steam Audio documentation correction ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
 - [@nomlasvrc](https://github.com/nomlasvrc) — deprecated VRCInstantiate cleanup ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp field and serialization behavior, plus SDK 3.10.4 knowledge ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
+- [@ureishi](https://github.com/ureishi) — UdonSharp field and serialization behavior, SDK 3.10.4 knowledge, and array callback caveats ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **English** | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="License" />
@@ -132,9 +132,9 @@ UdonSharp scripting core skill. Covers compile constraints, networking, events, 
 |------|---------|
 | **Constraints** | C# features blocked in Udon runtime, their alternatives (`List<T>` &rarr; `DataList`, `async` &rarr; `SendCustomEventDelayedSeconds`), and the Editor-evaluated initializer boundary |
 | **Networking** | Ownership model, Manual/Continuous sync, FieldChangeCallback, anti-patterns |
-| **NetworkCallable** | SDK 3.8.1+ parameterized network events (up to 8 args) |
-| **Persistence** | SDK 3.7.4+ PlayerData/PlayerObject API |
-| **Dynamics** | SDK 3.10.0+ PhysBones, Contacts, VRC Constraints for Worlds |
+| **NetworkCallable** | Introduced in SDK 3.8.1: parameterized network events (up to 8 args) |
+| **Persistence** | Introduced in SDK 3.7.4: PlayerData/PlayerObject API |
+| **Dynamics** | Introduced in SDK 3.10.0: PhysBones, Contacts, VRC Constraints for Worlds |
 | **Web Loading** | String/Image download, VRCJson, VRCUrl constraints |
 | **Templates** | 17 templates (interactions, sync patterns, persistence, editor utilities, and more) |
 
@@ -211,19 +211,25 @@ through unchanged and emits `VALIDATOR-WARNING: validation skipped
 
 ## SDK Versions
 
+**Active support / last verified**: VRChat SDK 3.10.4
+
+From v4.0.0 onward, the support policy is latest stable SDK only; the support target moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically. Current last verified target: 3.10.4.
+
+The table below keeps historical feature-introduction notes for migration reference. SDK 3.7.1-3.10.3 entries are historical information only; they are not active support or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy.
+
 | SDK Version | Key Features | Status |
 |:-----------:|:-------------|:------:|
-| **3.7.1** | `StringBuilder`, `Regex`, `System.Random` | Supported |
-| **3.7.4** | Persistence API (PlayerData / PlayerObject) | Supported |
-| **3.7.6** | Multi-platform Build & Publish (PC + Android) | Supported |
-| **3.8.0** | PhysBone dependency sorting, Force Kinematic On Remote | Supported |
-| **3.8.1** | `[NetworkCallable]` parameterized events, `Others`/`Self` targets | Supported |
-| **3.9.0** | Camera Dolly API, Auto Hold pickup | Supported |
-| **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | Supported |
-| **3.10.1** | Bug fixes, stability improvements | Supported |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Supported |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Supported |
-| **3.10.4** | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary capacity APIs | Latest Stable |
+| **3.7.1** | `StringBuilder`, `Regex`, `System.Random` | Historical |
+| **3.7.4** | Persistence API (PlayerData / PlayerObject) | Historical |
+| **3.7.6** | Multi-platform Build & Publish (PC + Android) | Historical |
+| **3.8.0** | PhysBone dependency sorting, Force Kinematic On Remote | Historical |
+| **3.8.1** | `[NetworkCallable]` parameterized events, `Others`/`Self` targets | Historical |
+| **3.9.0** | Camera Dolly API, Auto Hold pickup | Historical |
+| **3.10.0** | VRChat Dynamics for Worlds (PhysBones, Contacts, VRC Constraints) | Historical |
+| **3.10.1** | Bug fixes, stability improvements | Historical |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate, PhysBones fixes, shader time globals | Historical |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Historical |
+| **3.10.4** | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary capacity APIs | Active / Last verified |
 
 > **Note**: Before publishing, confirm that the project uses an SDK version currently supported by VRChat.
 
@@ -238,6 +244,21 @@ through unchanged and emits `VALIDATOR-WARNING: validation skipped
 | VRChat Forums (Q&A) | https://ask.vrchat.com/ |
 | VRChat Canny (Bugs/Features) | https://feedback.vrchat.com/ |
 | VRChat Community GitHub | https://github.com/vrchat-community |
+
+---
+
+<h2 id="community-contributors">Community Contributors</h2>
+
+This project has benefited from people who took the time to file concrete Issues and help verify the fixes. Thank you to:
+
+- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject lookup alternatives, performance trade-offs, reusable-room patterns, event coverage, and network-event authorization ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
+- [@Guribo](https://github.com/Guribo) — ownership-transfer timing and networking anti-pattern verification ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
+- [@haru0416-dev](https://github.com/haru0416-dev) — installer upgrade consistency and jq-safe validation ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
+- [@Yodokoro](https://github.com/Yodokoro) — layer behavior, NetworkCallable guidance, and spatial-audio setup ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
+- [@tetradice](https://github.com/tetradice) — Agent Skill metadata compatibility ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
+- [@owlboy](https://github.com/owlboy) — Steam Audio documentation correction ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
+- [@nomlasvrc](https://github.com/nomlasvrc) — deprecated VRCInstantiate cleanup ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
+- [@ureishi](https://github.com/ureishi) — UdonSharp field and serialization behavior, plus SDK 3.10.4 knowledge ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
 
 ---
 
@@ -264,7 +285,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 - Content is provided **"AS IS"** without warranty. See [LICENSE](LICENSE).
 - This is a personal project. **Errors, outdated information, or incomplete content may exist.** Always verify against [official VRChat documentation](https://creators.vrchat.com/).
 - The author assumes no liability for issues caused by this repository (build errors, upload rejections, unexpected world behavior, etc.).
-- SDK coverage (3.7.1 - 3.10.4) reflects the last update. Behavior may change with new VRChat releases.
+- Active SDK support is limited to 3.10.4, the last verified target. Older version entries are historical migration information, not a promise to test or fix those SDKs. Behavior may change with new VRChat releases.
 
 ### AI-Assisted Creation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -257,7 +257,7 @@ Bash 验证器需要 `jq`。如果无法使用 `jq`，钩子会原样传递输�
 - [@tetradice](https://github.com/tetradice) — Agent Skill 元数据兼容性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
 - [@owlboy](https://github.com/owlboy) — Steam Audio 文档修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
 - [@nomlasvrc](https://github.com/nomlasvrc) — 移除已弃用的 VRCInstantiate 用法 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp 字段与序列化行为，以及 SDK 3.10.4 知识 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
+- [@ureishi](https://github.com/ureishi) — UdonSharp 字段与序列化行为、SDK 3.10.4 知识，以及数组回调的注意事项 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | **简体中文** | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="AI Agent 技能" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="许可证" />
@@ -132,9 +132,9 @@ UdonSharp 脚本核心技能。涵盖编译约束、网络同步、事件和模�
 |------|------|
 | **约束** | Udon runtime 中被禁用的 C# 特性及替代方案（`List<T>` &rarr; `DataList`、`async` &rarr; `SendCustomEventDelayedSeconds`），以及 Editor 字段初始化式的边界 |
 | **网络同步** | Ownership 模型、Manual/Continuous 同步、FieldChangeCallback、反模式 |
-| **NetworkCallable** | SDK 3.8.1+ 参数化网络事件（最多 8 个参数） |
-| **持久化** | SDK 3.7.4+ PlayerData/PlayerObject API |
-| **动态组件** | SDK 3.10.0+ PhysBones、Contacts、VRC Constraints for Worlds |
+| **NetworkCallable** | SDK 3.8.1 引入的参数化网络事件（最多 8 个参数） |
+| **持久化** | SDK 3.7.4 引入的 PlayerData/PlayerObject API |
+| **动态组件** | SDK 3.10.0 引入的 PhysBones、Contacts、VRC Constraints for Worlds |
 | **网络加载** | String/Image 下载、VRCJson、VRCUrl 约束 |
 | **模板** | 17 个模板（交互、同步模式、持久化、编辑器工具等） |
 
@@ -210,19 +210,25 @@ Bash 验证器需要 `jq`。如果无法使用 `jq`，钩子会原样传递输�
 
 ## SDK 版本
 
+**当前支持 / 最后验证**：VRChat SDK 3.10.4
+
+从 v4.0.0 起，本项目只支持最新的稳定版 SDK；只有在本仓库完成验证后，支持目标才会切换到新的稳定版本。目前最后验证的目标是 3.10.4。
+
+下表保留了便于迁移参考的功能引入历史。SDK 3.7.1-3.10.3的条目仅供历史参考，不属于本 Skill 的支持或验证目标。这是本 Skill 的支持边界，并不代表 VRChat 自身的 SDK 政策。
+
 | SDK 版本 | 主要特性 | 状态 |
 |:--------:|:---------|:----:|
-| **3.7.1** | `StringBuilder`、`Regex`、`System.Random` | 已支持 |
-| **3.7.4** | Persistence API（PlayerData / PlayerObject） | 已支持 |
-| **3.7.6** | 多平台构建与发布（PC + Android） | 已支持 |
-| **3.8.0** | PhysBone 依赖排序、Force Kinematic On Remote | 已支持 |
-| **3.8.1** | `[NetworkCallable]` 参数化事件、`Others`/`Self` 目标 | 已支持 |
-| **3.9.0** | Camera Dolly API、Auto Hold 拾取 | 已支持 |
-| **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支持 |
-| **3.10.1** | Bug 修复、稳定性改进 | 已支持 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 已支持 |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（头像）、Mirror 渲染顺序修复 | 已支持 |
-| **3.10.4** | VRCTween、Box 形 Contacts、Global Avatar PhysBone Colliders、世界 `VRCPhysBoneCollider` Udon 访问、DataList/DataDictionary 容量 API | 最新稳定版 |
+| **3.7.1** | `StringBuilder`、`Regex`、`System.Random` | 历史 |
+| **3.7.4** | Persistence API（PlayerData / PlayerObject） | 历史 |
+| **3.7.6** | 多平台构建与发布（PC + Android） | 历史 |
+| **3.8.0** | PhysBone 依赖排序、Force Kinematic On Remote | 历史 |
+| **3.8.1** | `[NetworkCallable]` 参数化事件、`Others`/`Self` 目标 | 历史 |
+| **3.9.0** | Camera Dolly API、Auto Hold 拾取 | 历史 |
+| **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 历史 |
+| **3.10.1** | Bug 修复、稳定性改进 | 历史 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修复、着色器时间全局变量 | 历史 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（头像）、Mirror 渲染顺序修复 | 历史 |
+| **3.10.4** | VRCTween、Box 形 Contacts、Global Avatar PhysBone Colliders、世界 `VRCPhysBoneCollider` Udon 访问、DataList/DataDictionary 容量 API | 当前支持 / 最后验证 |
 
 > **注意**：发布前，请确认项目使用的是 VRChat 当前支持的 SDK 版本。
 
@@ -237,6 +243,21 @@ Bash 验证器需要 `jq`。如果无法使用 `jq`，钩子会原样传递输�
 | VRChat 论坛（问答） | https://ask.vrchat.com/ |
 | VRChat Canny（Bug/功能请求） | https://feedback.vrchat.com/ |
 | VRChat 社区 GitHub | https://github.com/vrchat-community |
+
+---
+
+<h2 id="community-contributors">社区贡献者</h2>
+
+感谢这些提交具体 Issue、参与验证并帮助完善修正方案的贡献者。
+
+- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject 查找替代方案、性能取舍、可复用房间模式、事件文档覆盖和网络事件授权 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
+- [@Guribo](https://github.com/Guribo) — 所有权转移时机和网络反模式验证 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
+- [@haru0416-dev](https://github.com/haru0416-dev) — 安装器升级一致性和无 jq 环境下的安全验证 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
+- [@Yodokoro](https://github.com/Yodokoro) — 图层行为、NetworkCallable 指引和空间音频设置 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
+- [@tetradice](https://github.com/tetradice) — Agent Skill 元数据兼容性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
+- [@owlboy](https://github.com/owlboy) — Steam Audio 文档修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
+- [@nomlasvrc](https://github.com/nomlasvrc) — 移除已弃用的 VRCInstantiate 用法 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
+- [@ureishi](https://github.com/ureishi) — UdonSharp 字段与序列化行为，以及 SDK 3.10.4 知识 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
 
 ---
 
@@ -263,7 +284,7 @@ Bash 验证器需要 `jq`。如果无法使用 `jq`，钩子会原样传递输�
 - 内容以 **"按原样"（AS IS）** 提供，不附带任何保证。请参阅 [LICENSE](LICENSE)。
 - 这是一个个人项目。**可能存在错误、过时信息或不完整的内容。** 请始终以 [VRChat 官方文档](https://creators.vrchat.com/) 为准进行验证。
 - 作者不对因使用本仓库而导致的任何问题（构建错误、上传被拒、意外的世界行为等）承担责任。
-- SDK 覆盖范围（3.7.1 - 3.10.4）反映最后一次更新的状态。VRChat 新版本发布后，行为可能会发生变化。
+- 当前支持的 SDK 仅为最后验证过的 3.10.4。较旧版本的条目只是迁移历史信息，并不承诺对这些 SDK 进行验证或修复。VRChat 新版本发布后，行为可能会发生变化。
 
 ### AI 辅助创建
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,7 +1,7 @@
 [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | **繁體中文** | [한국어](README.ko.md)
 
 <p align="center">
-  <img src="https://img.shields.io/badge/VRChat_SDK-3.7.1--3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
+  <img src="https://img.shields.io/badge/VRChat_SDK-3.10.4-00b4d8?style=for-the-badge" alt="VRChat SDK" />
   <img src="https://img.shields.io/badge/UdonSharp-C%23_%E2%86%92_Udon-5C2D91?style=for-the-badge&logo=csharp&logoColor=white" alt="UdonSharp" />
   <img src="https://img.shields.io/badge/AI_Agent-Skills_%26_Rules-ff6b35?style=for-the-badge" alt="Agent Skills" />
   <img src="https://img.shields.io/github/license/niaka3dayo/agent-skills-vrc-udon?style=for-the-badge" alt="授權條款" />
@@ -132,9 +132,9 @@ UdonSharp 腳本核心技能。涵蓋編譯限制、網路、事件與範本。
 |------|------|
 | **限制** | Udon runtime 中被禁止的 C# 功能與替代方案（`List<T>` → `DataList`、`async` → `SendCustomEventDelayedSeconds`），以及 Editor 欄位初始設定式的邊界 |
 | **網路** | 所有權模型、Manual/Continuous 同步、FieldChangeCallback、反模式 |
-| **NetworkCallable** | SDK 3.8.1+ 參數化網路事件（最多 8 個參數） |
-| **持久化** | SDK 3.7.4+ PlayerData/PlayerObject API |
-| **動態元件** | SDK 3.10.0+ PhysBones、Contacts、VRC Constraints for Worlds |
+| **NetworkCallable** | SDK 3.8.1 導入的參數化網路事件（最多 8 個參數） |
+| **持久化** | SDK 3.7.4 導入的 PlayerData/PlayerObject API |
+| **動態元件** | SDK 3.10.0 導入的 PhysBones、Contacts、VRC Constraints for Worlds |
 | **網頁載入** | String/Image 下載、VRCJson、VRCUrl 限制 |
 | **範本** | 17 個範本（互動、同步模式、持久化、編輯器工具等） |
 
@@ -210,19 +210,25 @@ Bash 驗證器需要 `jq`。若無法使用 `jq`，掛鉤會原樣傳遞輸入�
 
 ## SDK 版本
 
+**目前支援 / 最後驗證**：VRChat SDK 3.10.4
+
+從 v4.0.0 起，本專案只支援最新的穩定版 SDK；只有在本儲存庫完成驗證後，支援目標才會切換到新的穩定版本。目前最後驗證的目標是 3.10.4。
+
+下表保留了方便移轉參考的功能導入歷史。SDK 3.7.1-3.10.3的項目僅供歷史參考，不是本 Skill 的支援或驗證目標。這是本 Skill 的支援界線，不代表 VRChat 自身的 SDK 政策。
+
 | SDK 版本 | 主要功能 | 狀態 |
 |:--------:|:---------|:----:|
-| **3.7.1** | `StringBuilder`、`Regex`、`System.Random` | 已支援 |
-| **3.7.4** | Persistence API（PlayerData / PlayerObject） | 已支援 |
-| **3.7.6** | 多平台建置與發布（PC + Android） | 已支援 |
-| **3.8.0** | PhysBone 依賴排序、Force Kinematic On Remote | 已支援 |
-| **3.8.1** | `[NetworkCallable]` 參數化事件、`Others`/`Self` 目標 | 已支援 |
-| **3.9.0** | Camera Dolly API、Auto Hold pickup | 已支援 |
-| **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 已支援 |
-| **3.10.1** | 錯誤修正、穩定性改善 | 已支援 |
-| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 已支援 |
-| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（頭像）、Mirror 渲染順序修正 | 已支援 |
-| **3.10.4** | VRCTween、Box 形 Contacts、Global Avatar PhysBone Colliders、世界 `VRCPhysBoneCollider` Udon 存取、DataList/DataDictionary 容量 API | 最新穩定版 |
+| **3.7.1** | `StringBuilder`、`Regex`、`System.Random` | 歷史 |
+| **3.7.4** | Persistence API（PlayerData / PlayerObject） | 歷史 |
+| **3.7.6** | 多平台建置與發布（PC + Android） | 歷史 |
+| **3.8.0** | PhysBone 依賴排序、Force Kinematic On Remote | 歷史 |
+| **3.8.1** | `[NetworkCallable]` 參數化事件、`Others`/`Self` 目標 | 歷史 |
+| **3.9.0** | Camera Dolly API、Auto Hold pickup | 歷史 |
+| **3.10.0** | VRChat Dynamics for Worlds（PhysBones、Contacts、VRC Constraints） | 歷史 |
+| **3.10.1** | 錯誤修正、穩定性改善 | 歷史 |
+| **3.10.2** | EventTiming.PostLateUpdate/FixedUpdate、PhysBones 修正、shader 時間全域變數 | 歷史 |
+| **3.10.3** | `VRCPlayerApi.isVRCPlus`、VRCRaycast（頭像）、Mirror 渲染順序修正 | 歷史 |
+| **3.10.4** | VRCTween、Box 形 Contacts、Global Avatar PhysBone Colliders、世界 `VRCPhysBoneCollider` Udon 存取、DataList/DataDictionary 容量 API | 目前支援 / 最後驗證 |
 
 > **注意**：發佈前，請確認專案使用的是 VRChat 目前支援的 SDK 版本。
 
@@ -237,6 +243,21 @@ Bash 驗證器需要 `jq`。若無法使用 `jq`，掛鉤會原樣傳遞輸入�
 | VRChat 論壇（問答） | https://ask.vrchat.com/ |
 | VRChat Canny（錯誤/功能建議） | https://feedback.vrchat.com/ |
 | VRChat 社群 GitHub | https://github.com/vrchat-community |
+
+---
+
+<h2 id="community-contributors">社群貢獻者</h2>
+
+感謝這些提出具體 Issue、參與驗證並協助完善修正方案的貢獻者。
+
+- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject 搜尋替代方案、效能取捨、可重複使用的房間模式、事件文件涵蓋與網路事件授權 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
+- [@Guribo](https://github.com/Guribo) — 所有權轉移時機與網路反模式驗證 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
+- [@haru0416-dev](https://github.com/haru0416-dev) — 安裝器升級一致性與無 jq 環境的安全驗證 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
+- [@Yodokoro](https://github.com/Yodokoro) — 圖層行為、NetworkCallable 指引與空間音訊設定 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
+- [@tetradice](https://github.com/tetradice) — Agent Skill 中繼資料相容性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
+- [@owlboy](https://github.com/owlboy) — Steam Audio 文件修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
+- [@nomlasvrc](https://github.com/nomlasvrc) — 移除已棄用的 VRCInstantiate 用法 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
+- [@ureishi](https://github.com/ureishi) — UdonSharp 欄位與序列化行為，以及 SDK 3.10.4 知識 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
 
 ---
 
@@ -263,7 +284,7 @@ Bash 驗證器需要 `jq`。若無法使用 `jq`，掛鉤會原樣傳遞輸入�
 - 內容以**「現狀」**提供，不附帶任何保證。請參閱 [LICENSE](LICENSE)。
 - 這是一個個人專案。**可能存在錯誤、過時資訊或不完整的內容。** 請務必與 [VRChat 官方文件](https://creators.vrchat.com/) 進行核對。
 - 作者不對本儲存庫造成的問題承擔任何責任（建置錯誤、上傳被拒絕、非預期的世界行為等）。
-- SDK 涵蓋範圍（3.7.1 - 3.10.4）反映的是最後更新時的狀態。VRChat 發布新版本時，行為可能會有所變更。
+- 目前支援的 SDK 僅限最後驗證過的 3.10.4。較舊版本的項目只是移轉歷史資訊，不承諾對這些 SDK 進行驗證或修正。VRChat 發布新版本時，行為可能會有所變更。
 
 ### AI 輔助建立
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -257,7 +257,7 @@ Bash 驗證器需要 `jq`。若無法使用 `jq`，掛鉤會原樣傳遞輸入�
 - [@tetradice](https://github.com/tetradice) — Agent Skill 中繼資料相容性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
 - [@owlboy](https://github.com/owlboy) — Steam Audio 文件修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
 - [@nomlasvrc](https://github.com/nomlasvrc) — 移除已棄用的 VRCInstantiate 用法 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp 欄位與序列化行為，以及 SDK 3.10.4 知識 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342))
+- [@ureishi](https://github.com/ureishi) — UdonSharp 欄位與序列化行為、SDK 3.10.4 知識，以及陣列回呼的注意事項 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -1,6 +1,8 @@
 # UdonSharp Cheatsheet
 
-**SDK 3.7.1 - 3.10.4 Coverage**
+**Active support / last verified**: SDK 3.10.4
+
+SDK 3.7.1-3.10.3 labels below are historical feature-introduction notes only; they are not supported or validation targets for this Skill.
 
 ## Features Blocked in Udon Runtime
 
@@ -16,7 +18,7 @@ These alternatives apply to code that executes in Udon. Editor-evaluated field i
 | LINQ | `for` loops |
 | `interface` | Base class / `SendCustomEvent` |
 
-## Available Features (SDK 3.7.1+)
+## Available Features (historical baseline: SDK 3.7.1)
 
 | Feature | SDK | Notes |
 |---------|-----|-------|
@@ -210,7 +212,7 @@ public void _DoLoop() {
 }
 ```
 
-For cancelable timers on SDK 3.10.4+, use `VRCTween.DelayedCall`; keep helper-`GameObject` cancellation workarounds only for older SDK projects.
+For cancelable timers on the active SDK target (3.10.4), use `VRCTween.DelayedCall`. The helper-`GameObject` workaround below is historical migration guidance for unsupported older projects only.
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -216,7 +216,7 @@ For cancelable timers on the active SDK target (3.10.4), use `VRCTween.DelayedCa
 
 ---
 
-## VRCTween (SDK 3.10.4+)
+## VRCTween (introduced in SDK 3.10.4)
 
 ```csharp
 using VRC.SDK3.Components;
@@ -241,7 +241,7 @@ void OnDestroy() {
 | Need | Use | Notes |
 |------|-----|-------|
 | Smooth transform/UI/audio changes | `TweenPosition`, `TweenScale`, `TweenFade`, `TweenPitch` | Returns `VRCTweenHandle` |
-| Cancelable delayed event | `VRCTween.DelayedCall(this, nameof(Method), seconds)` | Prefer over helper objects on SDK 3.10.4+ |
+| Cancelable delayed event | `VRCTween.DelayedCall(this, nameof(Method), seconds)` | Prefer over helper objects on the active SDK target (3.10.4) |
 | Delayed active toggle | `VRCTween.DelayedSetActive(target, active, seconds)` | Use for local visibility/state toggles |
 | Cleanup | `handle.Kill()` / `gameObject.KillAllTweens()` | Kill stored handles and long/infinite tweens |
 | High-frequency retargeting | `ChangeEndValue`, `SetDuration`, `SetEase`, `Restart` | Reuse a handle instead of kill/recreate in hot paths |

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: unity-vrc-udon-sharp
 description: >-
-    UdonSharp scripting skill for SDK 3.7.1-3.10.4. Use when writing,
+    UdonSharp scripting skill for VRChat SDK 3.10.4 (active and verified target). Use when writing,
     reviewing, debugging, or migrating UdonSharp C# and UdonBehaviour code.
     Positive triggers include UdonSharp, NetworkCallable, NetworkCalling,
     CallingPlayer, Udon network authorization, synced runtime state, a local public helper,
@@ -81,9 +81,9 @@ These Udon runtime constraints cause either **compile-time failures** or **silen
 | 10 | Use `Button.onClick.AddListener()` | Not available in Udon — no runtime delegate support | Configure `SendCustomEvent` via Inspector OnClick |
 | 11 | Mix Continuous and Manual sync concerns on one behaviour | Wastes bandwidth (discrete values in Continuous) or loses control (redundant `RequestSerialization` in Continuous) | Separate behaviours: Continuous for position/rotation, Manual for discrete state |
 | 12 | Write to `[UdonSynced]` fields without an `IsOwner` guard | Non-owner writes are purely local and silently reverted on the next deserialization from the actual owner | `Networking.SetOwner` first if needed (locally immediate), then write under `IsOwner` and call `RequestSerialization()` |
-| 13 | Use `[NetworkCallable]` on SDK < 3.8.1 | Compile error — the attribute and parameterized network-event API are unavailable | Upgrade to SDK 3.8.1+; otherwise use synced variables and react in `OnDeserialization`/`FieldChangeCallback` instead of pairing them with a network event |
-| 14 | Use PhysBones/Contacts API (`OnPhysBoneGrabbed`, `OnContactEnter`, etc.) on SDK < 3.10.0 | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Verify SDK >= 3.10.0; Dynamics for Worlds was added in 3.10.0 |
-| 15 | Use `PlayerData` persistence API on SDK < 3.7.4 | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Verify SDK >= 3.7.4; persistence was added in 3.7.4 |
+| 13 | Use `[NetworkCallable]` on an unsupported SDK below 3.8.1 (historical migration only) | Compile error — the attribute and parameterized network-event API are unavailable | Use the active SDK target, 3.10.4; for historical migration notes, use synced variables and react in `OnDeserialization`/`FieldChangeCallback` instead of pairing them with a network event |
+| 14 | Use PhysBones/Contacts API (`OnPhysBoneGrabbed`, `OnContactEnter`, etc.) on an unsupported SDK below 3.10.0 (historical migration only) | Compiles but silently ignored at runtime — world-side Dynamics did not exist pre-3.10.0, so callbacks never fire | Use the active SDK target, 3.10.4; for historical migration, verify the project is at least SDK 3.10.0 |
+| 15 | Use `PlayerData` persistence API on an unsupported SDK below 3.7.4 (historical migration only) | Compile error — missing symbol; `PlayerData`, `PlayerObject`, and `OnPlayerRestored` were added in 3.7.4 and are not in the Udon whitelist before then | Use the active SDK target, 3.10.4; for historical migration, verify the project is at least SDK 3.7.4 |
 | 16 | Put a Unity `.asmdef` around UdonSharpBehaviour without matching U# Assembly Definition | Unity compiles the C# assembly, but UdonSharp reports the script does not belong to a U# assembly | For simple world scripts, avoid asmdef; for package/asmdef workflows, create the corresponding U# Assembly Definition and set Source Assembly to the Unity `.asmdef` (see `references/assembly-definitions.md`) |
 | 17 | Create a `.cs` script without a corresponding `.asset` file | Script is not recognized as UdonBehaviour — "The associated script cannot be loaded", no Udon compilation | **Every time** a `.cs` is created: verify `Assets/Editor/UdonSharpProgramAssetAutoGenerator.cs` exists, install from `references/editor-scripting.md` if missing, notify the user (see Rule 8 in `rules/udonsharp-constraints.md`) |
 | 18 | Call `Debug.Log()` inside `Update()`, `PostLateUpdate()`, or any per-frame event | VRChat's client-side log rate limiter silently drops excess entries; the implicit string allocation every frame causes sustained GC pressure that tanks framerate. ClientSim and Unity Editor hide both symptoms | Guard with `if (debugMode && Time.frameCount % 60 == 0)`, or move all logging to event-driven callbacks |
@@ -95,7 +95,7 @@ These Udon runtime constraints cause either **compile-time failures** or **silen
 Changing every frame (position, rotation)?    -> Continuous sync
 Changing on user action (toggle, score)?      -> Manual sync + RequestSerialization()
 No sync needed (local UI, effects)?           -> NoVariableSync
-Need reliable one-shot calls with params?     -> [NetworkCallable] (SDK 3.8.1+)
+Need reliable one-shot calls with params?     -> [NetworkCallable] (introduced in SDK 3.8.1; active target 3.10.4)
 Temporary effect for all players, no state?   -> SendCustomNetworkEvent (no synced vars)
 ```
 
@@ -183,13 +183,13 @@ Station + trigger zone detection?       -> troubleshooting.md
 | Interactive object (click/use) | `BasicInteraction.cs` | Cooldown, toggle, audio feedback |
 | Synced toggle / shared object | `SyncedObject.cs` | Ownership guard, FieldChangeCallback, late-joiner init |
 | Per-player movement settings | `PlayerSettings.cs` | Walk/run/jump speed via trigger zone |
-| Contact-based collision detection | `ContactReceiver.cs` | OnContactEnter/Exit, avatar vs world, debounce (SDK 3.10.0+) |
+| Contact-based collision detection | `ContactReceiver.cs` | OnContactEnter/Exit, avatar vs world, debounce (introduced in SDK 3.10.0; active target 3.10.4) |
 | **State & Game Logic** | | |
 | State machine / game flow | `StateMachine.cs` | Timed transitions, synced state, late-joiner safety |
 | Game with undo/history | `UndoableGameManager.cs` | byte[] history, NetworkCallable `_OwnerProcessMove`/`_OwnerUndo`/`_OwnerReset` |
 | Object pool (player slots) | `MasterManagedPlayerPool.cs` | FIFO ring buffer, master-managed, OnPlayerJoined/Left |
 | **Persistence & Data** | | |
-| Save/load player data | `DataPersistence.cs` | PlayerData API, OnPlayerRestored, auto-save (SDK 3.7.4+) |
+| Save/load player data | `DataPersistence.cs` | PlayerData API, OnPlayerRestored, auto-save (introduced in SDK 3.7.4; active target 3.10.4) |
 | **Networking Patterns** | | |
 | Rate-limited sync (slider drag) | `RateLimitedSync.cs` | 0.15s cooldown, last-write-wins |
 | Batched sync (rapid events) | `BatchedSync.cs` | Idempotent schedule, 0.2s delay, single packet |
@@ -218,21 +218,27 @@ Compile constraints and networking rules are defined in **always-loaded Rules**:
 
 ## SDK Versions
 
-| SDK Version | Key Features |
-|-------------|--------------|
-| 3.7.1 | Added `StringBuilder`, `RegularExpressions`, `System.Random` |
-| 3.7.4 | Added **Persistence API** (PlayerData/PlayerObject) |
-| 3.7.6 | Multi-platform Build & Publish (PC + Android simultaneously) |
-| 3.8.0 | PhysBone dependency sorting, Drone API (VRCDroneInteractable) |
-| 3.8.1 | **`[NetworkCallable]`** attribute, parameterized network events, `NetworkCalling.CallingPlayer`/`.InNetworkCall`, `NetworkEventTarget.Others`/`.Self` |
-| 3.9.0 | Camera Dolly API, Auto Hold pickup simplification |
-| 3.10.0 | **VRChat Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints) |
-| 3.10.1 | Bug fixes and stability improvements |
-| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals |
-| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix |
-| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary custom capacity, `DataDictionary.EnsureCapacity` |
+**Active support / last verified**: SDK 3.10.4
 
-Use the current supported SDK for publishing. Check the matching release notes before relying on a version-specific API or migration step.
+From v4.0.0 onward, the policy is latest stable SDK only; support moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically. Current last verified target: 3.10.4.
+
+The table below keeps feature-introduction history for migration reference. SDK 3.7.1-3.10.3 entries are historical information only; they are not active support or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy. Primary generated examples target SDK 3.10.4 unless a reference explicitly marks a historical migration case.
+
+| SDK Version | Key Features | Status |
+|-------------|--------------|--------|
+| 3.7.1 | Added `StringBuilder`, `RegularExpressions`, `System.Random` | Historical |
+| 3.7.4 | Added **Persistence API** (PlayerData/PlayerObject) | Historical |
+| 3.7.6 | Multi-platform Build & Publish (PC + Android simultaneously) | Historical |
+| 3.8.0 | PhysBone dependency sorting, Drone API (VRCDroneInteractable) | Historical |
+| 3.8.1 | **`[NetworkCallable]`** attribute, parameterized network events, `NetworkCalling.CallingPlayer`/`.InNetworkCall`, `NetworkEventTarget.Others`/`.Self` | Historical |
+| 3.9.0 | Camera Dolly API, Auto Hold pickup simplification | Historical |
+| 3.10.0 | **VRChat Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints) | Historical |
+| 3.10.1 | Bug fixes and stability improvements | Historical |
+| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals | Historical |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Historical |
+| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary custom capacity, `DataDictionary.EnsureCapacity` | Active / Last verified |
+
+Use SDK 3.10.4 for publishing. Check the matching release notes before relying on a version-specific API or migration step.
 
 ## Official Resources
 
@@ -252,8 +258,8 @@ Use the current supported SDK for publishing. Check the matching release notes b
 | `networking.md` | Ownership model, sync modes, RequestSerialization, NetworkCallable, network-event sender authorization, data limits | UdonSynced, SetOwner, BehaviourSyncMode, FieldChangeCallback, OnDeserialization, NetworkCalling, CallingPlayer, InNetworkCall, legacy event, underscore, authorization, master leave, ownership cascade |
 | `networking-bandwidth.md` | Bandwidth throttling, bit packing, synced data size examples, debugging, owner-centric architecture | IsClogged, bandwidth, throttle, bit packing, data budget, IsMaster |
 | `networking-antipatterns.md` | 6 anti-patterns to avoid; 5 advanced sync patterns with template links | anti-pattern, race condition, ownership fight, late-joiner, PackedStateSync, BatchedSync |
-| `persistence.md` | Storage layer decision tree (local/synced/PlayerData/PlayerObject); PlayerData/PlayerObject API (SDK 3.7.4+); per-player save data; storage usage query API (SDK 3.10.0+) | storage layer, decision tree, local variable, PlayerData, PlayerObject, OnPlayerRestored, SetInt, TryGetInt, GetPlayerDataStorageUsage, GetPlayerDataStorageLimit, GetPlayerObjectStorageUsage, GetPlayerObjectStorageLimit, RequestStorageUsageUpdate, OnPersistenceUsageUpdated, storage quota, storage usage, which storage, when to use PlayerData |
-| `dynamics.md` | PhysBones, Contacts, VRC Constraints (SDK 3.10.0+); VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access (SDK 3.10.4+) | PhysBone, ContactReceiver, ContactSender, Box Contact, Global Avatar PhysBone Collider, VRCPhysBoneCollider, VRCTween, VRCConstraint, OnContactEnter |
+| `persistence.md` | Storage layer decision tree (local/synced/PlayerData/PlayerObject); PlayerData/PlayerObject API (introduced in SDK 3.7.4; active target 3.10.4); per-player save data; storage usage query API (introduced in SDK 3.10.0; active target 3.10.4) | storage layer, decision tree, local variable, PlayerData, PlayerObject, OnPlayerRestored, SetInt, TryGetInt, GetPlayerDataStorageUsage, GetPlayerDataStorageLimit, GetPlayerObjectStorageUsage, GetPlayerObjectStorageLimit, RequestStorageUsageUpdate, OnPersistenceUsageUpdated, storage quota, storage usage, which storage, when to use PlayerData |
+| `dynamics.md` | PhysBones, Contacts, VRC Constraints (introduced in SDK 3.10.0; active target 3.10.4); VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access (SDK 3.10.4+) | PhysBone, ContactReceiver, ContactSender, Box Contact, Global Avatar PhysBone Collider, VRCPhysBoneCollider, VRCTween, VRCConstraint, OnContactEnter |
 | `patterns-core.md` | Initialization, interaction, player detection, timer, audio, pickup, animation, UI, teleportation, lazy init guard, remote players | Interact, OnEnable, Initialize, AudioSource, VRCPickup, Animator, UI, TeleportTo, remote players, _GetRemotePlayers, exclude local player, FindAll alternative |
 | `patterns-networking.md` | Object pooling, NetworkCallable sender-validation patterns, persistence integration, dynamics interactions, synced game state, distant-room pseudo-multi-room (state/presentation split, self-owned or master-coordinated session arbitration), delayed event debounce, string join for array sync | pool, MasterManagedPlayerPool, NetworkCallable, CallingPlayer, InNetworkCall, sender authorization, DamageReceiver, game state, distant room, pseudo multi-room, room assignment, roomIndex, LocalRoomPresenter, RoomAssignment, NoVariableSync, TeleportTo per-client, debounce, state machine, string join, array sync, paragraph separator, U+2029 |
 | `patterns-performance.md` | Partial class pattern, update handler, PostLateUpdate, spatial query, platform optimization, frame budget Stopwatch, heavy processing architecture (rebuild, replay, reset/cancel), rate limit resolver, GameObject lookup cost tiers | Update, PostLateUpdate, Bounds, AnimatorHash, performance, mobile, PC, Stopwatch, frame budget, SendCustomEventDelayedFrames, heavy processing, rebuild, replay, reset, cancel, operation log, authoritative data, derived state, cursor rebuild, rate limit, URL scheduler, video load queue, GameObject.Find, Find cost, lookup cost tier, SerializeField vs Find, silent failure on rename, SendCustomEvent cost, cross-behaviour call, EventBus hot path, delayed loop spike, public method lookup, event dispatch tier |
@@ -281,8 +287,8 @@ Use the current supported SDK for publishing. Check the matching release notes b
 | `SyncedObject.cs` | Network-synced object (Manual sync, ownership guard, late-joiner init flag) |
 | `PlayerSettings.cs` | Per-player movement settings (walk/run/jump speed) |
 | `StateMachine.cs` | State machine with synced state and transitions |
-| `DataPersistence.cs` | PlayerData save/load with OnPlayerRestored (SDK 3.7.4+) |
-| `ContactReceiver.cs` | Contact receiver for world-side collision detection (SDK 3.10.0+) |
+| `DataPersistence.cs` | PlayerData save/load with OnPlayerRestored (introduced in SDK 3.7.4; active target 3.10.4) |
+| `ContactReceiver.cs` | Contact receiver for world-side collision detection (introduced in SDK 3.10.0; active target 3.10.4) |
 | `CustomInspector.cs` | Custom editor inspector with UdonSharpEditor |
 | `MasterManagedPlayerPool.cs` | Master-managed player object pool for non-security session arbitration; FIFO ring buffer; OnPlayerJoined/Left; `_VerifyAssignments` after master handoff |
 | `EventBus.cs` | Subscriber list event bus (max 32 listeners); RegisterListener/UnregisterListener/RaiseEvent; in-place compaction |

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -2,7 +2,9 @@
 
 Complete reference of VRChat-specific classes, methods, and types available in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 ## VRCPlayerApi
 

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -3,7 +3,9 @@
 Complete reference of C# features and their availability in UdonSharp, including SDK version availability,
 compiler behavior details, and annotated code examples.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 > For the quick-reference checklist and code generation rules, see `rules/udonsharp-constraints.md`.
 

--- a/skills/unity-vrc-udon-sharp/references/dynamics.md
+++ b/skills/unity-vrc-udon-sharp/references/dynamics.md
@@ -1,8 +1,11 @@
 # VRChat Dynamics for Worlds Reference
 
-Comprehensive guide to PhysBones, Contacts, and VRC Constraints in VRChat worlds (SDK 3.10.0 - 3.10.4).
+Comprehensive guide to PhysBones, Contacts, and VRC Constraints in VRChat worlds. Dynamics were introduced in SDK 3.10.0; the active verified target is SDK 3.10.4.
 
-**Supported SDK Versions**: 3.10.0 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+**Historical feature introduction**: SDK 3.10.0
+
+SDK 3.10.0-3.10.3 entries are historical feature context only, not active support or validation targets for this Skill.
 
 ## Overview
 

--- a/skills/unity-vrc-udon-sharp/references/events.md
+++ b/skills/unity-vrc-udon-sharp/references/events.md
@@ -2,7 +2,9 @@
 
 Complete reference of all events available in UdonSharp. Override these methods to respond to events.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 ## Important: override vs Non-override
 

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -1,6 +1,8 @@
 # Image Loading — VRAM & Memory Management
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 Extended memory management guide for `VRCImageDownloader`. Covers GPU memory lifecycle,
 safe texture cleanup, double-buffer fade, stock vs. streaming mode, mipmap bias control,

--- a/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
+++ b/skills/unity-vrc-udon-sharp/references/networking-antipatterns.md
@@ -64,7 +64,7 @@ public class CapturePoint : UdonSharpBehaviour
 
 **When `OnOwnershipRequest` fits.** If the *current owner* needs to reject ownership transfers during a critical action (turn-based logic, mid-transaction state), use `OnOwnershipRequest`. That is a different problem class — owner-side protection — not arbitration among concurrent requesters. See [networking.md §"Ownership Arbitration with OnOwnershipRequest"](networking.md#ownership-arbitration-with-onownershiprequest).
 
-> *Footnote: Pre-2021.2.2 SDKs were asynchronous; this skill targets SDK 3.7.1+ where the locally-immediate behavior is in effect.*
+> *Footnote: Pre-2021.2.2 SDKs were asynchronous; the active target (SDK 3.10.4) has the locally-immediate behavior.*
 
 ---
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -2,7 +2,9 @@
 
 Comprehensive guide to networking and synchronization in UdonSharp.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 > **Warning**: Networking in Udon is a work in progress and can be fragile. Keep implementations simple and test thoroughly with multiple players.
 >

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -530,7 +530,7 @@ public override void OnOwnershipTransferred(VRCPlayerApi player)
 - **On remote clients:** the new ownership becomes visible after VRChat propagates the change. Each remote client's `OnOwnershipTransferred` fires when the propagation arrives.
 - **No client-side arbitration:** when two clients call `SetOwner` simultaneously, both succeed locally and may write synced variables; VRChat resolves the durable owner by network arrival order. The loser's write is overwritten when the winner's serialization arrives. This is by design — see [networking-antipatterns.md §1](networking-antipatterns.md#1-ownership-race-condition) for the recommended `IsOwner`-guarded pattern, and [§"Ownership Arbitration with OnOwnershipRequest"](#ownership-arbitration-with-onownershiprequest) below for owner-side protection during critical actions.
 
-> *Footnote: Pre-2021.2.2 SDKs treated `SetOwner` as asynchronous on the calling client; current SDKs (3.7.1+, this skill's coverage range) are locally immediate. Source: [Ownership Transfer Events](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram).*
+> *Footnote: Pre-2021.2.2 SDKs treated `SetOwner` as asynchronous on the calling client; the active target (SDK 3.10.4) is locally immediate. Source: [Ownership Transfer Events](https://creators.vrchat.com/worlds/udon/networking/ownership/#transfer-events-diagram).*
 
 ### Owner Leave and Ownership Cascade
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -2,6 +2,9 @@
 
 Object pooling, synced game state management, NetworkCallable patterns, persistence, dynamics interactions, and delayed event debouncing.
 
+**Active support / last verified**: SDK 3.10.4
+**Historical version notes**: Older version numbers record feature introductions or migration facts only; they are not supported or validation targets.
+
 ## Object Pooling
 
 ### Simple Object Pooling
@@ -610,7 +613,7 @@ Reuse a single local room model to render the illusion of multiple rooms by sepa
 - Some level of voice isolation between rooms is desired (a side effect of physical separation)
 - Players in the same room must visibly share the same space; players in different rooms must not collide
 
-The recommended `VRCPlayerObject` tier was introduced in SDK 3.7.4; use the active SDK target, SDK 3.10.4. The other tiers (fixed-size synced array, local-only) are retained as historical migration guidance for unsupported older projects, not as active support routes.
+The recommended `VRCPlayerObject` tier was introduced in SDK 3.7.4 and remains the recommended choice on the active SDK target, SDK 3.10.4. The fixed-size synced-array tier remains a valid alternative for small, capacity-limited worlds, while the local-only tier is valid for single-player preview or debugging. The 3.7.4 version note is historical migration context, not an active-support cutoff.
 
 ### Architecture (state vs presentation split)
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -610,7 +610,7 @@ Reuse a single local room model to render the illusion of multiple rooms by sepa
 - Some level of voice isolation between rooms is desired (a side effect of physical separation)
 - Players in the same room must visibly share the same space; players in different rooms must not collide
 
-Requires SDK >= 3.7.4 for the recommended `VRCPlayerObject` tier. The other tiers (fixed-size synced array, local-only) work on older SDKs.
+The recommended `VRCPlayerObject` tier was introduced in SDK 3.7.4; use the active SDK target, SDK 3.10.4. The other tiers (fixed-size synced array, local-only) are retained as historical migration guidance for unsupported older projects, not as active support routes.
 
 ### Architecture (state vs presentation split)
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -508,9 +508,9 @@ public class MyResultHandler : ProcessCallbackBase
 
 `SendCustomEventDelayedSeconds` has no cancellation API. Once scheduled, the callback will fire even if the caller's state has changed and the event is no longer wanted. The pending-callback-counter debounce (see [Delayed Event Debounce in patterns-networking.md](patterns-networking.md)) handles "soft cancel" — it lets the callback fire but makes it a no-op. That is sufficient for debounce cases but not for situations where the callback absolutely must not execute: side effects inside the callback (audio playback, network requests, object destruction) will still run through the guard check even if they then return early.
 
-### Solution for SDK 3.10.4+
+### Solution on the active SDK target (3.10.4)
 
-Prefer `VRCTween.DelayedCall`, which behaves like `SendCustomEventDelayedSeconds` but returns a `VRCTweenHandle` that can be killed before it fires. See [VRCTween Patterns](vrctween.md#cancelable-delays) for the routeable SDK 3.10.4+ guidance.
+Prefer `VRCTween.DelayedCall`, which behaves like `SendCustomEventDelayedSeconds` but returns a `VRCTweenHandle` that can be killed before it fires. See [VRCTween Patterns](vrctween.md#cancelable-delays) for the active SDK 3.10.4 guidance.
 
 ```csharp
 using VRC.SDK3.Components;
@@ -533,7 +533,7 @@ public void _CancelPendingRetry()
 
 For historical migration only, projects pinned below SDK 3.10.4 can instantiate a helper `GameObject` that carries a tiny `UdonSharpBehaviour`. Schedule `SendCustomEventDelayedSeconds` on the helper itself. To cancel, call `Destroy(helperGameObject)` before the delay expires — the destroyed behaviour never executes its scheduled callback.
 
-**Trade-off:** Allocates a `GameObject` per timer instance. Use `VRCTween.DelayedCall` on SDK 3.10.4+; use the pending-callback-counter pattern for high-frequency debounce; use this historical fallback only when documenting an unsupported older project that truly must not fire the callback.
+**Trade-off:** Allocates a `GameObject` per timer instance. Use `VRCTween.DelayedCall` on the active SDK target (3.10.4); use the pending-callback-counter pattern for high-frequency debounce; use this historical fallback only when documenting an unsupported older project that truly must not fire the callback.
 
 **When to use:**
 - SDK < 3.10.4 projects where `VRCTween.DelayedCall` is unavailable

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -2,6 +2,9 @@
 
 Array helpers, array utility helpers (List&lt;T&gt; alternatives), event bus, GameObject relay communication, pseudo-struct double-cast, and abstract class callback patterns.
 
+**Active support / last verified**: SDK 3.10.4
+**Historical version notes**: Older version numbers record feature introductions or migration facts only; they are not supported or validation targets.
+
 ## Array Helpers
 
 ```csharp

--- a/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-utilities.md
@@ -529,11 +529,11 @@ public void _CancelPendingRetry()
 }
 ```
 
-### Fallback for Older SDKs
+### Historical fallback for unsupported SDKs
 
-For projects pinned below SDK 3.10.4, instantiate a helper `GameObject` that carries a tiny `UdonSharpBehaviour`. Schedule `SendCustomEventDelayedSeconds` on the helper itself. To cancel, call `Destroy(helperGameObject)` before the delay expires — the destroyed behaviour never executes its scheduled callback.
+For historical migration only, projects pinned below SDK 3.10.4 can instantiate a helper `GameObject` that carries a tiny `UdonSharpBehaviour`. Schedule `SendCustomEventDelayedSeconds` on the helper itself. To cancel, call `Destroy(helperGameObject)` before the delay expires — the destroyed behaviour never executes its scheduled callback.
 
-**Trade-off:** Allocates a `GameObject` per timer instance. Use `VRCTween.DelayedCall` on SDK 3.10.4+; use the pending-callback-counter pattern for high-frequency debounce; use this fallback only when an older SDK project needs a callback that truly must not fire.
+**Trade-off:** Allocates a `GameObject` per timer instance. Use `VRCTween.DelayedCall` on SDK 3.10.4+; use the pending-callback-counter pattern for high-frequency debounce; use this historical fallback only when documenting an unsupported older project that truly must not fire the callback.
 
 **When to use:**
 - SDK < 3.10.4 projects where `VRCTween.DelayedCall` is unavailable

--- a/skills/unity-vrc-udon-sharp/references/persistence.md
+++ b/skills/unity-vrc-udon-sharp/references/persistence.md
@@ -1,8 +1,11 @@
 # VRChat Persistence Reference
 
-Comprehensive guide to persistent data storage in VRChat worlds (SDK 3.7.4+).
+Comprehensive guide to persistent data storage in VRChat worlds. The feature was introduced in SDK 3.7.4; the active verified target is SDK 3.10.4.
 
-**Supported SDK Versions**: 3.7.4+ (2024 onward)
+**Active support / last verified**: SDK 3.10.4
+**Historical feature introduction**: SDK 3.7.4
+
+SDK 3.7.4-3.10.3 references are historical migration information only, not active support or validation targets for this Skill.
 
 ## Overview
 

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -2,10 +2,13 @@
 
 Step-by-step guide for upgrading UdonSharp worlds across major SDK versions.
 
-**Applies to**: SDK 3.7.x through 3.10.4
+**Historical migration coverage**: SDK 3.7.x through 3.10.4
+**Active support / last verified**: SDK 3.10.4
 
-Use the current supported SDK when publishing. The version markers below describe
-feature availability; they do not claim an upload cutoff for older SDK versions.
+Use SDK 3.10.4 when publishing. The version markers below preserve feature
+availability and migration facts; SDK 3.7.1-3.10.3 are not support or validation
+targets for this Skill. This is the Skill's boundary, not a claim about VRChat's
+own SDK policy.
 
 ## Version markers
 

--- a/skills/unity-vrc-udon-sharp/references/testing.md
+++ b/skills/unity-vrc-udon-sharp/references/testing.md
@@ -2,7 +2,9 @@
 
 Practical guide for testing and debugging UdonSharp worlds in VRChat.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -2,7 +2,9 @@
 
 Common errors, causes, and solutions for VRChat UdonSharp development.
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 ## Table of Contents
 

--- a/skills/unity-vrc-udon-sharp/references/vrctween.md
+++ b/skills/unity-vrc-udon-sharp/references/vrctween.md
@@ -1,6 +1,10 @@
-# VRCTween Patterns (SDK 3.10.4+)
+# VRCTween Patterns (introduced in SDK 3.10.4)
 
-Route animation and cancelable-delay questions here when a project can use SDK 3.10.4 or newer.
+**Active support / last verified**: SDK 3.10.4
+
+This reference describes the active SDK target. The 3.10.4 marker records when VRCTween was introduced; it is not an automatic support promise for later SDKs.
+
+Route animation and cancelable-delay questions here for the active SDK target, SDK 3.10.4.
 
 ## When to Use VRCTween
 
@@ -65,7 +69,7 @@ public class TweenedDoor : UdonSharpBehaviour
 
 ## Cancelable Delays
 
-Prefer `VRCTween.DelayedCall` over `SendCustomEventDelayedSeconds` helper-`GameObject` cancellation workarounds on SDK 3.10.4+:
+Prefer `VRCTween.DelayedCall` over `SendCustomEventDelayedSeconds` helper-`GameObject` cancellation workarounds on the active SDK target, SDK 3.10.4:
 
 ```csharp
 private VRCTweenHandle _timer;
@@ -87,7 +91,7 @@ public void _OnTimer()
 }
 ```
 
-Keep the helper-`GameObject` workaround only for projects pinned to older SDKs where `VRCTween.DelayedCall` is unavailable.
+Keep the helper-`GameObject` workaround only as historical migration guidance for unsupported older SDK projects where `VRCTween.DelayedCall` is unavailable. It is not an active support route.
 
 Use `VRCTween.DelayedSetActive(target, active, seconds)` for a simple delayed local active-state change. Store the returned `VRCTweenHandle` if the toggle may need cancellation.
 

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -1,6 +1,8 @@
 # Web Loading — Advanced Packed Resource Patterns
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 Advanced techniques for embedding multiple textures in a single `VRCStringDownloader` response
 to work around `VRCImageDownloader` limitations. For the base API reference see

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -875,7 +875,7 @@ public class PackedResourceLoader : UdonSharpBehaviour
 
 | Symptom | Likely Cause | Solution |
 |---|---|---|
-| `Convert.FromBase64String` throws at runtime | `System.Convert` unavailable in older SDK | Requires SDK 3.7.1+; check SDK version in `ProjectSettings` |
+| `Convert.FromBase64String` throws at runtime | `System.Convert` unavailable in an older SDK | Historical migration guidance only: SDK 3.7.1 introduced the available surface; unsupported older projects should verify their project version in `ProjectSettings` rather than treating this as an active support route |
 | Decoded texture is entirely black or garbled | Texture format mismatch (DXT on Quest, or ETC2 on PC) | Verify `#if UNITY_ANDROID` selects the correct `TextureFormat`; confirm server served the right platform file |
 | `LoadRawTextureData` produces corrupt image | Wrong byte count — `dataLength` in JSON does not match actual encoded data | Re-validate the server pack builder; log `rawBytes.Length` vs the expected `width * height * bpp` |
 | VRAM grows after repeated resource loads | `Destroy()` not called on old textures before creating new ones | In `ApplyTextureFromCache`, call `Destroy(oldSprite.texture)` before assigning the new sprite |

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -1,6 +1,8 @@
 # Web Loading (String / Image Download)
 
-**Supported SDK Versions**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this reference record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md
@@ -2,7 +2,9 @@
 
 UdonSharp compiles C# to Udon Assembly. Code that executes in the Udon runtime must adhere to these constraints, which differ from standard C#. Unity/Editor-side field initializer evaluation has the narrow exception described below.
 
-**SDK Coverage**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this rule record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 > For detailed examples, SDK version availability, and compiler behavior explanations,
 > see `references/constraints.md`.
@@ -33,7 +35,9 @@ UdonSharp compiles C# to Udon Assembly. Code that executes in the Udon runtime m
 | `System.Threading` | Not available |
 | `unsafe`, pointers | Not available |
 
-## Available Features (SDK 3.7.1+)
+## Available Features (historical baseline: SDK 3.7.1)
+
+The version labels in this section are historical feature-introduction markers; use SDK 3.10.4 for current generation and validation.
 
 | Feature | Notes |
 |---------|-------|

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -2,7 +2,9 @@
 
 Core networking rules and constraints. See `../references/networking.md` for detailed patterns.
 
-**SDK Coverage**: 3.7.1 - 3.10.4
+**Active support / last verified**: SDK 3.10.4
+
+Older version numbers in this rule record feature introductions or migration facts only; SDK 3.7.1-3.10.3 are not supported or validation targets for this Skill.
 
 ## Ownership Model
 

--- a/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
+++ b/skills/unity-vrc-world-sdk-3/CHEATSHEET.md
@@ -1,6 +1,8 @@
 # VRC World SDK 3 Cheatsheet
 
-**SDK 3.7.1 - 3.10.4 supported**
+**Active support / last verified**: SDK 3.10.4
+
+SDK 3.7.1-3.10.3 labels below are historical feature-introduction notes only; they are not supported or validation targets for this Skill.
 
 ---
 
@@ -426,7 +428,7 @@ site:github.com/vrchat-community "issue keyword"
 |-------|------|
 | Performance targets, Quest optimization checklist | [references/performance.md](references/performance.md) |
 | Lightmap settings, Quest bake parameter reference | [references/lighting.md](references/lighting.md) |
-| Full SDK 3.7.1-3.10.4 world component reference | [references/components.md](references/components.md) |
+| Full active SDK 3.10.4 world component reference | [references/components.md](references/components.md) |
 | VRChat layer system, collision, and selective rendering reference | [references/layers.md](references/layers.md) |
 | Audio and video configuration, voice settings, Steam Audio, and video players | [references/audio-video.md](references/audio-video.md) |
 | SDK Build Panel validation alert catalog, Auto Fix side effects, red/yellow/white warning responses | [references/build-validation.md](references/build-validation.md) |

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -9,7 +9,7 @@ description: >
     VRC_ObjectSync, VRC_CameraDolly, spawn points, collision matrices,
     PhysBone and Contact component placement, Box Contacts,
     Global Avatar PhysBone Colliders, and VRCPhysBoneCollider component setup.
-    SDK 3.7.1-3.10.4. Triggers on: VRChat world scene, VRC SDK, scene setup,
+    Active support / last verified: SDK 3.10.4. Triggers on: VRChat world scene, VRC SDK, scene setup,
     component placement, optimization, Quest support, light baking, upload,
     SDK validation, Build Panel warning, Auto Fix, red warning, yellow warning, or white warning.
     Do not use for UdonSharp C# or VRCTween calls; use
@@ -141,23 +141,27 @@ Quest required? → Yes
 
 ## SDK Versions
 
-**Covered versions**: SDK 3.7.1 - 3.10.4 (last verified: 3.10.4)
+**Active support / last verified**: SDK 3.10.4
+
+From v4.0.0 onward, the policy is latest stable SDK only; support moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically. Current last verified target: 3.10.4.
+
+The table below keeps feature-introduction history for migration reference. SDK 3.7.1-3.10.3 entries are historical information only; they are not active support or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy. Primary generated examples target SDK 3.10.4 unless a reference explicitly marks a historical migration case.
 
 | SDK    | New Features                                                                   | Status         |
 | ------ | ------------------------------------------------------------------------------ | -------------- |
-| 3.7.1  | StringBuilder, Regex, System.Random                                            | ✅             |
-| 3.7.4  | **Persistence API** (PlayerData/PlayerObject)                                  | ✅             |
-| 3.7.6  | **Multi-platform Build & Publish** (simultaneous PC + Android builds)          | ✅             |
-| 3.8.0  | PhysBone dependency sorting, **Force Kinematic On Remote**, Drone API          | ✅             |
-| 3.8.1  | **[NetworkCallable]** events with parameters, `Others`/`Self` targets, VRCCameraSettings | ✅ |
-| 3.9.0  | **Camera Dolly API**, Auto Hold simplification, VRCCameraSettings additions (CullingMask, GetCurrentCamera) | ✅ |
-| 3.10.0 | **Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints)                 | ✅             |
-| 3.10.1 | Bug fixes and stability improvements                                           | ✅             |
-| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | ✅             |
-| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix         | ✅             |
-| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, Data Container capacity APIs | ✅ Last verified |
+| 3.7.1  | StringBuilder, Regex, System.Random                                            | Historical     |
+| 3.7.4  | **Persistence API** (PlayerData/PlayerObject)                                  | Historical     |
+| 3.7.6  | **Multi-platform Build & Publish** (simultaneous PC + Android builds)          | Historical     |
+| 3.8.0  | PhysBone dependency sorting, **Force Kinematic On Remote**, Drone API          | Historical     |
+| 3.8.1  | **[NetworkCallable]** events with parameters, `Others`/`Self` targets, VRCCameraSettings | Historical |
+| 3.9.0  | **Camera Dolly API**, Auto Hold simplification, VRCCameraSettings additions (CullingMask, GetCurrentCamera) | Historical |
+| 3.10.0 | **Dynamics for Worlds** (PhysBones, Contacts, VRC Constraints)                 | Historical     |
+| 3.10.1 | Bug fixes and stability improvements                                           | Historical     |
+| 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals                   | Historical     |
+| 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix         | Historical     |
+| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, Data Container capacity APIs | Active / Last verified |
 
-Use the current supported SDK for publishing and verify version-sensitive APIs against the matching release notes before migrating a project.
+Use SDK 3.10.4 for publishing and verify version-sensitive APIs against the matching release notes before migrating a project.
 
 ---
 

--- a/skills/unity-vrc-world-sdk-3/references/components.md
+++ b/skills/unity-vrc-world-sdk-3/references/components.md
@@ -1,6 +1,9 @@
 # VRChat World Components Complete Reference
 
-Full component reference for SDK 3.7.1 - 3.10.4.
+Full component reference for the active SDK target, 3.10.4. Version-specific feature introductions below are retained as historical migration information only.
+
+**Active support / last verified**: SDK 3.10.4
+**Historical version notes**: Older version numbers are not supported or validation targets for this Skill.
 
 ## Table of Contents
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -20,7 +20,13 @@ Networking rule: a parameterless `public` method without a leading `_` is a lega
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.4)
+## SDK (active: 3.10.4)
+
+**Active support / last verified**: SDK 3.10.4
+
+From v4.0.0 onward, the policy is latest stable SDK only; support moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically. Current last verified target: 3.10.4.
+
+The table below keeps historical feature-introduction notes for migration. SDK 3.7.1-3.10.3 entries are not supported or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy.
 
 | Version | Key Features |
 |---------|--------------|

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -20,7 +20,13 @@ Networking rule: a parameterless `public` method without a leading `_` is a lega
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.4)
+## SDK (active: 3.10.4)
+
+**Active support / last verified**: SDK 3.10.4
+
+From v4.0.0 onward, the policy is latest stable SDK only; support moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically. Current last verified target: 3.10.4.
+
+The table below keeps historical feature-introduction notes for migration. SDK 3.7.1-3.10.3 entries are not supported or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy.
 
 | Version | Key Features |
 |---------|--------------|

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -20,7 +20,13 @@ Networking rule: a parameterless `public` method without a leading `_` is a lega
 | `unity-vrc-udon-sharp` | UdonSharp coding, networking, events, templates | `skills/unity-vrc-udon-sharp/SKILL.md` |
 | `unity-vrc-world-sdk-3` | VRC component placement, layer configuration, world optimization | `skills/unity-vrc-world-sdk-3/SKILL.md` |
 
-## SDK (3.7.1 - 3.10.4)
+## SDK (active: 3.10.4)
+
+**Active support / last verified**: SDK 3.10.4
+
+From v4.0.0 onward, the policy is latest stable SDK only; support moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically. Current last verified target: 3.10.4.
+
+The table below keeps historical feature-introduction notes for migration. SDK 3.7.1-3.10.3 entries are not supported or validation targets for this Skill. This is the Skill's support boundary, not a statement about VRChat's own SDK policy.
 
 | Version | Key Features |
 |---------|--------------|

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -27,7 +27,7 @@ EXPECTED_HANDLES=(
 )
 EXPECTED_ISSUES=(
     164 165 171 181 182 189 199 213 267 281
-    286 297 302 324 333 337 338 341 342
+    286 297 302 324 333 337 338 341 342 344
 )
 
 CENSUS="$ROOT_DIR/tests/docs/fixtures/community-contributor-census.json"
@@ -43,8 +43,8 @@ contributors = data["contributors"]
 issues = sorted(issue for contributor in contributors for issue in contributor["issues"])
 assert classification["issues_scanned"] >= 1
 assert classification["selected_reporters"] == len(contributors) == 8
-assert classification["selected_issues"] == len(issues) == 19
-assert len(set(issues)) == 19
+assert classification["selected_issues"] == len(issues) == 20
+assert len(set(issues)) == 20
 assert classification["duplicate_invalid_wontfix_spam_issues_selected"] == 0
 PY
 

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+README_FILES=(
+    "$ROOT_DIR/README.md"
+    "$ROOT_DIR/README.ja.md"
+    "$ROOT_DIR/README.zh-CN.md"
+    "$ROOT_DIR/README.zh-TW.md"
+    "$ROOT_DIR/README.ko.md"
+)
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+EXPECTED_HANDLES=(
+    KatanoShingo
+    Guribo
+    haru0416-dev
+    Yodokoro
+    tetradice
+    owlboy
+    nomlasvrc
+    ureishi
+)
+EXPECTED_ISSUES=(
+    164 165 171 181 182 189 199 213 267 281
+    286 297 302 324 333 337 338 341 342
+)
+
+CENSUS="$ROOT_DIR/tests/docs/fixtures/community-contributor-census.json"
+[ -f "$CENSUS" ] || fail "missing contributor census evidence: $CENSUS"
+python3 - "$CENSUS" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+classification = data["classification"]
+contributors = data["contributors"]
+issues = sorted(issue for contributor in contributors for issue in contributor["issues"])
+assert classification["issues_scanned"] >= 1
+assert classification["selected_reporters"] == len(contributors) == 8
+assert classification["selected_issues"] == len(issues) == 19
+assert len(set(issues)) == 19
+assert classification["duplicate_invalid_wontfix_spam_issues_selected"] == 0
+PY
+
+section() {
+    local path="$1"
+    awk '
+        /<h2 id="community-contributors">/ { found=1; next }
+        found && /^<h2[ >]/ { exit }
+        found { print }
+    ' "$path"
+}
+
+for path in "${README_FILES[@]}"; do
+    body="$(section "$path")"
+    [ -n "$body" ] || fail "$path is missing the community-contributors section"
+
+    for handle in "${EXPECTED_HANDLES[@]}"; do
+        grep -Fq -- "https://github.com/$handle" <<<"$body" \
+            || fail "$path is missing contributor @$handle"
+    done
+
+    # Keep the section bounded to the issue-originated contributors and avoid
+    # silently crediting the maintainer or automation accounts.
+    if grep -Eiq 'github\.com/(niaka3dayo|github-actions|dependabot|renovate)(\)|$)' <<<"$body"; then
+        fail "$path credits a maintainer or bot in the contributor section"
+    fi
+
+    actual_issues="$(grep -Eo 'https://github\.com/niaka3dayo/agent-skills-vrc-udon/issues/[0-9]+' <<<"$body" | sort -u || true)"
+    expected_issues="$(printf '%s\n' "${EXPECTED_ISSUES[@]}" | sed 's#^#https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/#' | sort -u)"
+    [ "$actual_issues" = "$expected_issues" ] \
+        || fail "$path has a different Issue census from the other READMEs"
+
+    issue_count="$(grep -Eo 'https://github\.com/niaka3dayo/agent-skills-vrc-udon/issues/[0-9]+' <<<"$body" | sort -u | wc -l)"
+    [ "$issue_count" -eq "${#EXPECTED_ISSUES[@]}" ] \
+        || fail "$path has $issue_count unique Issue links; expected ${#EXPECTED_ISSUES[@]}"
+done
+
+echo "PASS: community contributor list is synchronized across all READMEs"

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -15,71 +15,106 @@ fail() {
     exit 1
 }
 
-EXPECTED_HANDLES=(
-    KatanoShingo
-    Guribo
-    haru0416-dev
-    Yodokoro
-    tetradice
-    owlboy
-    nomlasvrc
-    ureishi
-)
-EXPECTED_ISSUES=(
-    164 165 171 181 182 189 199 213 267 281
-    286 297 302 324 333 337 338 341 342 344
-)
-
 CENSUS="$ROOT_DIR/tests/docs/fixtures/community-contributor-census.json"
 [ -f "$CENSUS" ] || fail "missing contributor census evidence: $CENSUS"
-python3 - "$CENSUS" <<'PY'
+
+# The census is the sole source of truth. Each README is compared against the
+# fixture's contributor handles and per-contributor Issue set, rather than
+# keeping a second hard-coded list in this test.
+python3 - "$CENSUS" "${README_FILES[@]}" <<'PY'
 import json
+import re
 import sys
 from pathlib import Path
 
-data = json.loads(Path(sys.argv[1]).read_text())
+census_path = Path(sys.argv[1])
+readme_paths = [Path(path) for path in sys.argv[2:]]
+data = json.loads(census_path.read_text(encoding="utf-8"))
 classification = data["classification"]
 contributors = data["contributors"]
-issues = sorted(issue for contributor in contributors for issue in contributor["issues"])
-assert classification["issues_scanned"] >= 1
-assert classification["selected_reporters"] == len(contributors) == 8
-assert classification["selected_issues"] == len(issues) == 20
-assert len(set(issues)) == 20
-assert classification["duplicate_invalid_wontfix_spam_issues_selected"] == 0
-PY
 
-section() {
-    local path="$1"
-    awk '
-        /<h2 id="community-contributors">/ { found=1; next }
-        found && /^<h2[ >]/ { exit }
-        found { print }
-    ' "$path"
+excluded_handles = {
+    "niaka3dayo",
+    "github-actions",
+    "dependabot",
+    "renovate",
 }
+expected_by_handle = {
+    contributor["handle"]: sorted({int(issue) for issue in contributor["issues"]})
+    for contributor in contributors
+}
+assert len(expected_by_handle) == len(contributors)
+assert not excluded_handles.intersection(expected_by_handle)
+expected_issues = sorted({issue for issues in expected_by_handle.values() for issue in issues})
+all_fixture_issues = [issue for contributor in contributors for issue in contributor["issues"]]
+assert classification["issues_scanned"] >= 1
+assert classification["selected_reporters"] == len(expected_by_handle) > 0
+assert classification["selected_issues"] == len(expected_issues) > 0
+assert len(all_fixture_issues) == len(set(all_fixture_issues)) == len(expected_issues)
+assert classification["duplicate_invalid_wontfix_spam_issues_selected"] == 0
 
-for path in "${README_FILES[@]}"; do
-    body="$(section "$path")"
-    [ -n "$body" ] || fail "$path is missing the community-contributors section"
+profile_re = re.compile(r"https://github\.com/([A-Za-z0-9_-]+)\)")
+contributor_line_re = re.compile(
+    r"^- \[@([A-Za-z0-9_-]+)\]\(https://github\.com/([A-Za-z0-9_-]+)\)",
+    re.MULTILINE,
+)
+issue_re = re.compile(
+    r"https://github\.com/niaka3dayo/agent-skills-vrc-udon/issues/(\d+)"
+)
 
-    for handle in "${EXPECTED_HANDLES[@]}"; do
-        grep -Fq -- "https://github.com/$handle" <<<"$body" \
-            || fail "$path is missing contributor @$handle"
-    done
+for path in readme_paths:
+    text = path.read_text(encoding="utf-8")
+    heading = '<h2 id="community-contributors">'
+    start = text.find(heading)
+    assert start >= 0, f"{path} is missing the community-contributors section"
+    body_start = start + len(heading)
+    next_heading = re.search(r"^<h2[ >]", text[body_start:], re.MULTILINE)
+    assert next_heading, f"{path} has an unterminated community-contributors section"
+    body = text[body_start : body_start + next_heading.start()]
+    assert body.strip(), f"{path} has an empty community-contributors section"
 
-    # Keep the section bounded to the issue-originated contributors and avoid
-    # silently crediting the maintainer or automation accounts.
-    if grep -Eiq 'github\.com/(niaka3dayo|github-actions|dependabot|renovate)(\)|$)' <<<"$body"; then
-        fail "$path credits a maintainer or bot in the contributor section"
-    fi
+    profile_matches = profile_re.findall(body)
+    profile_handles = set(profile_matches)
+    expected_handles = set(expected_by_handle)
+    assert len(profile_matches) == len(profile_handles) == len(expected_handles), (
+        f"{path} has {len(profile_handles)} unique contributor profiles; "
+        f"expected {len(expected_handles)}"
+    )
+    assert profile_handles == expected_handles, (
+        f"{path} contributor profiles differ from the census: "
+        f"actual={sorted(profile_handles)} expected={sorted(expected_handles)}"
+    )
+    assert not excluded_handles.intersection(profile_handles), (
+        f"{path} credits a maintainer or bot in the contributor section"
+    )
 
-    actual_issues="$(grep -Eo 'https://github\.com/niaka3dayo/agent-skills-vrc-udon/issues/[0-9]+' <<<"$body" | sort -u || true)"
-    expected_issues="$(printf '%s\n' "${EXPECTED_ISSUES[@]}" | sed 's#^#https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/#' | sort -u)"
-    [ "$actual_issues" = "$expected_issues" ] \
-        || fail "$path has a different Issue census from the other READMEs"
+    actual_by_handle = {}
+    for match in contributor_line_re.finditer(body):
+        display_handle, linked_handle = match.groups()
+        assert display_handle == linked_handle, (
+            f"{path} has a contributor profile/link mismatch for @{display_handle}"
+        )
+        assert display_handle not in actual_by_handle, (
+            f"{path} lists @{display_handle} more than once"
+        )
+        line_end = body.find("\n", match.start())
+        line = body[match.start() : line_end if line_end >= 0 else len(body)]
+        actual_by_handle[display_handle] = sorted(
+            {int(issue) for issue in issue_re.findall(line)}
+        )
+    assert actual_by_handle == expected_by_handle, (
+        f"{path} per-contributor Issue links differ from the census: "
+        f"actual={actual_by_handle} expected={expected_by_handle}"
+    )
 
-    issue_count="$(grep -Eo 'https://github\.com/niaka3dayo/agent-skills-vrc-udon/issues/[0-9]+' <<<"$body" | sort -u | wc -l)"
-    [ "$issue_count" -eq "${#EXPECTED_ISSUES[@]}" ] \
-        || fail "$path has $issue_count unique Issue links; expected ${#EXPECTED_ISSUES[@]}"
-done
+    actual_issues = sorted({int(issue) for issue in issue_re.findall(body)})
+    assert actual_issues == expected_issues, (
+        f"{path} aggregate Issue links differ from the census: "
+        f"actual={actual_issues} expected={expected_issues}"
+    )
 
-echo "PASS: community contributor list is synchronized across all READMEs"
+print(
+    "PASS: community contributor profiles, per-contributor Issues, and "
+    "aggregate Issue census are exact across all five READMEs"
+)
+PY

--- a/tests/docs/fixtures/community-contributor-census.json
+++ b/tests/docs/fixtures/community-contributor-census.json
@@ -1,0 +1,92 @@
+{
+  "generated_at": "2026-08-18",
+  "repository": "niaka3dayo/agent-skills-vrc-udon",
+  "query": "gh issue list --state all --limit 1000 --json number,title,state,author,labels,comments,url,closedAt",
+  "timeline_query": "gh api repos/niaka3dayo/agent-skills-vrc-udon/issues/{number}/timeline --paginate -H 'Accept: application/vnd.github+json'",
+  "scope": "External authors of GitHub Issues that contributed accepted, confirmed, or implemented corrections or knowledge additions. PR-only contributors are out of scope.",
+  "classification": {
+    "issues_scanned": 151,
+    "maintainer_and_bot_authors_excluded": [
+      "niaka3dayo",
+      "github-actions[bot]",
+      "dependabot[bot]",
+      "renovate[bot]"
+    ],
+    "selected_reporters": 8,
+    "selected_issues": 19,
+    "duplicate_invalid_wontfix_spam_issues_selected": 0,
+    "selection_rule": "Include an external Issue author when the Issue was confirmed, accepted, or implemented. Confirmed open reports remain included when they are part of the current support work. Exclude duplicate, invalid, wontfix, spam, maintainer, bot, and PR-only activity."
+  },
+  "contributors": [
+    {
+      "handle": "KatanoShingo",
+      "issues": [181, 182, 189, 199, 213, 302],
+      "evidence": {
+        "classification": "implemented",
+        "merged_prs": [183, 187, 191, 194, 198, 201, 202, 204, 215, 216, 229, 314, 323]
+      }
+    },
+    {
+      "handle": "Guribo",
+      "issues": [171],
+      "evidence": {
+        "classification": "implemented and confirmed",
+        "merged_prs": [172]
+      }
+    },
+    {
+      "handle": "haru0416-dev",
+      "issues": [164, 165],
+      "evidence": {
+        "classification": "implemented",
+        "merged_prs": [166, 167, 168]
+      }
+    },
+    {
+      "handle": "Yodokoro",
+      "issues": [267, 286, 297],
+      "evidence": {
+        "classification": "implemented and confirmed",
+        "merged_prs": [269, 287, 298]
+      }
+    },
+    {
+      "handle": "tetradice",
+      "issues": [281],
+      "evidence": {
+        "classification": "implemented and reporter-confirmed",
+        "merged_prs": [282]
+      }
+    },
+    {
+      "handle": "owlboy",
+      "issues": [324],
+      "evidence": {
+        "classification": "implemented and confirmed",
+        "merged_prs": [325]
+      }
+    },
+    {
+      "handle": "nomlasvrc",
+      "issues": [333],
+      "evidence": {
+        "classification": "implemented and confirmed",
+        "merged_prs": [334]
+      }
+    },
+    {
+      "handle": "ureishi",
+      "issues": [337, 338, 341, 342],
+      "evidence": {
+        "classification": "implemented, confirmed, and accepted current work",
+        "merged_prs": [339, 340],
+        "open_accepted_issues": [341, 342]
+      }
+    }
+  ],
+  "exclusions": {
+    "external_reporters_with_no_accepted_confirmed_or_implemented_issue": [],
+    "duplicate_invalid_wontfix_spam_reports": [],
+    "pr_only_contributors": "Not searched as contributors because this census is intentionally Issue-originated."
+  }
+}

--- a/tests/docs/fixtures/community-contributor-census.json
+++ b/tests/docs/fixtures/community-contributor-census.json
@@ -5,7 +5,7 @@
   "timeline_query": "gh api repos/niaka3dayo/agent-skills-vrc-udon/issues/{number}/timeline --paginate -H 'Accept: application/vnd.github+json'",
   "scope": "External authors of GitHub Issues that contributed accepted, confirmed, or implemented corrections or knowledge additions. PR-only contributors are out of scope.",
   "classification": {
-    "issues_scanned": 151,
+    "issues_scanned": 152,
     "maintainer_and_bot_authors_excluded": [
       "niaka3dayo",
       "github-actions[bot]",
@@ -13,9 +13,9 @@
       "renovate[bot]"
     ],
     "selected_reporters": 8,
-    "selected_issues": 19,
+    "selected_issues": 20,
     "duplicate_invalid_wontfix_spam_issues_selected": 0,
-    "selection_rule": "Include an external Issue author when the Issue was confirmed, accepted, or implemented. Confirmed open reports remain included when they are part of the current support work. Exclude duplicate, invalid, wontfix, spam, maintainer, bot, and PR-only activity."
+    "selection_rule": "Include an external Issue author when the Issue was confirmed, accepted, or implemented. Confirmed or accepted open reports remain included when they are part of the current v4.0.0 support work. Exclude duplicate, invalid, wontfix, spam, maintainer, bot, and PR-only activity."
   },
   "contributors": [
     {
@@ -76,11 +76,14 @@
     },
     {
       "handle": "ureishi",
-      "issues": [337, 338, 341, 342],
+      "issues": [337, 338, 341, 342, 344],
       "evidence": {
         "classification": "implemented, confirmed, and accepted current work",
         "merged_prs": [339, 340],
-        "open_accepted_issues": [341, 342]
+        "open_accepted_issues": [341, 342, 344],
+        "acceptance_notes": {
+          "344": "Accepted into the v4.0.0 support work; technical implementation is tracked separately from this policy PR."
+        }
       }
     }
   ],

--- a/tests/docs/fixtures/sdk-support-policy-corpus.json
+++ b/tests/docs/fixtures/sdk-support-policy-corpus.json
@@ -42,7 +42,7 @@
   "classification_counts": {"historical_release_record":2,"historical_support_boundary":34,"historical_feature_introduction_or_availability":25},
   "active_support_declarations": {
     "stale_active_declaration_scan": {
-      "patterns": "(?:Supported SDK Versions|SDK Coverage|Covered versions)\\s*[:(][^\\n]{0,40}3\\.7\\.1|(?:this skill(?:'s)? coverage range|this skill targets SDK\\s+3\\.7\\.1\\+|VRChat_SDK-3\\.7\\.1--3\\.10\\.4|SDK\\s+3\\.7\\.1\\s*(?:-|–)\\s*3\\.10\\.4)",
+      "patterns": "(?:Supported SDK Versions|SDK Coverage|Covered versions)(?:\\*\\*)?\\s*[:(][^\\n]*[0-9]+\\.[0-9]+\\.[0-9]+|(?:this skill(?:'s)? coverage range|this skill targets SDK\\s+[0-9]+\\.[0-9]+\\.[0-9]+\\+|VRChat_SDK-[0-9]+\\.[0-9]+\\.[0-9]+--[0-9]+\\.[0-9]+\\.[0-9]+|SDK\\s+3\\.7\\.1\\s*(?:-|–)\\s*3\\.10\\.4)",
       "excluded_historical_records": ["CHANGELOG.md"],
       "excluded_test_contracts": ["tests/docs/sdk-support-policy.test.sh"],
       "matches": [],

--- a/tests/docs/fixtures/sdk-support-policy-corpus.json
+++ b/tests/docs/fixtures/sdk-support-policy-corpus.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-08-18",
   "repository": "niaka3dayo/agent-skills-vrc-udon",
-  "scope": "Tracked Markdown corpus at the Issue #343 implementation HEAD. This is an evidence snapshot, not a generated API mirror. The fixture itself is excluded from the scan.",
+  "scope": "Tracked Markdown corpus at the Issue #343 implementation HEAD; the fixture itself is excluded from the scan.",
   "scan": {
     "command": "git grep -n -F '3.7.1' -- '*.md' ':!tests/docs/fixtures/sdk-support-policy-corpus.json'",
     "tracked_markdown_files_scanned": 81,
@@ -9,506 +9,90 @@
     "occurrences": 61,
     "files_with_literal": 28,
     "files": [
-      {
-        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_release_record": 1
-        },
-        "lines": [
-          61
-        ]
-      },
-      {
-        "path": "CHANGELOG.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_release_record": 1
-        },
-        "lines": [
-          46
-        ]
-      },
-      {
-        "path": "CONTRIBUTING.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          177
-        ]
-      },
-      {
-        "path": "README.ja.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          218,
-          222
-        ]
-      },
-      {
-        "path": "README.ko.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          218,
-          222
-        ]
-      },
-      {
-        "path": "README.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          218,
-          222
-        ]
-      },
-      {
-        "path": "README.zh-CN.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          217,
-          221
-        ]
-      },
-      {
-        "path": "README.zh-TW.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          217,
-          221
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/CHEATSHEET.md",
-        "occurrences": 5,
-        "categories": {
-          "historical_support_boundary": 2,
-          "historical_feature_introduction_or_availability": 3
-        },
-        "lines": [
-          5,
-          21,
-          25,
-          26,
-          27
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/SKILL.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          225,
-          229
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/api.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          7
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/constraints.md",
-        "occurrences": 14,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 13
-        },
-        "lines": [
-          8,
-          101,
-          102,
-          107,
-          222,
-          223,
-          224,
-          225,
-          227,
-          257,
-          273,
-          533,
-          534,
-          535
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/events.md",
-        "occurrences": 3,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 2
-        },
-        "lines": [
-          7,
-          64,
-          65
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/image-loading-vram.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          5
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/networking.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          7
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/patterns-performance.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_feature_introduction_or_availability": 1
-        },
-        "lines": [
-          637
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/sdk-migration.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 1
-        },
-        "lines": [
-          9,
-          332
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/testing.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          7
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/troubleshooting.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          7
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/web-loading-advanced.md",
-        "occurrences": 3,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 2
-        },
-        "lines": [
-          5,
-          172,
-          878
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/web-loading.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          5
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          7,
-          38
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          7
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-world-sdk-3/CHEATSHEET.md",
-        "occurrences": 1,
-        "categories": {
-          "historical_support_boundary": 1
-        },
-        "lines": [
-          5
-        ]
-      },
-      {
-        "path": "skills/unity-vrc-world-sdk-3/SKILL.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 2
-        },
-        "lines": [
-          148,
-          152
-        ]
-      },
-      {
-        "path": "templates/AGENTS.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 1
-        },
-        "lines": [
-          29,
-          33
-        ]
-      },
-      {
-        "path": "templates/CLAUDE.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 1
-        },
-        "lines": [
-          29,
-          33
-        ]
-      },
-      {
-        "path": "templates/GEMINI.md",
-        "occurrences": 2,
-        "categories": {
-          "historical_support_boundary": 1,
-          "historical_feature_introduction_or_availability": 1
-        },
-        "lines": [
-          29,
-          33
-        ]
-      }
+      {"path":".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md","occurrences":1,"categories":{"historical_release_record":1},"lines":[61]},
+      {"path":"CHANGELOG.md","occurrences":1,"categories":{"historical_release_record":1},"lines":[46]},
+      {"path":"CONTRIBUTING.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[177]},
+      {"path":"README.ja.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[218,222]},
+      {"path":"README.ko.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[218,222]},
+      {"path":"README.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[218,222]},
+      {"path":"README.zh-CN.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[217,221]},
+      {"path":"README.zh-TW.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[217,221]},
+      {"path":"skills/unity-vrc-udon-sharp/CHEATSHEET.md","occurrences":5,"categories":{"historical_support_boundary":2,"historical_feature_introduction_or_availability":3},"lines":[5,21,25,26,27]},
+      {"path":"skills/unity-vrc-udon-sharp/SKILL.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[225,229]},
+      {"path":"skills/unity-vrc-udon-sharp/references/api.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[7]},
+      {"path":"skills/unity-vrc-udon-sharp/references/constraints.md","occurrences":14,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":13},"lines":[8,101,102,107,222,223,224,225,227,257,273,533,534,535]},
+      {"path":"skills/unity-vrc-udon-sharp/references/events.md","occurrences":3,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":2},"lines":[7,64,65]},
+      {"path":"skills/unity-vrc-udon-sharp/references/image-loading-vram.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[5]},
+      {"path":"skills/unity-vrc-udon-sharp/references/networking.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[7]},
+      {"path":"skills/unity-vrc-udon-sharp/references/patterns-performance.md","occurrences":1,"categories":{"historical_feature_introduction_or_availability":1},"lines":[637]},
+      {"path":"skills/unity-vrc-udon-sharp/references/sdk-migration.md","occurrences":2,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":1},"lines":[9,332]},
+      {"path":"skills/unity-vrc-udon-sharp/references/testing.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[7]},
+      {"path":"skills/unity-vrc-udon-sharp/references/troubleshooting.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[7]},
+      {"path":"skills/unity-vrc-udon-sharp/references/web-loading-advanced.md","occurrences":3,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":2},"lines":[5,172,878]},
+      {"path":"skills/unity-vrc-udon-sharp/references/web-loading.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[5]},
+      {"path":"skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[7,38]},
+      {"path":"skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[7]},
+      {"path":"skills/unity-vrc-world-sdk-3/CHEATSHEET.md","occurrences":1,"categories":{"historical_support_boundary":1},"lines":[5]},
+      {"path":"skills/unity-vrc-world-sdk-3/SKILL.md","occurrences":2,"categories":{"historical_support_boundary":2},"lines":[148,152]},
+      {"path":"templates/AGENTS.md","occurrences":2,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":1},"lines":[29,33]},
+      {"path":"templates/CLAUDE.md","occurrences":2,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":1},"lines":[29,33]},
+      {"path":"templates/GEMINI.md","occurrences":2,"categories":{"historical_support_boundary":1,"historical_feature_introduction_or_availability":1},"lines":[29,33]}
     ]
   },
-  "classification_counts": {
-    "historical_release_record": 2,
-    "historical_support_boundary": 34,
-    "historical_feature_introduction_or_availability": 25
-  },
+  "classification_counts": {"historical_release_record":2,"historical_support_boundary":34,"historical_feature_introduction_or_availability":25},
   "active_support_declarations": {
     "stale_active_declaration_scan": {
-      "patterns": "(?:Supported SDK Versions|SDK Coverage|Covered versions)\\s*[:(][^\\n]{0,40}3\\.7\\.1|(?:this skill(?:\\'s)? coverage range|this skill targets SDK\\s+3\\.7\\.1\\+|VRChat_SDK-3\\.7\\.1--3\\.10\\.4|SDK\\s+3\\.7\\.1\\s*(?:-|–)\\s*3\\.10\\.4)",
-      "excluded_historical_records": [
-        "CHANGELOG.md"
-      ],
-      "excluded_test_contracts": [
-        "tests/docs/sdk-support-policy.test.sh"
-      ],
+      "patterns": "(?:Supported SDK Versions|SDK Coverage|Covered versions)\\s*[:(][^\\n]{0,40}3\\.7\\.1|(?:this skill(?:'s)? coverage range|this skill targets SDK\\s+3\\.7\\.1\\+|VRChat_SDK-3\\.7\\.1--3\\.10\\.4|SDK\\s+3\\.7\\.1\\s*(?:-|–)\\s*3\\.10\\.4)",
+      "excluded_historical_records": ["CHANGELOG.md"],
+      "excluded_test_contracts": ["tests/docs/sdk-support-policy.test.sh"],
       "matches": [],
       "result": "no stale active-support declarations"
     },
     "positive_declaration_count": 34,
     "positive_declarations": [
-      {
-        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
-        "line": 74
-      },
-      {
-        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
-        "line": 76
-      },
-      {
-        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
-        "line": 77
-      },
-      {
-        "path": ".claude/skills/unity-vrc-skills-renovator/references/skill-structure.md",
-        "line": 124
-      },
-      {
-        "path": ".claude/skills/unity-vrc-skills-renovator/references/update-checklist.md",
-        "line": 7
-      },
-      {
-        "path": "CONTRIBUTING.md",
-        "line": 175
-      },
-      {
-        "path": "README.md",
-        "line": 214
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/CHEATSHEET.md",
-        "line": 3
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/SKILL.md",
-        "line": 4
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/SKILL.md",
-        "line": 221
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/api.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/constraints.md",
-        "line": 6
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/dynamics.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/events.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/image-loading-vram.md",
-        "line": 3
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/networking.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/persistence.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/sdk-migration.md",
-        "line": 6
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/testing.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/troubleshooting.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/web-loading-advanced.md",
-        "line": 3
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/references/web-loading.md",
-        "line": 3
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md",
-        "line": 5
-      },
-      {
-        "path": "skills/unity-vrc-world-sdk-3/CHEATSHEET.md",
-        "line": 3
-      },
-      {
-        "path": "skills/unity-vrc-world-sdk-3/SKILL.md",
-        "line": 12
-      },
-      {
-        "path": "skills/unity-vrc-world-sdk-3/SKILL.md",
-        "line": 144
-      },
-      {
-        "path": "skills/unity-vrc-world-sdk-3/references/components.md",
-        "line": 5
-      },
-      {
-        "path": "templates/AGENTS.md",
-        "line": 23
-      },
-      {
-        "path": "templates/AGENTS.md",
-        "line": 25
-      },
-      {
-        "path": "templates/CLAUDE.md",
-        "line": 23
-      },
-      {
-        "path": "templates/CLAUDE.md",
-        "line": 25
-      },
-      {
-        "path": "templates/GEMINI.md",
-        "line": 23
-      },
-      {
-        "path": "templates/GEMINI.md",
-        "line": 25
-      }
+      {"path":".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md","line":74},
+      {"path":".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md","line":76},
+      {"path":".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md","line":77},
+      {"path":".claude/skills/unity-vrc-skills-renovator/references/skill-structure.md","line":124},
+      {"path":".claude/skills/unity-vrc-skills-renovator/references/update-checklist.md","line":7},
+      {"path":"CONTRIBUTING.md","line":175},
+      {"path":"README.md","line":214},
+      {"path":"skills/unity-vrc-udon-sharp/CHEATSHEET.md","line":3},
+      {"path":"skills/unity-vrc-udon-sharp/SKILL.md","line":4},
+      {"path":"skills/unity-vrc-udon-sharp/SKILL.md","line":221},
+      {"path":"skills/unity-vrc-udon-sharp/references/api.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/constraints.md","line":6},
+      {"path":"skills/unity-vrc-udon-sharp/references/dynamics.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/events.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/image-loading-vram.md","line":3},
+      {"path":"skills/unity-vrc-udon-sharp/references/networking.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/persistence.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/sdk-migration.md","line":6},
+      {"path":"skills/unity-vrc-udon-sharp/references/testing.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/troubleshooting.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/references/web-loading-advanced.md","line":3},
+      {"path":"skills/unity-vrc-udon-sharp/references/web-loading.md","line":3},
+      {"path":"skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md","line":5},
+      {"path":"skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md","line":5},
+      {"path":"skills/unity-vrc-world-sdk-3/CHEATSHEET.md","line":3},
+      {"path":"skills/unity-vrc-world-sdk-3/SKILL.md","line":12},
+      {"path":"skills/unity-vrc-world-sdk-3/SKILL.md","line":144},
+      {"path":"skills/unity-vrc-world-sdk-3/references/components.md","line":5},
+      {"path":"templates/AGENTS.md","line":23},
+      {"path":"templates/AGENTS.md","line":25},
+      {"path":"templates/CLAUDE.md","line":23},
+      {"path":"templates/CLAUDE.md","line":25},
+      {"path":"templates/GEMINI.md","line":23},
+      {"path":"templates/GEMINI.md","line":25}
     ]
   },
   "historical_introduction_facts": {
-    "categories": [
-      "historical_release_record",
-      "historical_support_boundary",
-      "historical_feature_introduction_or_availability"
-    ],
+    "categories": ["historical_release_record","historical_support_boundary","historical_feature_introduction_or_availability"],
     "policy": "Preserve accurate feature-introduction and migration facts; do not present them as active support or validation promises."
   },
   "test_contracts": [
-    {
-      "path": "tests/docs/sdk-support-policy.test.sh",
-      "role": "RED/GREEN active-support and stale-range contract"
-    },
-    {
-      "path": "tests/docs/community-contributors.test.sh",
-      "role": "RED/GREEN five-README contributor parity contract"
-    },
-    {
-      "path": "tests/docs/network-event-hardening.test.sh",
-      "role": "updated positive active-target assertion"
-    }
+    {"path":"tests/docs/sdk-support-policy.test.sh","role":"RED/GREEN active-support and stale-range contract"},
+    {"path":"tests/docs/community-contributors.test.sh","role":"RED/GREEN five-README contributor parity contract"},
+    {"path":"tests/docs/network-event-hardening.test.sh","role":"updated positive active-target assertion"}
   ]
 }

--- a/tests/docs/fixtures/sdk-support-policy-corpus.json
+++ b/tests/docs/fixtures/sdk-support-policy-corpus.json
@@ -1,0 +1,514 @@
+{
+  "generated_at": "2026-08-18",
+  "repository": "niaka3dayo/agent-skills-vrc-udon",
+  "scope": "Tracked Markdown corpus at the Issue #343 implementation HEAD. This is an evidence snapshot, not a generated API mirror. The fixture itself is excluded from the scan.",
+  "scan": {
+    "command": "git grep -n -F '3.7.1' -- '*.md' ':!tests/docs/fixtures/sdk-support-policy-corpus.json'",
+    "tracked_markdown_files_scanned": 81,
+    "literal": "3.7.1",
+    "occurrences": 61,
+    "files_with_literal": 28,
+    "files": [
+      {
+        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_release_record": 1
+        },
+        "lines": [
+          61
+        ]
+      },
+      {
+        "path": "CHANGELOG.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_release_record": 1
+        },
+        "lines": [
+          46
+        ]
+      },
+      {
+        "path": "CONTRIBUTING.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          177
+        ]
+      },
+      {
+        "path": "README.ja.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          218,
+          222
+        ]
+      },
+      {
+        "path": "README.ko.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          218,
+          222
+        ]
+      },
+      {
+        "path": "README.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          218,
+          222
+        ]
+      },
+      {
+        "path": "README.zh-CN.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          217,
+          221
+        ]
+      },
+      {
+        "path": "README.zh-TW.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          217,
+          221
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/CHEATSHEET.md",
+        "occurrences": 5,
+        "categories": {
+          "historical_support_boundary": 2,
+          "historical_feature_introduction_or_availability": 3
+        },
+        "lines": [
+          5,
+          21,
+          25,
+          26,
+          27
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/SKILL.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          225,
+          229
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/api.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          7
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/constraints.md",
+        "occurrences": 14,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 13
+        },
+        "lines": [
+          8,
+          101,
+          102,
+          107,
+          222,
+          223,
+          224,
+          225,
+          227,
+          257,
+          273,
+          533,
+          534,
+          535
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/events.md",
+        "occurrences": 3,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 2
+        },
+        "lines": [
+          7,
+          64,
+          65
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/image-loading-vram.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          5
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/networking.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          7
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/patterns-performance.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_feature_introduction_or_availability": 1
+        },
+        "lines": [
+          637
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/sdk-migration.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 1
+        },
+        "lines": [
+          9,
+          332
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/testing.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          7
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/troubleshooting.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          7
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/web-loading-advanced.md",
+        "occurrences": 3,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 2
+        },
+        "lines": [
+          5,
+          172,
+          878
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/web-loading.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          5
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          7,
+          38
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          7
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-world-sdk-3/CHEATSHEET.md",
+        "occurrences": 1,
+        "categories": {
+          "historical_support_boundary": 1
+        },
+        "lines": [
+          5
+        ]
+      },
+      {
+        "path": "skills/unity-vrc-world-sdk-3/SKILL.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 2
+        },
+        "lines": [
+          148,
+          152
+        ]
+      },
+      {
+        "path": "templates/AGENTS.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 1
+        },
+        "lines": [
+          29,
+          33
+        ]
+      },
+      {
+        "path": "templates/CLAUDE.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 1
+        },
+        "lines": [
+          29,
+          33
+        ]
+      },
+      {
+        "path": "templates/GEMINI.md",
+        "occurrences": 2,
+        "categories": {
+          "historical_support_boundary": 1,
+          "historical_feature_introduction_or_availability": 1
+        },
+        "lines": [
+          29,
+          33
+        ]
+      }
+    ]
+  },
+  "classification_counts": {
+    "historical_release_record": 2,
+    "historical_support_boundary": 34,
+    "historical_feature_introduction_or_availability": 25
+  },
+  "active_support_declarations": {
+    "stale_active_declaration_scan": {
+      "patterns": "(?:Supported SDK Versions|SDK Coverage|Covered versions)\\s*[:(][^\\n]{0,40}3\\.7\\.1|(?:this skill(?:\\'s)? coverage range|this skill targets SDK\\s+3\\.7\\.1\\+|VRChat_SDK-3\\.7\\.1--3\\.10\\.4|SDK\\s+3\\.7\\.1\\s*(?:-|–)\\s*3\\.10\\.4)",
+      "excluded_historical_records": [
+        "CHANGELOG.md"
+      ],
+      "excluded_test_contracts": [
+        "tests/docs/sdk-support-policy.test.sh"
+      ],
+      "matches": [],
+      "result": "no stale active-support declarations"
+    },
+    "positive_declaration_count": 34,
+    "positive_declarations": [
+      {
+        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
+        "line": 74
+      },
+      {
+        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
+        "line": 76
+      },
+      {
+        "path": ".claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md",
+        "line": 77
+      },
+      {
+        "path": ".claude/skills/unity-vrc-skills-renovator/references/skill-structure.md",
+        "line": 124
+      },
+      {
+        "path": ".claude/skills/unity-vrc-skills-renovator/references/update-checklist.md",
+        "line": 7
+      },
+      {
+        "path": "CONTRIBUTING.md",
+        "line": 175
+      },
+      {
+        "path": "README.md",
+        "line": 214
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/CHEATSHEET.md",
+        "line": 3
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/SKILL.md",
+        "line": 4
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/SKILL.md",
+        "line": 221
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/api.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/constraints.md",
+        "line": 6
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/dynamics.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/events.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/image-loading-vram.md",
+        "line": 3
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/networking.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/persistence.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/sdk-migration.md",
+        "line": 6
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/testing.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/troubleshooting.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/web-loading-advanced.md",
+        "line": 3
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/references/web-loading.md",
+        "line": 3
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md",
+        "line": 5
+      },
+      {
+        "path": "skills/unity-vrc-world-sdk-3/CHEATSHEET.md",
+        "line": 3
+      },
+      {
+        "path": "skills/unity-vrc-world-sdk-3/SKILL.md",
+        "line": 12
+      },
+      {
+        "path": "skills/unity-vrc-world-sdk-3/SKILL.md",
+        "line": 144
+      },
+      {
+        "path": "skills/unity-vrc-world-sdk-3/references/components.md",
+        "line": 5
+      },
+      {
+        "path": "templates/AGENTS.md",
+        "line": 23
+      },
+      {
+        "path": "templates/AGENTS.md",
+        "line": 25
+      },
+      {
+        "path": "templates/CLAUDE.md",
+        "line": 23
+      },
+      {
+        "path": "templates/CLAUDE.md",
+        "line": 25
+      },
+      {
+        "path": "templates/GEMINI.md",
+        "line": 23
+      },
+      {
+        "path": "templates/GEMINI.md",
+        "line": 25
+      }
+    ]
+  },
+  "historical_introduction_facts": {
+    "categories": [
+      "historical_release_record",
+      "historical_support_boundary",
+      "historical_feature_introduction_or_availability"
+    ],
+    "policy": "Preserve accurate feature-introduction and migration facts; do not present them as active support or validation promises."
+  },
+  "test_contracts": [
+    {
+      "path": "tests/docs/sdk-support-policy.test.sh",
+      "role": "RED/GREEN active-support and stale-range contract"
+    },
+    {
+      "path": "tests/docs/community-contributors.test.sh",
+      "role": "RED/GREEN five-README contributor parity contract"
+    },
+    {
+      "path": "tests/docs/network-event-hardening.test.sh",
+      "role": "updated positive active-target assertion"
+    }
+  ]
+}

--- a/tests/docs/network-event-hardening.test.sh
+++ b/tests/docs/network-event-hardening.test.sh
@@ -143,10 +143,10 @@ for path in "$UDON_DIR/SKILL.md" "$README_EN" "$README_JA" "$README_KO" \
     require_text "$path" 'JQ_UNAVAILABLE'
 done
 
-# Current support declarations must agree on the SDK 3.10.4 upper bound.
-require_text "$CONTRIBUTING" "SDK 3.7.1 - 3.10.4"
-require_text "$CONSTRAINTS_RULE" "**SDK Coverage**: 3.7.1 - 3.10.4"
-require_text "$RULE" "**SDK Coverage**: 3.7.1 - 3.10.4"
+# Current support declarations must agree on the sole active SDK 3.10.4 target.
+require_text "$CONTRIBUTING" "**Active and verified target**: SDK 3.10.4"
+require_text "$CONSTRAINTS_RULE" "**Active support / last verified**: SDK 3.10.4"
+require_text "$RULE" "**Active support / last verified**: SDK 3.10.4"
 
 # Historical, version-specific evidence must not be rewritten as current coverage.
 require_text "$API_REF" "observed in the SDK 3.10.3 Udon wrapper symbols"

--- a/tests/docs/repository-governance-contract.test.sh
+++ b/tests/docs/repository-governance-contract.test.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SECURITY="$ROOT_DIR/SECURITY.md"
 CHANGELOG="$ROOT_DIR/CHANGELOG.md"
 DOC_SYNC="$ROOT_DIR/.claude/rules/doc-sync.md"
+CONTRIBUTING="$ROOT_DIR/CONTRIBUTING.md"
 CLAUDE="$ROOT_DIR/CLAUDE.md"
 LABELS="$ROOT_DIR/.github/labels.yml"
 LABEL_SYNC="$ROOT_DIR/.github/workflows/label-sync.yml"
@@ -37,6 +38,18 @@ for path in "$CHANGELOG" "$DOC_SYNC" "$CLAUDE"; do
     require_text "$path" "$ARCHIVE"
     require_text "$path" "$NO_BACKFILL"
 done
+
+# The contributor census is intentionally Issue-originated and must not turn
+# maintainer, bot, invalid-report, or PR-only activity into public credit.
+require_text "$DOC_SYNC" 'external GitHub Issue reporters'
+require_text "$DOC_SYNC" 'Exclude maintainer and bot accounts'
+require_text "$DOC_SYNC" 'invalid/duplicate/wontfix/spam Issues'
+require_text "$DOC_SYNC" 'PR-only contributors'
+
+# The support boundary applies to both distributed Skills, not only the file
+# from which this guidance happened to be copied.
+require_text "$CONTRIBUTING" 'for either distributed Skill'
+require_text "$CONTRIBUTING" 'applies to both distributed Skills'
 require_text "$CHANGELOG" '[1.2.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.2.0'
 require_text "$CHANGELOG" '[1.0.0]: https://github.com/niaka3dayo/agent-skills-vrc-udon/releases/tag/v1.0.0'
 forbid_text "$DOC_SYNC" 'CHANGELOG.md` — managed by Release Drafter, not manual edits'

--- a/tests/docs/sdk-support-policy.test.sh
+++ b/tests/docs/sdk-support-policy.test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CORPUS_FIXTURE="$ROOT_DIR/tests/docs/fixtures/sdk-support-policy-corpus.json"
 
 fail() {
     echo "ERROR: $*" >&2
@@ -37,6 +38,38 @@ README_FILES=(
     "$ROOT_DIR/README.zh-TW.md"
     "$ROOT_DIR/README.ko.md"
 )
+
+# Keep the tracked literal census and its classifications alongside the
+# contract. The fixture deliberately excludes this test file's negative
+# examples and immutable CHANGELOG entries from the stale-declaration scan.
+[ -f "$CORPUS_FIXTURE" ] || fail "missing SDK support-policy corpus census: $CORPUS_FIXTURE"
+python3 - "$CORPUS_FIXTURE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+scan = data["scan"]
+files = scan["files"]
+assert scan["literal"] == "3.7.1"
+assert scan["occurrences"] == sum(item["occurrences"] for item in files) == 61
+assert scan["files_with_literal"] == len(files) == 28
+assert sum(data["classification_counts"].values()) == scan["occurrences"]
+stale = data["active_support_declarations"]["stale_active_declaration_scan"]
+assert stale["matches"] == []
+assert stale["result"] == "no stale active-support declarations"
+assert {item["path"] for item in data["test_contracts"]} == {
+    "tests/docs/sdk-support-policy.test.sh",
+    "tests/docs/community-contributors.test.sh",
+    "tests/docs/network-event-hardening.test.sh",
+}
+PY
+
+# Re-run the stale declaration scan against the live tracked corpus. The
+# changelog and this test's negative fixtures intentionally retain old release
+# wording as historical/test evidence.
+STALE_ACTIVE_SCAN="$(git -C "$ROOT_DIR" grep -n -E '(^|[^[:alnum:]])(Supported SDK Versions|SDK Coverage|Covered versions)[[:space:]]*[:(][^[:cntrl:]]*3\.7\.1|this skill.?s coverage range|this skill targets SDK[[:space:]]+3\.7\.1\+|VRChat_SDK-3\.7\.1--3\.10\.4|SDK[[:space:]]+3\.7\.1[[:space:]]*(-|–)[[:space:]]*3\.10\.4' -- '*.md' ':!CHANGELOG.md' ':!tests/docs/*' || true)"
+[ -z "$STALE_ACTIVE_SCAN" ] || fail "stale active-support declaration found:\n$STALE_ACTIVE_SCAN"
 
 # The repository-level contract must name the one actively verified target and
 # distinguish it from historical feature-introduction entries. This wording is

--- a/tests/docs/sdk-support-policy.test.sh
+++ b/tests/docs/sdk-support-policy.test.sh
@@ -67,9 +67,45 @@ PY
 
 # Re-run the stale declaration scan against the live tracked corpus. The
 # changelog and this test's negative fixtures intentionally retain old release
-# wording as historical/test evidence.
-STALE_ACTIVE_SCAN="$(git -C "$ROOT_DIR" grep -n -E '(^|[^[:alnum:]])(Supported SDK Versions|SDK Coverage|Covered versions)[[:space:]]*[:(][^[:cntrl:]]*3\.7\.1|this skill.?s coverage range|this skill targets SDK[[:space:]]+3\.7\.1\+|VRChat_SDK-3\.7\.1--3\.10\.4|SDK[[:space:]]+3\.7\.1[[:space:]]*(-|–)[[:space:]]*3\.10\.4' -- '*.md' ':!CHANGELOG.md' ':!tests/docs/*' || true)"
+# wording as historical/test evidence. Match any numeric active range rather
+# than hard-coding the retired lower bound, so a future policy regression such
+# as 3.8.1 - 3.10.4 cannot silently pass.
+STALE_ACTIVE_DECLARATION_PATTERN='(^|[^[:alnum:]])(Supported SDK Versions|SDK Coverage|Covered versions)(\*\*)?[[:space:]]*[:(][^[:cntrl:]]*[0-9]+\.[0-9]+\.[0-9]+'
+STALE_ACTIVE_SCAN_PATTERN="$STALE_ACTIVE_DECLARATION_PATTERN|this skill.?s coverage range|this skill targets SDK[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+\+|VRChat_SDK-[0-9]+\.[0-9]+\.[0-9]+--[0-9]+\.[0-9]+\.[0-9]+|SDK[[:space:]]+3\.7\.1[[:space:]]*(-|–)[[:space:]]*3\.10\.4"
+STALE_ACTIVE_SCAN="$(git -C "$ROOT_DIR" grep -n -E "$STALE_ACTIVE_SCAN_PATTERN" -- '*.md' ':!CHANGELOG.md' ':!tests/docs/*' || true)"
 [ -z "$STALE_ACTIVE_SCAN" ] || fail "stale active-support declaration found:\n$STALE_ACTIVE_SCAN"
+
+# A future SDK is not an active support target until this repository verifies
+# it. Reject the easy-to-miss "3.10.4 or newer" routing form while preserving
+# historical feature-introduction notes such as "SDK 3.8.1+".
+FUTURE_AUTO_SUPPORT_PATTERN='SDK[[:space:]]+3\.10\.4[[:space:]]+or[[:space:]]+newer'
+FUTURE_AUTO_SUPPORT_SCAN="$(git -C "$ROOT_DIR" grep -n -E -i "$FUTURE_AUTO_SUPPORT_PATTERN" -- '*.md' ':!CHANGELOG.md' ':!tests/docs/*' || true)"
+[ -z "$FUTURE_AUTO_SUPPORT_SCAN" ] || fail "unverified future SDK auto-support wording found:\n$FUTURE_AUTO_SUPPORT_SCAN"
+
+# Keep the two negative cases executable. This is the mutation guard for the
+# contract itself: broad old ranges must be rejected, future auto-support must
+# be rejected, and an SDK x+ feature-introduction note must remain allowed.
+MUTATED_REFERENCE="$(mktemp)"
+trap 'rm -f "$MUTATED_REFERENCE"' EXIT
+cp "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/vrctween.md" "$MUTATED_REFERENCE"
+cat >> "$MUTATED_REFERENCE" <<'EOF'
+
+**Supported SDK Versions**: 3.8.1 - 3.10.4
+Route this reference to projects using SDK 3.10.4 or newer.
+Historical feature introduction: SDK 3.8.1+ remains valid migration context.
+EOF
+grep -Eiq "$STALE_ACTIVE_DECLARATION_PATTERN" "$MUTATED_REFERENCE" \
+    || fail "mutation guard missed an arbitrary old active SDK range"
+grep -Eiq "$FUTURE_AUTO_SUPPORT_PATTERN" "$MUTATED_REFERENCE" \
+    || fail "mutation guard missed unverified future SDK auto-support wording"
+if grep -Eiq 'Historical feature introduction: SDK 3\.8\.1\+' "$MUTATED_REFERENCE" \
+    && ! grep -Eiq "$STALE_ACTIVE_DECLARATION_PATTERN" <(grep -E 'Historical feature introduction:' "$MUTATED_REFERENCE"); then
+    echo "PASS: historical SDK x+ introduction note remains allowed"
+else
+    fail "historical SDK x+ introduction note was treated as an active declaration"
+fi
+echo "PASS: arbitrary old active SDK range mutation rejected"
+echo "PASS: unverified future SDK auto-support mutation rejected"
 
 # The repository-level contract must name the one actively verified target and
 # distinguish it from historical feature-introduction entries. This wording is
@@ -160,6 +196,14 @@ require_text "$ROOT_DIR/CONTRIBUTING.md" 'historical migration information only'
 require_text "$ROOT_DIR/.claude/skills/unity-vrc-skills-renovator/references/skill-structure.md" '**Active support / last verified**: SDK 3.10.4'
 require_text "$ROOT_DIR/.claude/skills/unity-vrc-skills-renovator/references/update-checklist.md" 'active-versus-historical boundary'
 require_text "$ROOT_DIR/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md" 'active and verified target'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/vrctween.md" '**Active support / last verified**: SDK 3.10.4'
+forbid_regex "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/vrctween.md" 'SDK 3\.10\.4\+|SDK 3\.10\.4 or newer'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/CHEATSHEET.md" '## VRCTween (introduced in SDK 3.10.4)'
+forbid_regex "$ROOT_DIR/skills/unity-vrc-udon-sharp/CHEATSHEET.md" '## VRCTween \(SDK 3\.10\.4\+\)|on SDK 3\.10\.4\+'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md" 'Solution on the active SDK target (3.10.4)'
+forbid_regex "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md" 'routeable SDK 3\.10\.4\+|on SDK 3\.10\.4\+'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'historical migration guidance for unsupported older projects'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md" 'Historical migration guidance only: SDK 3.7.1 introduced the available surface'
 
 # This contract must be part of the required Documentation Smoke Tests job.
 CI="$ROOT_DIR/.github/workflows/ci.yml"

--- a/tests/docs/sdk-support-policy.test.sh
+++ b/tests/docs/sdk-support-policy.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+require_text() {
+    local path="$1"
+    local text="$2"
+    grep -Fq -- "$text" "$path" || fail "$path is missing: $text"
+}
+
+forbid_text() {
+    local path="$1"
+    local text="$2"
+    if grep -Fq -- "$text" "$path"; then
+        fail "$path still contains stale active-support text: $text"
+    fi
+}
+
+forbid_regex() {
+    local path="$1"
+    local pattern="$2"
+    if grep -Eq -- "$pattern" "$path"; then
+        fail "$path still matches stale active-support pattern: $pattern"
+    fi
+}
+
+README_FILES=(
+    "$ROOT_DIR/README.md"
+    "$ROOT_DIR/README.ja.md"
+    "$ROOT_DIR/README.zh-CN.md"
+    "$ROOT_DIR/README.zh-TW.md"
+    "$ROOT_DIR/README.ko.md"
+)
+
+# The repository-level contract must name the one actively verified target and
+# distinguish it from historical feature-introduction entries. This wording is
+# deliberately English in the canonical README so future translations can be
+# checked against the same policy without treating VRChat's own policy as ours.
+require_text "$ROOT_DIR/README.md" '**Active support / last verified**: VRChat SDK 3.10.4'
+require_text "$ROOT_DIR/README.md" 'From v4.0.0 onward, the support policy is latest stable SDK only; the support target moves to a new stable release only after this repository verifies it. A new stable release is not supported automatically.'
+require_text "$ROOT_DIR/README.md" 'historical feature-introduction notes'
+require_text "$ROOT_DIR/README.md" "not a statement about VRChat's own SDK policy"
+forbid_text "$ROOT_DIR/README.md" 'VRChat_SDK-3.7.1--3.10.4'
+forbid_text "$ROOT_DIR/README.md" 'SDK coverage (3.7.1 - 3.10.4)'
+
+# All translations carry the same current target and must not advertise the old
+# range in their badge or accuracy note.
+for path in "${README_FILES[@]}"; do
+    require_text "$path" '3.10.4'
+    forbid_regex "$path" '3\.7\.1.{0,8}3\.10\.4'
+done
+
+# Translations must carry the same stable-only policy and verification gate,
+# rather than merely repeating the current version number.
+declare -A README_POLICY=()
+README_POLICY["$ROOT_DIR/README.md"]='From v4.0.0 onward, the support policy is latest stable SDK only; the support target moves to a new stable release only after this repository verifies it.'
+README_POLICY["$ROOT_DIR/README.ja.md"]='v4.0.0以降は最新の安定版SDKのみをサポートし、新しい安定版への切り替えはこのリポジトリで検証してから行います。'
+README_POLICY["$ROOT_DIR/README.zh-CN.md"]='从 v4.0.0 起，本项目只支持最新的稳定版 SDK；只有在本仓库完成验证后，支持目标才会切换到新的稳定版本。'
+README_POLICY["$ROOT_DIR/README.zh-TW.md"]='從 v4.0.0 起，本專案只支援最新的穩定版 SDK；只有在本儲存庫完成驗證後，支援目標才會切換到新的穩定版本。'
+README_POLICY["$ROOT_DIR/README.ko.md"]='v4.0.0부터는 최신 안정 SDK만 지원하며, 새 안정 버전으로의 지원 전환은 이 저장소에서 검증한 뒤에만 진행합니다.'
+for path in "${README_FILES[@]}"; do
+    require_text "$path" "${README_POLICY[$path]}"
+done
+
+# Both distributed skills expose the same active-support boundary. Historical
+# version rows may remain, but the former range must not remain a coverage claim.
+for path in \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/SKILL.md" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/SKILL.md"; do
+    require_text "$path" 'Active support / last verified'
+    require_text "$path" 'SDK 3.10.4'
+    require_text "$path" 'historical'
+    forbid_regex "$path" '(Supported SDK Versions|SDK Coverage|Covered versions|SDK 3\.7\.1-3\.10\.4|SDK 3\.7\.1 - 3\.10\.4)'
+done
+
+for path in \
+    "$ROOT_DIR/templates/AGENTS.md" \
+    "$ROOT_DIR/templates/CLAUDE.md" \
+    "$ROOT_DIR/templates/GEMINI.md"; do
+    require_text "$path" 'From v4.0.0 onward'
+    require_text "$path" 'not supported or validation targets'
+done
+
+# Reference headers are active-support declarations, not feature-introduction
+# history. Keep the historical baseline in body text where it explains an API.
+for path in \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/api.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/constraints.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/dynamics.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/events.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/image-loading-vram.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/networking.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/persistence.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/testing.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/troubleshooting.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/web-loading.md" \
+    "$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/components.md"; do
+    require_text "$path" 'Active support / last verified'
+    require_text "$path" '3.10.4'
+done
+
+for path in \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/rules/udonsharp-constraints.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md"; do
+    require_text "$path" 'Active support / last verified'
+    require_text "$path" '3.10.4'
+    forbid_regex "$path" 'SDK Coverage.*3\.7\.1'
+done
+
+# Distributed agent templates and maintainer guidance must teach the same
+# active-vs-historical boundary.
+for path in "$ROOT_DIR/templates/AGENTS.md" "$ROOT_DIR/templates/CLAUDE.md" "$ROOT_DIR/templates/GEMINI.md"; do
+    require_text "$path" 'active: 3.10.4'
+    require_text "$path" 'historical'
+    forbid_regex "$path" 'SDK \(3\.7\.1.{0,8}3\.10\.4\)'
+done
+
+require_text "$ROOT_DIR/CONTRIBUTING.md" '**Active and verified target**: SDK 3.10.4'
+require_text "$ROOT_DIR/CONTRIBUTING.md" 'historical migration information only'
+require_text "$ROOT_DIR/.claude/skills/unity-vrc-skills-renovator/references/skill-structure.md" '**Active support / last verified**: SDK 3.10.4'
+require_text "$ROOT_DIR/.claude/skills/unity-vrc-skills-renovator/references/update-checklist.md" 'active-versus-historical boundary'
+require_text "$ROOT_DIR/.claude/skills/unity-vrc-skills-renovator/references/changelog-sources.md" 'active and verified target'
+
+# This contract must be part of the required Documentation Smoke Tests job.
+CI="$ROOT_DIR/.github/workflows/ci.yml"
+require_text "$CI" 'Check SDK active support policy'
+require_text "$CI" 'bash tests/docs/sdk-support-policy.test.sh'
+
+echo "PASS: SDK active support policy contract"

--- a/tests/docs/sdk-support-policy.test.sh
+++ b/tests/docs/sdk-support-policy.test.sh
@@ -165,6 +165,8 @@ for path in \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/events.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/image-loading-vram.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/networking.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/persistence.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/testing.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/troubleshooting.md" \
@@ -173,6 +175,12 @@ for path in \
     "$ROOT_DIR/skills/unity-vrc-world-sdk-3/references/components.md"; do
     require_text "$path" 'Active support / last verified'
     require_text "$path" '3.10.4'
+done
+
+for path in \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md"; do
+    require_text "$path" '**Historical version notes**: Older version numbers record feature introductions or migration facts only; they are not supported or validation targets.'
 done
 
 for path in \
@@ -202,8 +210,12 @@ require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/CHEATSHEET.md" '## VRCTween 
 forbid_regex "$ROOT_DIR/skills/unity-vrc-udon-sharp/CHEATSHEET.md" '## VRCTween \(SDK 3\.10\.4\+\)|on SDK 3\.10\.4\+'
 require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md" 'Solution on the active SDK target (3.10.4)'
 forbid_regex "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md" 'routeable SDK 3\.10\.4\+|on SDK 3\.10\.4\+'
-require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'historical migration guidance for unsupported older projects'
 require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md" 'Historical migration guidance only: SDK 3.7.1 introduced the available surface'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'remains the recommended choice on the active SDK target, SDK 3.10.4'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'valid alternative for small, capacity-limited worlds'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'valid for single-player preview or debugging'
+require_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'historical migration context, not an active-support cutoff'
+forbid_text "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" 'not as active support routes'
 
 # This contract must be part of the required Documentation Smoke Tests job.
 CI="$ROOT_DIR/.github/workflows/ci.yml"

--- a/tests/docs/sdk-support-policy.test.sh
+++ b/tests/docs/sdk-support-policy.test.sh
@@ -168,6 +168,7 @@ for path in \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-networking.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/patterns-utilities.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/persistence.md" \
+    "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/sdk-migration.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/testing.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/troubleshooting.md" \
     "$ROOT_DIR/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md" \


### PR DESCRIPTION
## Summary

- Make VRChat SDK 3.10.4 the sole active and last-verified target for both public Skills.
- Keep SDK 3.7.1-3.10.3 feature-introduction and migration notes, but label them as historical rather than supported or validation targets.
- Define the v4.0.0+ latest-stable-only policy: a new stable SDK becomes the target only after this repository verifies it.
- Synchronize the policy across five READMEs, distributed templates, Skills, cheatsheets, references, and maintainer guidance.
- Remove active-support routing language from the VRCTween, networking, web-loading, and utility cross-references while preserving their historical version facts.
- Add a GitHub Issue census and synchronized Community Contributors acknowledgement for 8 external reporters and 20 linked Issues.
- Clarify the contributor eligibility rule, apply the support boundary to both distributed Skills, and keep the networking cost-tier alternatives accurate on SDK 3.10.4.
- Add active-support and historical-notes headers to the networking and utility pattern references.

## Breaking change

This changes the public support contract. SDK 3.7.1-3.10.3 are no longer support or validation targets. The package and Skill version fields are intentionally unchanged here; v4.0.0 release preparation is a separate step.

## Verification

- All documentation smoke tests, including the RED-to-GREEN support-policy and contributor-list contracts
- SDK support mutation guards reject arbitrary old active ranges and unverified `SDK 3.10.4 or newer` routing, while allowing historical `SDK x+` feature notes
- Contributor mutation guard exact-compares fixture-backed profile handles, per-contributor Issue sets, and the aggregate Issue set across all five READMEs
- Follow-up documentation contracts cover contributor eligibility, both-Skill support wording, networking tier semantics, and active reference headers
- The active-reference contract now covers `sdk-migration.md`; removing its support header is rejected by the mutation check
- Hook validator and BusyBox portability suites
- `bash -n` for the new contract tests
- `npm pack --dry-run`
- `git diff --check`

The local environment does not have `lychee` or `editorconfig-checker`; those remain CI gates.

## Out of scope

- #341 (`VRCUrl.Empty` initializer guidance)
- #342 (`IUdonEventReceiver` example update)
- Package/Skill version bump and v4.0.0 release preparation

Closes #343


