### PR TITLE
docs(udon-sharp): use direct SDK 3.10.4 event receivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Check SDK active support policy
         run: bash tests/docs/sdk-support-policy.test.sh
 
+      - name: Check Udon event receiver reference
+        run: bash tests/docs/udon-event-receiver-reference.test.sh
+
       - name: Check community contributor acknowledgements
         run: bash tests/docs/community-contributors.test.sh
 

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -438,16 +438,16 @@ See `references/web-loading.md` for details.
 
 ```csharp
 using VRC.SDK3.StringLoading;  // String Loading
-using VRC.SDK3.ImageLoading;   // Image Loading
+using VRC.SDK3.Image;           // Image Loading
 using VRC.SDK3.Data;           // VRCJson
 
 // String download
-VRCStringDownloader.LoadUrl(url, (IUdonEventReceiver)this);
+VRCStringDownloader.LoadUrl(url, this);
 // -> OnStringLoadSuccess(IVRCStringDownload) / OnStringLoadError
 
 // Image download (Dispose the wrapper + Destroy the assigned Texture2D — see image-loading-vram.md)
 var dl = new VRCImageDownloader();
-dl.DownloadImage(url, material, (IUdonEventReceiver)this, textureInfo);
+dl.DownloadImage(url, material, this, textureInfo);
 // -> OnImageLoadSuccess(IVRCImageDownload) / OnImageLoadError
 
 // JSON parse (after string download)

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -249,7 +249,7 @@ The table below keeps feature-introduction history for migration reference. SDK 
 | 3.10.1 | Bug fixes and stability improvements | Historical |
 | 3.10.2 | EventTiming extensions, PhysBones fixes, shader time globals | Historical |
 | 3.10.3 | `VRCPlayerApi.isVRCPlus`, VRCRaycast (avatar), Mirror render-order fix | Historical |
-| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary custom capacity, `DataDictionary.EnsureCapacity` | Active / Last verified |
+| 3.10.4 | VRCTween, Box-shaped Contacts, Global Avatar PhysBone Colliders, world `VRCPhysBoneCollider` Udon access, DataList/DataDictionary custom capacity, `DataDictionary.EnsureCapacity`, `UdonSharpBehaviour` implements `IUdonEventReceiver` and accepts direct receiver `this` | Active / Last verified |
 
 Use SDK 3.10.4 for publishing. Check the matching release notes before relying on a version-specific API or migration step.
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -55,6 +55,18 @@ compiler constraints, use `unity-vrc-world-sdk-3` and read
 4. **Sync Minimization** — Every synced variable costs bandwidth (see data budget in `udonsharp-sync-selection.md`). Derive what you can locally; sync only the source of truth.
 5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()` **for state-change reactions; for hot-path or periodic work, see [Event Dispatch & Cross-Behaviour Call Cost Tiers](references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers)**.
 
+## SDK 3.10.4 event receiver arguments
+
+SDK 3.10.4 is the active and verified target for this Skill.
+SDK 3.10.4: `UdonSharpBehaviour` implements `IUdonEventReceiver` directly.
+An API that requires a receiver can therefore receive `this` directly:
+
+```csharp
+VRCStringDownloader.LoadUrl(dataUrl, this);
+```
+
+The receiver argument is still required; only the explicit `(IUdonEventReceiver)` cast is unnecessary on the active SDK. Keep any pre-3.10.4 cast in the historical migration reference only. This follows the [official SDK 3.10.4 release notes](https://creators.vrchat.com/releases/release-3-10-4/) and the SDK source declaration.
+
 ### Public fields: Inspector visibility is not persistence policy
 
 `[HideInInspector]` only hides a public field from the Inspector; Unity still serializes it. Use `[HideInInspector] public` when Editor-time DI, baking, or autowiring must persist the value into a Scene/Prefab. Use `[System.NonSerialized] public` for a runtime-only value that another UdonBehaviour must access through direct access or `SetProgramVariable`. When `[HideInInspector]` is intentional, leave a comment explaining why the value must be persisted.

--- a/skills/unity-vrc-udon-sharp/references/api.md
+++ b/skills/unity-vrc-udon-sharp/references/api.md
@@ -251,7 +251,7 @@ if (NetworkCalling.InNetworkCall && caller != null && caller.IsValid())
 
 // Get queued events for a specific method on this behaviour
 int queuedCount = NetworkCalling.GetQueuedEvents(
-    (IUdonEventReceiver)this,
+    this,
     nameof(_MyNetworkMethod)
 );
 
@@ -293,7 +293,7 @@ public class NetworkMonitor : UdonSharpBehaviour
     void Update()
     {
         int myEventQueue = NetworkCalling.GetQueuedEvents(
-            (IUdonEventReceiver)this,
+            this,
             nameof(_OnNetworkEvent)
         );
         int totalQueue = NetworkCalling.GetAllQueuedEvents();
@@ -306,7 +306,7 @@ public class NetworkMonitor : UdonSharpBehaviour
     public void _SendEvent()
     {
         // Check before sending to avoid queue buildup
-        if (NetworkCalling.GetQueuedEvents((IUdonEventReceiver)this, nameof(_OnNetworkEvent)) < 10)
+        if (NetworkCalling.GetQueuedEvents(this, nameof(_OnNetworkEvent)) < 10)
         {
             SendCustomNetworkEvent(NetworkEventTarget.All, nameof(_OnNetworkEvent));
         }
@@ -469,7 +469,6 @@ using UdonSharp;
 using UnityEngine;
 using VRC.SDK3.Components;
 using VRC.SDKBase;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class PoolManager : UdonSharpBehaviour
@@ -718,8 +717,8 @@ sync.FlagDiscontinuity();
 For details on the Web Loading API, see `references/web-loading.md`.
 
 **Key Points:**
-- `VRCStringDownloader.LoadUrl(url, (IUdonEventReceiver)this)` -- Text/JSON download
-- `new VRCImageDownloader().DownloadImage(url, material, (IUdonEventReceiver)this, textureInfo)` -- Image download
+- `VRCStringDownloader.LoadUrl(url, this)` -- Text/JSON download
+- `new VRCImageDownloader().DownloadImage(url, material, this, textureInfo)` -- Image download
 - Rate limit: **Once every 5 seconds** (for String/Image each)
 - Max image resolution: **2048 x 2048**
 - Trusted URLs: Domain allowlist restrictions apply
@@ -727,12 +726,12 @@ For details on the Web Loading API, see `references/web-loading.md`.
 
 ```csharp
 // String Loading (VRC.SDK3.StringLoading)
-VRCStringDownloader.LoadUrl(dataUrl, (IUdonEventReceiver)this);
+VRCStringDownloader.LoadUrl(dataUrl, this);
 // -> OnStringLoadSuccess / OnStringLoadError
 
-// Image Loading (VRC.SDK3.ImageLoading)
+// Image Loading (VRC.SDK3.Image)
 var downloader = new VRCImageDownloader();
-downloader.DownloadImage(imageUrl, material, (IUdonEventReceiver)this);
+downloader.DownloadImage(imageUrl, material, this);
 // -> OnImageLoadSuccess / OnImageLoadError
 ```
 
@@ -1262,7 +1261,6 @@ VRCPlayerApi pilot = drone.GetPlayer();
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
-using VRC.Udon.Common.Interfaces;
 
 public class DroneCheckpoint : UdonSharpBehaviour
 {

--- a/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
+++ b/skills/unity-vrc-udon-sharp/references/image-loading-vram.md
@@ -99,8 +99,7 @@ does not free a texture you have applied to a material. You must call
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
-using VRC.SDK3.ImageLoading;
-using VRC.Udon.Common.Interfaces;
+using VRC.SDK3.Image;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class SafeImageLoader : UdonSharpBehaviour
@@ -135,7 +134,7 @@ public class SafeImageLoader : UdonSharpBehaviour
         _currentDownload = _downloader.DownloadImage(
             imageUrl,
             null,                       // pass null — we apply the texture manually
-            (IUdonEventReceiver)this,
+            this,
             info
         );
     }
@@ -222,8 +221,7 @@ time-delayed operations, use `SendCustomEventDelayedSeconds(nameof(_MethodName),
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
-using VRC.SDK3.ImageLoading;
-using VRC.Udon.Common.Interfaces;
+using VRC.SDK3.Image;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class DoubleBufferImageDisplay : UdonSharpBehaviour
@@ -294,7 +292,7 @@ public class DoubleBufferImageDisplay : UdonSharpBehaviour
         _pendingDownload = _downloader.DownloadImage(
             imageUrls[_nextUrlIndex],
             null,
-            (IUdonEventReceiver)this,
+            this,
             info
         );
 
@@ -467,8 +465,7 @@ Runtime: Cycle through cached textures  → no further downloads
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
-using VRC.SDK3.ImageLoading;
-using VRC.Udon.Common.Interfaces;
+using VRC.SDK3.Image;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class StockModeGallery : UdonSharpBehaviour
@@ -527,7 +524,7 @@ public class StockModeGallery : UdonSharpBehaviour
         _downloader.DownloadImage(
             imageUrls[idx],
             galleryMaterials[idx],      // downloader applies texture to this material
-            (IUdonEventReceiver)this,
+            this,
             info
         );
 
@@ -790,8 +787,7 @@ by a base delay to stagger when it first downloads.
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
-using VRC.SDK3.ImageLoading;
-using VRC.Udon.Common.Interfaces;
+using VRC.SDK3.Image;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class StaggeredImageLoader : UdonSharpBehaviour
@@ -840,7 +836,7 @@ public class StaggeredImageLoader : UdonSharpBehaviour
         _currentDownload = _downloader.DownloadImage(
             imageUrl,
             null,
-            (IUdonEventReceiver)this,
+            this,
             info
         );
     }

--- a/skills/unity-vrc-udon-sharp/references/patterns-video.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-video.md
@@ -39,7 +39,6 @@ using VRC.SDKBase;
 using VRC.SDK3.Video.Components;
 using VRC.SDK3.Video.Components.AVPro;
 using VRC.SDK3.Video.Components.Base;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
 public class VideoPlayerStateMachine : UdonSharpBehaviour

--- a/skills/unity-vrc-udon-sharp/references/sdk-migration.md
+++ b/skills/unity-vrc-udon-sharp/references/sdk-migration.md
@@ -20,6 +20,20 @@ Version-specific notes in this skill use three marker forms. Match them verbatim
 
 ---
 
+## SDK 3.10.4 receiver migration
+
+`UdonSharpBehaviour` directly implements `IUdonEventReceiver` starting with SDK 3.10.4. The active Skill examples therefore pass `this` directly and keep the receiver argument.
+The cast below is historical migration syntax for SDK 3.10.3 and earlier; do not copy it into an active 3.10.4 example.
+
+```csharp
+using VRC.SDK3.StringLoading;
+using VRC.Udon.Common.Interfaces;
+
+VRCStringDownloader.LoadUrl(dataUrl, (IUdonEventReceiver)this);
+```
+
+When a project moves to the active SDK target, remove the cast and remove the interface using when that block no longer refers to `IUdonEventReceiver` or another type from that namespace.
+
 ## SDK 3.7.x to 3.8.x
 
 ### New Features

--- a/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading-advanced.md
@@ -105,7 +105,6 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.StringLoading;
 using VRC.SDK3.Data;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class PackFormatParser : UdonSharpBehaviour
@@ -532,7 +531,6 @@ using System;
 using VRC.SDKBase;
 using VRC.SDK3.StringLoading;
 using VRC.SDK3.Data;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class PackedResourceLoader : UdonSharpBehaviour
@@ -605,7 +603,7 @@ public class PackedResourceLoader : UdonSharpBehaviour
         _hasRuntimeSprite = new bool[_uiSlots.Length];
 
         // Download resource index first
-        VRCStringDownloader.LoadUrl(_indexUrl, (IUdonEventReceiver)this);
+        VRCStringDownloader.LoadUrl(_indexUrl, this);
     }
 
     // ── Download callbacks ───────────────────────────────────────────────────
@@ -712,7 +710,7 @@ public class PackedResourceLoader : UdonSharpBehaviour
         if (urlIdx >= _packUrls.Length) return;
         _pendingUrlIndex  = urlIdx;
         _pendingSlotIndex = slotIdx;
-        VRCStringDownloader.LoadUrl(_packUrls[urlIdx], (IUdonEventReceiver)this);
+        VRCStringDownloader.LoadUrl(_packUrls[urlIdx], this);
         // Rate limit: next slot after 5.5 s
         SendCustomEventDelayedSeconds(nameof(_LoadNextSlot), 5.5f);
     }

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -6,12 +6,26 @@ Older version numbers in this reference record feature introductions or migratio
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 
+### SDK 3.10.4 event receiver arguments
+
+On SDK 3.10.4, pass `this` as the receiver argument; the explicit cast is no longer needed.
+The receiver argument is still required for UdonSharp callbacks, including on SDK 3.10.4.
+
+```csharp
+VRCStringDownloader.LoadUrl(dataUrl, this);
+
+var downloader = new VRCImageDownloader();
+downloader.DownloadImage(imageUrl, material, this);
+```
+
+This is a change to the cast, not to callback routing: omit the receiver argument and the completion event still has no target.
+
 ## Overview
 
 | API | Purpose | Namespace |
 |-----|------|----------|
 | `VRCStringDownloader` | Text/JSON download | `VRC.SDK3.StringLoading` |
-| `VRCImageDownloader` | Image download (Texture2D) | `VRC.SDK3.ImageLoading` |
+| `VRCImageDownloader` | Image download (Texture2D) | `VRC.SDK3.Image` |
 | `VRCJson` | JSON parsing (string -> DataDictionary) | `VRC.SDK3.Data` |
 
 ## Common Constraints
@@ -89,7 +103,6 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.Components;
 using VRC.SDK3.StringLoading;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class UserUrlLoader : UdonSharpBehaviour
@@ -100,7 +113,7 @@ public class UserUrlLoader : UdonSharpBehaviour
     public void _OnLoadButtonClicked()
     {
         VRCUrl url = urlInputField.GetUrl();
-        VRCStringDownloader.LoadUrl(url, (IUdonEventReceiver)this);
+        VRCStringDownloader.LoadUrl(url, this);
     }
 
     public override void OnStringLoadSuccess(IVRCStringDownload result)
@@ -136,7 +149,7 @@ public void _LoadNext()
     _downloader.DownloadImage(
         imageUrls[_currentIndex],
         targetMaterial,
-        (IUdonEventReceiver)this,
+        this,
         new TextureInfo()
     );
     _currentIndex++;
@@ -149,7 +162,7 @@ public void _LoadNext()
 
 public void _FetchScores()
 {
-    VRCStringDownloader.LoadUrl(scoreBoardUrl, (IUdonEventReceiver)this);
+    VRCStringDownloader.LoadUrl(scoreBoardUrl, this);
 }
 // -> The server returns the latest data. No need to change the URL itself.
 ```
@@ -184,6 +197,7 @@ VRCUrl url = new VRCUrl(dynamicUrl); // Compiles but fails at runtime
 
 ```csharp
 using VRC.SDK3.StringLoading;
+using VRC.Udon.Common.Interfaces;
 
 // Static method: Download text from URL
 VRCStringDownloader.LoadUrl(VRCUrl url, IUdonEventReceiver udonBehaviour);
@@ -215,7 +229,6 @@ using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.StringLoading;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class StringDownloadExample : UdonSharpBehaviour
@@ -224,7 +237,7 @@ public class StringDownloadExample : UdonSharpBehaviour
 
     public void _StartDownload()
     {
-        VRCStringDownloader.LoadUrl(dataUrl, (IUdonEventReceiver)this);
+        VRCStringDownloader.LoadUrl(dataUrl, this);
     }
 
     public override void OnStringLoadSuccess(IVRCStringDownload result)
@@ -247,7 +260,8 @@ public class StringDownloadExample : UdonSharpBehaviour
 ### API
 
 ```csharp
-using VRC.SDK3.ImageLoading;
+using VRC.SDK3.Image;
+using VRC.Udon.Common.Interfaces;
 
 // Constructor: Create an instance (reusable)
 VRCImageDownloader imageDownloader = new VRCImageDownloader();
@@ -328,8 +342,7 @@ using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
 using VRC.SDKBase;
-using VRC.SDK3.ImageLoading;
-using VRC.Udon.Common.Interfaces;
+using VRC.SDK3.Image;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class ImageDownloadExample : UdonSharpBehaviour
@@ -361,7 +374,7 @@ public class ImageDownloadExample : UdonSharpBehaviour
         _currentDownload = _downloader.DownloadImage(
             imageUrl,
             targetMaterial,
-            (IUdonEventReceiver)this,
+            this,
             info
         );
     }
@@ -427,7 +440,6 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.SDK3.StringLoading;
 using VRC.SDK3.Data;
-using VRC.Udon.Common.Interfaces;
 
 [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
 public class JsonDownloadExample : UdonSharpBehaviour
@@ -440,7 +452,7 @@ public class JsonDownloadExample : UdonSharpBehaviour
 
     public void _FetchData()
     {
-        VRCStringDownloader.LoadUrl(jsonUrl, (IUdonEventReceiver)this);
+        VRCStringDownloader.LoadUrl(jsonUrl, this);
     }
 
     public override void OnStringLoadSuccess(IVRCStringDownload result)
@@ -511,7 +523,7 @@ private const float RETRY_DELAY = 6.0f; // 5-second limit + margin
 public void _StartDownload()
 {
     _retryCount = 0;
-    VRCStringDownloader.LoadUrl(dataUrl, (IUdonEventReceiver)this);
+    VRCStringDownloader.LoadUrl(dataUrl, this);
 }
 
 public override void OnStringLoadError(IVRCStringDownload result)
@@ -530,7 +542,7 @@ public override void OnStringLoadError(IVRCStringDownload result)
 
 public void _RetryDownload()
 {
-    VRCStringDownloader.LoadUrl(dataUrl, (IUdonEventReceiver)this);
+    VRCStringDownloader.LoadUrl(dataUrl, this);
 }
 ```
 
@@ -560,7 +572,7 @@ public void _DownloadNext()
         OnAllDownloadsComplete();
         return;
     }
-    VRCStringDownloader.LoadUrl(urls[_currentIndex], (IUdonEventReceiver)this);
+    VRCStringDownloader.LoadUrl(urls[_currentIndex], this);
 }
 
 public override void OnStringLoadSuccess(IVRCStringDownload result)
@@ -596,7 +608,7 @@ private void OnAllDownloadsComplete()
 | Image download error | Image exceeds 2048x2048 | Pre-resize the image |
 | Image download error | URL redirects | Use a direct URL (short URLs not supported) |
 | Want to download faster than every 5 seconds | Rate limiting | Not possible. Requests are only queued. Processing order is random |
-| Image events not received in UdonSharp | `udonBehaviour` parameter not specified | Explicitly pass `(IUdonEventReceiver)this` |
+| Image events not received in UdonSharp | Receiver argument omitted | Pass `this` explicitly; the SDK 3.10.4 cast is unnecessary |
 | JSON numbers are not `int` | VRCJson specification | Cast with `(int)token.Double` |
 | Memory usage keeps growing | Old textures not destroyed | Call `Destroy(oldTexture)` before replacing textures; `IVRCImageDownload.Dispose()` only releases the wrapper state |
 | Error inside JSON after successful parse | Lazy parsing specification | Check for false on `TryGetValue` for nested values |

--- a/skills/unity-vrc-udon-sharp/references/web-loading.md
+++ b/skills/unity-vrc-udon-sharp/references/web-loading.md
@@ -6,7 +6,7 @@ Older version numbers in this reference record feature introductions or migratio
 
 Since `System.Net` is unavailable in UdonSharp, VRChat-specific APIs must be used to retrieve data from the web.
 
-### SDK 3.10.4 event receiver arguments
+## SDK 3.10.4 event receiver arguments
 
 On SDK 3.10.4, pass `this` as the receiver argument; the explicit cast is no longer needed.
 The receiver argument is still required for UdonSharp callbacks, including on SDK 3.10.4.

--- a/tests/docs/udon-event-receiver-reference.test.sh
+++ b/tests/docs/udon-event-receiver-reference.test.sh
@@ -68,10 +68,77 @@ def csharp_blocks(path: Path):
             block.append(line)
 
 
+def code_marker_positions(source: str, marker: str):
+    """Yield marker positions outside C# comments and string/char literals."""
+    index = 0
+    state = "code"
+    quote = ""
+    verbatim = False
+    while index < len(source):
+        char = source[index]
+        next_char = source[index + 1] if index + 1 < len(source) else ""
+        if state == "line-comment":
+            if char == "\n":
+                state = "code"
+            index += 1
+            continue
+        if state == "block-comment":
+            if char == "*" and next_char == "/":
+                state = "code"
+                index += 2
+            else:
+                index += 1
+            continue
+        if state == "string":
+            if verbatim:
+                if char == quote:
+                    if next_char == quote:
+                        index += 2
+                    else:
+                        state = "code"
+                        index += 1
+                else:
+                    index += 1
+            elif char == "\\":
+                index += 2
+            elif char == quote:
+                state = "code"
+                index += 1
+            else:
+                index += 1
+            continue
+        if char == "/" and next_char == "/":
+            state = "line-comment"
+            index += 2
+            continue
+        if char == "/" and next_char == "*":
+            state = "block-comment"
+            index += 2
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            verbatim = char == '"' and (
+                (index > 0 and source[index - 1] == "@")
+                or source[max(0, index - 2):index] in {"$@", "@$"}
+            )
+            state = "string"
+            index += 1
+            continue
+        marker_end = index + len(marker)
+        if source.startswith(marker, index) and re.match(
+            r"\s*\(", source[marker_end:]
+        ):
+            yield index
+            index = marker_end
+        else:
+            index += 1
+
+
 def call_arguments(source: str, marker: str):
     """Yield balanced arguments for calls whose expression starts at marker."""
-    for match in re.finditer(re.escape(marker) + r"\s*\(", source):
-        opening = match.end() - 1
+    for marker_start in code_marker_positions(source, marker):
+        marker_end = marker_start + len(marker)
+        opening = marker_end + re.match(r"\s*\(", source[marker_end:]).end() - 1
         depth = 0
         quote = None
         escaped = False
@@ -102,9 +169,7 @@ def call_arguments(source: str, marker: str):
             elif char == ")":
                 depth -= 1
                 if depth == 0:
-                    tail = source[index + 1:]
-                    if re.match(r"\s*;", tail):
-                        yield source[opening + 1:index]
+                    yield source[opening + 1:index]
                     break
 
 active_files = [
@@ -126,9 +191,10 @@ if active_casts:
 
 migration_text = migration.read_text(encoding="utf-8")
 migration_casts = re.findall(r"\(\s*IUdonEventReceiver\s*\)\s*this", migration_text)
-if not migration_casts:
+if len(migration_casts) != 1:
     raise SystemExit(
-        "expected at least one historical IUdonEventReceiver cast in sdk-migration.md"
+        "expected exactly one historical IUdonEventReceiver cast in sdk-migration.md; "
+        f"found {len(migration_casts)}"
     )
 
 # Calls in active C# examples must pass the receiver explicitly. API
@@ -136,13 +202,16 @@ if not migration_casts:
 missing_receivers = []
 for path in active_files:
     for start, block in csharp_blocks(path):
-        for marker in ("VRCStringDownloader.LoadUrl", "DownloadImage"):
+        for marker in (
+            "VRCStringDownloader.LoadUrl",
+            "DownloadImage",
+            "NetworkCalling.GetQueuedEvents",
+        ):
             for args in call_arguments(block, marker):
-                if re.search(r"\bIUdonEventReceiver\b", args):
-                    continue
-                if re.search(r"\bVRCUrl\s+url\b", args):
-                    continue
                 args_without_comments = re.sub(r"//.*?(?=\n|$)", "", args)
+                first_argument = args_without_comments.split(",", 1)[0].strip()
+                if re.match(r"(?:IUdonEventReceiver|VRCUrl)\s+\w+\b", first_argument):
+                    continue
                 if not re.search(r"(?:^|,)\s*this\s*(?:,|$)", args_without_comments):
                     missing_receivers.append(f"{path}:{start}: {marker}({args.strip()})")
         # If a block no longer refers to the interface or NetworkEventTarget,
@@ -153,7 +222,10 @@ for path in active_files:
                     f"unused VRC.Udon.Common.Interfaces import in {path}:{start}"
                 )
 if missing_receivers:
-    raise SystemExit("receiver argument omitted in active examples:\n" + "\n".join(missing_receivers))
+    raise SystemExit(
+        "receiver argument missing or not direct this in active examples:\n"
+        + "\n".join(missing_receivers)
+    )
 
 print("PASS: active receiver examples use direct this with an explicit receiver argument")
 print("PASS: historical casts remain isolated to sdk-migration.md")

--- a/tests/docs/udon-event-receiver-reference.test.sh
+++ b/tests/docs/udon-event-receiver-reference.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL_DIR="$ROOT_DIR/skills/unity-vrc-udon-sharp"
+MIGRATION="$SKILL_DIR/references/sdk-migration.md"
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+require_text() {
+    local path="$1"
+    local expected="$2"
+    grep -Fqx -- "$expected" "$path" \
+        || fail "$path is missing exact contract text: $expected"
+}
+
+require_text "$SKILL_DIR/references/web-loading.md" \
+    'On SDK 3.10.4, pass `this` as the receiver argument; the explicit cast is no longer needed.'
+require_text "$SKILL_DIR/references/web-loading.md" \
+    'The receiver argument is still required for UdonSharp callbacks, including on SDK 3.10.4.'
+require_text "$SKILL_DIR/references/web-loading.md" \
+    'VRCStringDownloader.LoadUrl(dataUrl, this);'
+require_text "$SKILL_DIR/references/web-loading.md" \
+    'downloader.DownloadImage(imageUrl, material, this);'
+if grep -RFn --include='*.md' -- 'VRC.SDK3.ImageLoading' "$SKILL_DIR" >/dev/null; then
+    fail "$SKILL_DIR still teaches the removed VRC.SDK3.ImageLoading namespace"
+fi
+require_text "$SKILL_DIR/references/web-loading.md" \
+    '| `VRCImageDownloader` | Image download (Texture2D) | `VRC.SDK3.Image` |'
+require_text "$SKILL_DIR/references/sdk-migration.md" \
+    'The cast below is historical migration syntax for SDK 3.10.3 and earlier; do not copy it into an active 3.10.4 example.'
+require_text "$SKILL_DIR/SKILL.md" \
+    'SDK 3.10.4: `UdonSharpBehaviour` implements `IUdonEventReceiver` directly.'
+grep -Fq -- 'https://creators.vrchat.com/releases/release-3-10-4/' "$SKILL_DIR/SKILL.md" \
+    || fail "$SKILL_DIR/SKILL.md is missing the official SDK 3.10.4 release-note link"
+
+python3 - "$SKILL_DIR" "$MIGRATION" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+skill_dir = Path(sys.argv[1])
+migration = Path(sys.argv[2]).resolve()
+
+
+def csharp_blocks(path: Path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    in_block = False
+    language = ""
+    block = []
+    start = 0
+    for number, line in enumerate(lines, 1):
+        if line.startswith("```"):
+            if not in_block:
+                in_block = True
+                language = line[3:].strip().lower()
+                block = []
+                start = number + 1
+            else:
+                if language in {"csharp", "cs"}:
+                    yield start, "\n".join(block)
+                in_block = False
+                language = ""
+        elif in_block:
+            block.append(line)
+
+
+def call_arguments(source: str, marker: str):
+    """Yield balanced arguments for calls whose expression starts at marker."""
+    for match in re.finditer(re.escape(marker) + r"\s*\(", source):
+        opening = match.end() - 1
+        depth = 0
+        quote = None
+        escaped = False
+        line_comment = False
+        for index in range(opening, len(source)):
+            char = source[index]
+            next_char = source[index + 1] if index + 1 < len(source) else ""
+            if line_comment:
+                if char == "\n":
+                    line_comment = False
+                continue
+            if quote:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                continue
+            if char == "/" and next_char == "/":
+                line_comment = True
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                continue
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    tail = source[index + 1:]
+                    if re.match(r"\s*;", tail):
+                        yield source[opening + 1:index]
+                    break
+
+active_files = [
+    path for path in skill_dir.rglob("*.md")
+    if path.resolve() != migration
+]
+
+# A cast is a historical migration aid only. Active guidance must use the
+# direct SDK 3.10.4 receiver form.
+active_casts = []
+cast_pattern = re.compile(r"\(\s*IUdonEventReceiver\s*\)\s*this")
+for path in active_files:
+    text = path.read_text(encoding="utf-8")
+    for match in cast_pattern.finditer(text):
+        line_number = text.count("\n", 0, match.start()) + 1
+        active_casts.append(f"{path}:{line_number}: {match.group(0)}")
+if active_casts:
+    raise SystemExit("active IUdonEventReceiver casts found:\n" + "\n".join(active_casts))
+
+migration_text = migration.read_text(encoding="utf-8")
+migration_casts = re.findall(r"\(\s*IUdonEventReceiver\s*\)\s*this", migration_text)
+if not migration_casts:
+    raise SystemExit(
+        "expected at least one historical IUdonEventReceiver cast in sdk-migration.md"
+    )
+
+# Calls in active C# examples must pass the receiver explicitly. API
+# declarations are skipped by their typed first argument / receiver type.
+missing_receivers = []
+for path in active_files:
+    for start, block in csharp_blocks(path):
+        for marker in ("VRCStringDownloader.LoadUrl", "DownloadImage"):
+            for args in call_arguments(block, marker):
+                if re.search(r"\bIUdonEventReceiver\b", args):
+                    continue
+                if re.search(r"\bVRCUrl\s+url\b", args):
+                    continue
+                args_without_comments = re.sub(r"//.*?(?=\n|$)", "", args)
+                if not re.search(r"(?:^|,)\s*this\s*(?:,|$)", args_without_comments):
+                    missing_receivers.append(f"{path}:{start}: {marker}({args.strip()})")
+        # If a block no longer refers to the interface or NetworkEventTarget,
+        # the namespace import is dead and should not be taught to users.
+        if "using VRC.Udon.Common.Interfaces;" in block:
+            if not re.search(r"\bIUdonEventReceiver\b|\bNetworkEventTarget\b", block):
+                raise SystemExit(
+                    f"unused VRC.Udon.Common.Interfaces import in {path}:{start}"
+                )
+if missing_receivers:
+    raise SystemExit("receiver argument omitted in active examples:\n" + "\n".join(missing_receivers))
+
+print("PASS: active receiver examples use direct this with an explicit receiver argument")
+print("PASS: historical casts remain isolated to sdk-migration.md")
+print("PASS: unused IUdonEventReceiver namespace imports are absent from active blocks")
+PY


### PR DESCRIPTION
## Summary

- Update active UdonSharp examples for SDK 3.10.4 so `UdonSharpBehaviour` is passed directly as `this` while the required receiver argument remains present.
- Keep the pre-3.10.4 cast in the historical migration reference only, and add a documentation smoke test covering the active examples, receiver arguments, namespace imports, and migration boundary.
- Correct the active image-loading namespace to `VRC.SDK3.Image`, based on the SDK 3.10.4 source and wrapper API.

## Validation

- All documentation smoke tests
- Bash syntax checks for repository shell scripts
- `validate-udonsharp` shell and BusyBox smoke tests
- Changed Markdown C# blocks through `validate-udonsharp.sh`
- `git diff --check`
- Symlink check
- `npm pack --dry-run`
- Version consistency check

## Unity verification

The first two local attempts were not successful and remain part of the diagnostic history: the WSL/UNC project was rejected because Unity does not support the case-sensitive filesystem (exit 21), and the first Windows-local probe used the obsolete `VRC.SDK3.ImageLoading` / `IVRCImageDownload` names (exit 1). No third run was made from this worktree after that stop condition.

A separate Windows-local verification was completed by the parent workflow after correcting the fixture and rebuilding the copied project. Unity 2022.3.22f1 with SDK 3.10.4 completed the Tundra build and UdonSharp compilation of three fixtures, reported `ISSUE342_PASS`, and confirmed direct `this` for String, Image, and `NetworkCalling` receiver calls. The result also confirmed `UdonSharpBehaviour` implements `IUdonEventReceiver` and the image API is `VRC.SDK3.Image.VRCImageDownloader`; source and execution copies matched by hash.

The same invocation initially reported a stale Bee input referencing unrelated removed Issue #338 utility scripts (`CS2001`). An additional Tundra rebuild followed, and only the subsequent successful build/compile/result is counted as verification. Compilation verification covers the three targeted fixtures; it does not claim runtime execution or unrelated scripts.

Closes #342
