### PR TITLE
docs(udon-sharp): document synced array callback behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Check VRCUrl.Empty field initializer boundary
         run: bash tests/docs/vrcurl-empty-initializer-reference.test.sh
 
+      - name: Check synced array callback and VRCUrl[] guidance
+        run: bash tests/docs/synced-array-callback-reference.test.sh
+
   markdown:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/skills/unity-vrc-udon-sharp/CHEATSHEET.md
+++ b/skills/unity-vrc-udon-sharp/CHEATSHEET.md
@@ -103,6 +103,13 @@ public void SetValue(int newValue) {
 }
 ```
 
+The property pattern above is for scalar values. **Synced arrays: always apply
+them from `OnDeserialization()`**. This covers same-length element changes,
+array reassignments, and array length changes; do not attach
+`FieldChangeCallback` to an array and wait for its setter. The owner should call
+the same idempotent `ApplyValues()` method immediately after the mutation, then
+call `RequestSerialization()` once for the completed update.
+
 ---
 
 ## Key Events
@@ -427,6 +434,7 @@ private void Log(string msg) {
 | NullReference on player | Check `player != null && player.IsValid()` |
 | Method not found (SendCustomEvent / network event target) | Make the target method public and parameterless (pass data via `SetProgramVariable`); plain network events are also parameterless ([NetworkCallable] allows up to 8) |
 | FieldChangeCallback not firing | Use property setter even for local changes |
+| Array contents changed: use `OnDeserialization()` | Rebuild derived state from the complete array snapshot; do not depend on `FieldChangeCallback` |
 | Cannot modify struct | `var v = struct; v.x = 1; struct = v;` |
 | Start() not called | Inactive object support: `OnEnable()` + `Initialize()` |
 

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -55,6 +55,12 @@ compiler constraints, use `unity-vrc-world-sdk-3` and read
 4. **Sync Minimization** — Every synced variable costs bandwidth (see data budget in `udonsharp-sync-selection.md`). Derive what you can locally; sync only the source of truth.
 5. **Event-Driven, Not Polling** — Use `OnDeserialization`, `[FieldChangeCallback]`, and `SendCustomEvent` instead of checking state in `Update()` **for state-change reactions; for hot-path or periodic work, see [Event Dispatch & Cross-Behaviour Call Cost Tiers](references/patterns-performance.md#event-dispatch--cross-behaviour-call-cost-tiers)**.
 
+**Synced arrays: always apply them from `OnDeserialization()`**. Array element
+changes do not provide a reliable `FieldChangeCallback` signal, and the same
+guidance applies to same-length changes, array reassignments, and length
+changes. Have the owner call the same idempotent apply method immediately after
+mutation, then request Manual serialization once.
+
 ## SDK 3.10.4 event receiver arguments
 
 SDK 3.10.4 is the active and verified target for this Skill.

--- a/skills/unity-vrc-udon-sharp/references/constraints.md
+++ b/skills/unity-vrc-udon-sharp/references/constraints.md
@@ -825,18 +825,19 @@ and assignments that only need an empty sentinel may still use `VRCUrl.Empty`.
 ### Synced VRCUrl Lists
 
 `VRCUrl[]` syncs like any other supported array type. VRChat 2021.3.2's release notes state
-"Udon can now sync `String` arrays and `VRCUrl` arrays", and `VRCUrl[]` is present in the SDK's
-syncable-type list (`UdonNetworkTypes.CanSync`, verified against SDK 3.10.3). Use Manual sync
-(Continuous does not support arrays) and always initialize the field -- an uninitialized synced
-array prevents the behaviour from syncing.
+"Udon can now sync `String` arrays and `VRCUrl` arrays", and `VRCUrl[]` is present in the SDK 3.10.4
+syncable-type list (`UdonNetworkTypes.CanSync`). Use Manual sync (Continuous does not support
+arrays) and always initialize the field -- an uninitialized synced array prevents the behaviour
+from syncing.
 
 ```csharp
 [UdonSynced] private VRCUrl[] _urls = new VRCUrl[0]; // Manual sync behaviour
 ```
 
-The example below uses individual fixed slots instead of an array -- a bounded-capacity variant
-that makes the maximum list size explicit. The JSON metadata pattern (sender name, timestamp,
-content type via `VRCJson`) applies equally to either layout.
+The example below uses individual fixed slots instead of an array -- a bounded-capacity variant.
+Fixed slots bound capacity and make the maximum list size explicit; they are a design choice for
+predictable limits, not a workaround for unsupported array sync. The JSON metadata pattern (sender
+name, timestamp, content type via `VRCJson`) applies equally to either layout.
 
 **Complete Example -- Fixed-Slot Synced URL List with Metadata:**
 
@@ -1090,7 +1091,7 @@ public class SyncedUrlList : UdonSharpBehaviour
 
 | Element | Purpose |
 |---------|---------|
-| Individual `[UdonSynced] VRCUrl` fields | Each URL synced as its own field (array sync not supported) |
+| Individual `[UdonSynced] VRCUrl` fields | Fixed-slot, bounded-capacity alternative when the maximum list size should be explicit; `VRCUrl[]` remains syncable |
 | `switch`-based get/set methods | Maps runtime index to the correct field |
 | `[UdonSynced] string` for metadata | JSON-encoded array of `[timestamp, type, sender]` entries |
 | `VRCJson.TrySerializeToJson` / `TryDeserializeFromJson` | Serialization of structured metadata into a single synced string |

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -684,7 +684,7 @@ public void _IncrementScore()
 
 ### Detecting Changes
 
-Use `OnDeserialization` or `FieldChangeCallback`:
+For scalar synced values, use `OnDeserialization` or `FieldChangeCallback`:
 
 ```csharp
 // Method 1: OnDeserialization
@@ -715,6 +715,86 @@ private void OnHealthChanged()
     healthBar.value = _health;
 }
 ```
+
+### Synced Arrays: Apply Them After Deserialization
+
+`FieldChangeCallback` is useful for scalar synced fields, but it is not a
+receiver contract for arrays. The official [`OnVariableChanged` guidance](https://creators.vrchat.com/worlds/udon/networking/network-components/#onvariablechanged)
+states that changing an array's contents does not trigger the event because the
+array itself is unchanged. The official [Udon Example Scene](https://creators.vrchat.com/worlds/examples/udon-example-scene/)
+uses `OnDeserialization()` for its array example for the same reason.
+
+Do not depend on `FieldChangeCallback` for same-length element changes, array reassignments, or array length changes. Reassignment and length changes are not special exceptions to this guidance; use one receiver path for every synced array shape. The owner applies the same idempotent method immediately after the mutation, and remote clients apply it from `OnDeserialization()` after the serialized snapshot is complete. For Manual sync, make all element writes (or a single array reassignment) first, then make one `RequestSerialization()` after the complete array update.
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+public class SyncedArrayReceiver : UdonSharpBehaviour
+{
+    [UdonSynced] private int[] _syncedValues = new int[4];
+
+    public void _SetValues(int[] values)
+    {
+        if (!Networking.IsOwner(gameObject))
+            Networking.SetOwner(Networking.LocalPlayer, gameObject);
+
+        _syncedValues = values;
+        ApplyValues();
+        RequestSerialization();
+    }
+
+    public override void OnDeserialization()
+    {
+        ApplyValues();
+    }
+
+    private void ApplyValues()
+    {
+        if (_syncedValues == null) return;
+
+        // Idempotent projection: derive the local display from the snapshot.
+        UpdateDisplay(_syncedValues);
+    }
+
+    private void UpdateDisplay(int[] values)
+    {
+        // Update UI or other derived state from values.
+    }
+}
+```
+
+The basic pattern intentionally has no revision counter: `ApplyValues()` is
+safe to run again for the same state. Add a revision only when the apply step
+has a non-idempotent side effect, such as playing a sound or writing a one-time
+record. A revision does not establish ordering or stale-packet rejection; it is
+only a duplicate-side-effect guard shared by the owner and `OnDeserialization`
+paths.
+
+```csharp
+// Optional guard for a non-idempotent effect; keep the basic path revision-free.
+[SerializeField] private AudioSource _sound;
+[UdonSynced] private int _revision;
+private int _appliedRevision;
+private bool _hasAppliedRevision;
+
+private void ApplyOneShotIfNeeded()
+{
+    if (_hasAppliedRevision && _appliedRevision == _revision) return;
+
+    _hasAppliedRevision = true;
+    _appliedRevision = _revision;
+    if (_sound != null) _sound.Play();
+}
+```
+
+Increment `_revision` with the array mutation, then call
+`ApplyOneShotIfNeeded()` immediately on the owner and again from
+`OnDeserialization()` on receivers. Use this only for the non-idempotent effect;
+keep ordinary UI or derived-state updates on the revision-free `ApplyValues()`
+path above.
 
 ## Network Events
 

--- a/skills/unity-vrc-udon-sharp/references/networking.md
+++ b/skills/unity-vrc-udon-sharp/references/networking.md
@@ -738,6 +738,8 @@ public class SyncedArrayReceiver : UdonSharpBehaviour
 
     public void _SetValues(int[] values)
     {
+        if (values == null) return;
+
         if (!Networking.IsOwner(gameObject))
             Networking.SetOwner(Networking.LocalPlayer, gameObject);
 

--- a/skills/unity-vrc-udon-sharp/references/patterns-networking.md
+++ b/skills/unity-vrc-udon-sharp/references/patterns-networking.md
@@ -816,7 +816,10 @@ public class DebouncedSearch : UdonSharpBehaviour
 
 ### Problem
 
-Syncing `string[]` via `[UdonSynced]` serialises each element individually with per-element overhead. For arrays that change together as a logical unit — playlist titles, display names, ordered slot labels — this wastes bandwidth and produces multiple `OnDeserialization` callbacks if the array is written element-by-element in a loop.
+For arrays that change together as a logical unit — playlist titles, display
+names, ordered slot labels — build the complete value first and serialize the
+batch once. Write every element (or build the joined string), then make one `RequestSerialization()` after all elements are updated. OnDeserialization runs after the serialized snapshot is applied, so it is not a per-element
+callback and should rebuild the local projection from that complete snapshot.
 
 ### Solution
 
@@ -916,7 +919,7 @@ public class SyncedPlaylist : UdonSharpBehaviour
     // ── Owner-side write ──────────────────────────────────────────────────
 
     /// <summary>
-    /// Sets the playlist titles (owner only) and serializes.
+    /// Sets the playlist titles (owner only) and serializes once.
     /// </summary>
     public void SetTitles(string[] titles)
     {
@@ -924,6 +927,8 @@ public class SyncedPlaylist : UdonSharpBehaviour
 
         _titles       = titles ?? new string[0];
         _syncedTitles = JoinForSync(_titles);
+        OnPlaylistUpdated();
+        // One request covers the complete batch; do not request inside a loop.
         RequestSerialization();
     }
 

--- a/skills/unity-vrc-udon-sharp/references/sync-examples.md
+++ b/skills/unity-vrc-udon-sharp/references/sync-examples.md
@@ -345,8 +345,8 @@ public class VoteSystemCore : UdonSharpBehaviour
         SyncedVoterPlayerIds[SyncedVoterCount] = caller.playerId;
         SyncedVoterCount++;
         ++SyncedYesCount;
-        RequestSerialization();
         RefreshCount();
+        RequestSerialization();
     }
 
     public override void OnDeserialization()

--- a/skills/unity-vrc-udon-sharp/references/sync-examples.md
+++ b/skills/unity-vrc-udon-sharp/references/sync-examples.md
@@ -372,6 +372,22 @@ array when the world capacity is lower.
 
 ---
 
+### Array values: use OnDeserialization, not FieldChangeCallback
+
+`FieldChangeCallback` is appropriate for the scalar counters below, but do not
+use it as the receive hook for a `[UdonSynced]` array. Array contents can change
+without the array variable itself changing, so the callback is not a contract
+for same length, reassigning the array, or changing its length. Apply the array
+from `OnDeserialization()` instead. The owner should call the same idempotent
+apply method immediately after its mutation and then call
+`RequestSerialization()` once for the completed update.
+
+The fixed `SyncedVoterPlayerIds` array in Pattern 3c follows this rule: the
+owner updates the accepted snapshot and `RefreshCount()` locally, while every
+receiver calls `RefreshCount()` from `OnDeserialization()`.
+
+---
+
 ## Pattern 4: Managing Multiple Values with FieldChangeCallback
 
 ```csharp
@@ -421,7 +437,7 @@ public class DualCounterSync : UdonSharpBehaviour
 | Approach | Pros | Cons |
 |------|------|------|
 | `OnDeserialization()` | Simple, full update | Cannot tell which variable changed |
-| `FieldChangeCallback` | Detects individual variable changes | Requires property definitions |
+| `FieldChangeCallback` | Detects individual scalar variable changes | Requires property definitions; not a synced-array receive hook |
 
 **When to use**: 1-2 variables -> OnDeserialization is sufficient. 3+ variables needing individual responses -> FieldChangeCallback.
 

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -454,6 +454,51 @@ MyProperty = 10;
 
 ---
 
+### Synced Array Callback Silent Failure
+
+**Symptom:** A remote client receives a new `[UdonSynced]` array, but the
+property setter and its `FieldChangeCallback` side effects do not run.
+
+`OnVariableChanged` does not fire for array-content changes. Do not rely on it
+for same-length element changes, array reassignments, and array length changes;
+the safe receive hook is `OnDeserialization()` for all three cases. This is a
+silent failure: the array can contain the new values while local UI or other
+derived state still shows the old projection.
+
+Use one idempotent `ApplyValues()` method on both paths:
+
+```csharp
+[UdonSynced] private int[] _syncedValues = new int[4];
+
+public void _SetValues(int[] values)
+{
+    if (!Networking.IsOwner(gameObject))
+        Networking.SetOwner(Networking.LocalPlayer, gameObject);
+
+    _syncedValues = values;
+    ApplyValues();
+    RequestSerialization();
+}
+
+public override void OnDeserialization()
+{
+    ApplyValues();
+}
+
+private void ApplyValues()
+{
+    if (_syncedValues == null) return;
+    // Rebuild UI or other derived state from the current snapshot.
+}
+```
+
+The owner calls `ApplyValues()` immediately after changing the array and calls
+`RequestSerialization()` once after the complete Manual-sync update. A revision
+guard is optional for non-idempotent effects only; it does not provide packet
+ordering or stale-packet rejection.
+
+---
+
 ### Ownership Transfer Race Conditions
 
 **Problem:** Multiple players attempting to take ownership simultaneously.

--- a/skills/unity-vrc-udon-sharp/references/troubleshooting.md
+++ b/skills/unity-vrc-udon-sharp/references/troubleshooting.md
@@ -472,6 +472,8 @@ Use one idempotent `ApplyValues()` method on both paths:
 
 public void _SetValues(int[] values)
 {
+    if (values == null) return;
+
     if (!Networking.IsOwner(gameObject))
         Networking.SetOwner(Networking.LocalPlayer, gameObject);
 

--- a/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
+++ b/skills/unity-vrc-udon-sharp/rules/udonsharp-networking.md
@@ -180,6 +180,64 @@ private void OnHealthChanged()
 }
 ```
 
+### Synced Arrays: OnDeserialization Is the Receiver Hook
+
+`OnVariableChanged` does not fire when an array's contents change because the array
+itself is still the same variable. Therefore, a `[UdonSynced]` array must not depend on `FieldChangeCallback` for its receive-side update. Do not make any of these mutation shapes an exception:
+
+- same-length element changes
+- array reassignments
+- array length changes
+
+Use `OnDeserialization()` for all three cases. The owner applies the same idempotent `ApplyValues()` method immediately after changing the array, then
+calls `RequestSerialization()` once after the complete update. Remote clients
+call that method from `OnDeserialization()` after the received snapshot has been
+applied. This keeps the owner and receivers on the same state-projection path
+without relying on a callback that is not an array contract.
+
+```csharp
+using UdonSharp;
+using UnityEngine;
+using UnityEngine.UI;
+using VRC.SDKBase;
+
+[UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
+public class SyncedArrayExample : UdonSharpBehaviour
+{
+    [SerializeField] private Text _valueText;
+    [UdonSynced] private int[] _syncedValues = new int[4];
+
+    public override void Interact()
+    {
+        if (!Networking.IsOwner(gameObject))
+            Networking.SetOwner(Networking.LocalPlayer, gameObject);
+
+        for (int i = 0; i < _syncedValues.Length; i++)
+            _syncedValues[i] = Random.Range(0, 100);
+
+        // Apply locally now; the owner does not wait for its own sync callback.
+        ApplyValues();
+        RequestSerialization();
+    }
+
+    public override void OnDeserialization()
+    {
+        ApplyValues();
+    }
+
+    private void ApplyValues()
+    {
+        if (_syncedValues == null || _syncedValues.Length == 0) return;
+
+        // Idempotent state projection: redraw from the current array snapshot.
+        if (_valueText != null) _valueText.text = _syncedValues[0].ToString();
+    }
+}
+```
+
+Keep `ApplyValues()` idempotent when possible. A revision is only an optional guard for non-idempotent side effects such as a sound, animation, or one-time record that must not run twice when the owner and receiver paths both visit the same revision. It does not provide ordering or stale-packet rejection;
+it is only a duplicate-side-effect guard.
+
 ## Key Principles
 
 1. **"The trick to syncing is not to sync"**: Sync only the minimum data and leverage local computation

--- a/tests/docs/synced-array-callback-reference.test.sh
+++ b/tests/docs/synced-array-callback-reference.test.sh
@@ -222,8 +222,8 @@ assert_order(
     "SyncedVoterPlayerIds[SyncedVoterCount] = caller.playerId;",
     "SyncedVoterCount++;",
     "++SyncedYesCount;",
-    "RequestSerialization();",
     "RefreshCount();",
+    "RequestSerialization();",
 )
 vote_receiver = method_block(vote, "public override void OnDeserialization()")
 if "RefreshCount();" not in vote_receiver:

--- a/tests/docs/synced-array-callback-reference.test.sh
+++ b/tests/docs/synced-array-callback-reference.test.sh
@@ -279,6 +279,9 @@ for path in skill_root.rglob("*.md"):
     for block in csharp_blocks(path):
         if forbidden_array_declarations(block):
             fail(f"FieldChangeCallback is attached to a synced array declaration in {path}")
+for path in skill_root.rglob("*.cs"):
+    if forbidden_array_declarations(path.read_text()):
+        fail(f"FieldChangeCallback is attached to a synced array declaration in {path}")
 
 print("PASS: canonical, vote, playlist, null-guard, and multiline-array structural contracts")
 PY

--- a/tests/docs/synced-array-callback-reference.test.sh
+++ b/tests/docs/synced-array-callback-reference.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UDON_DIR="$ROOT_DIR/skills/unity-vrc-udon-sharp"
+RULES="$UDON_DIR/rules/udonsharp-networking.md"
+NETWORKING="$UDON_DIR/references/networking.md"
+SYNC_EXAMPLES="$UDON_DIR/references/sync-examples.md"
+TROUBLESHOOTING="$UDON_DIR/references/troubleshooting.md"
+CHEATSHEET="$UDON_DIR/CHEATSHEET.md"
+SKILL="$UDON_DIR/SKILL.md"
+CONSTRAINTS="$UDON_DIR/references/constraints.md"
+PATTERNS="$UDON_DIR/references/patterns-networking.md"
+
+require_text() {
+    local path="$1"
+    local needle="$2"
+    if ! grep -Fq -- "$needle" "$path"; then
+        echo "ERROR: $path does not contain expected text: $needle" >&2
+        exit 1
+    fi
+}
+
+forbid_text() {
+    local path="$1"
+    local needle="$2"
+    local recursive=()
+    if [ -d "$path" ]; then
+        recursive=(-R)
+    fi
+    if grep "${recursive[@]}" -Fq -- "$needle" "$path"; then
+        echo "ERROR: $path contains obsolete text: $needle" >&2
+        exit 1
+    fi
+}
+
+# Keep one canonical, idempotent array-receiver contract in the always-loaded
+# rules. The three mutation shapes are intentionally listed separately so a
+# future edit cannot make only length changes sound exceptional.
+require_text "$RULES" '### Synced Arrays: OnDeserialization Is the Receiver Hook'
+require_text "$RULES" 'same-length element changes'
+require_text "$RULES" 'array reassignments'
+require_text "$RULES" 'array length changes'
+require_text "$RULES" 'must not depend on `FieldChangeCallback`'
+require_text "$RULES" 'the same idempotent `ApplyValues()` method'
+require_text "$RULES" '[UdonSynced] private int[] _syncedValues = new int[4];'
+require_text "$RULES" 'public override void OnDeserialization()'
+require_text "$RULES" 'RequestSerialization();'
+require_text "$RULES" 'revision is only an optional guard for non-idempotent side effects'
+require_text "$RULES" 'does not provide ordering or stale-packet rejection'
+
+# The detailed reference must point to the two official examples and preserve
+# the owner-immediate/remote-deserialization split.
+require_text "$NETWORKING" 'https://creators.vrchat.com/worlds/udon/networking/network-components/#onvariablechanged'
+require_text "$NETWORKING" 'https://creators.vrchat.com/worlds/examples/udon-example-scene/'
+require_text "$NETWORKING" 'same-length element changes'
+require_text "$NETWORKING" 'array reassignments'
+require_text "$NETWORKING" 'array length changes'
+require_text "$NETWORKING" 'owner applies the same idempotent method immediately'
+require_text "$NETWORKING" 'remote clients apply it from `OnDeserialization()`'
+require_text "$NETWORKING" 'one `RequestSerialization()` after the complete array update'
+require_text "$NETWORKING" 'revision does not establish ordering'
+require_text "$NETWORKING" '[UdonSynced] private int _revision;'
+require_text "$NETWORKING" 'ApplyOneShotIfNeeded()'
+
+# Every user-facing surface should route array reactions through
+# OnDeserialization, while keeping scalar FieldChangeCallback guidance intact.
+require_text "$SYNC_EXAMPLES" 'Array values: use OnDeserialization, not FieldChangeCallback'
+require_text "$SYNC_EXAMPLES" 'same length, reassigning the array, or changing its length'
+require_text "$TROUBLESHOOTING" '### Synced Array Callback Silent Failure'
+require_text "$TROUBLESHOOTING" 'same-length element changes, array reassignments, and array length changes'
+require_text "$TROUBLESHOOTING" 'ApplyValues()'
+require_text "$CHEATSHEET" 'Array contents changed: use `OnDeserialization()`'
+require_text "$SKILL" 'Synced arrays: always apply them from `OnDeserialization()`'
+
+# VRCUrl[] is a supported sync type. The old workaround wording must not
+# return in any distributed UdonSharp document.
+require_text "$CONSTRAINTS" '`VRCUrl[]` syncs like any other supported array type.'
+require_text "$CONSTRAINTS" 'Fixed slots bound capacity and make the maximum list size explicit'
+forbid_text "$CONSTRAINTS" '(array sync not supported)'
+forbid_text "$UDON_DIR" 'array sync not supported'
+
+# A single Manual request is made after a batch update; element-by-element
+# writes do not imply multiple deserialization callbacks.
+require_text "$PATTERNS" 'one `RequestSerialization()` after all elements are updated'
+require_text "$PATTERNS" 'OnDeserialization runs after the serialized snapshot is applied'
+forbid_text "$PATTERNS" 'produces multiple `OnDeserialization` callbacks'
+
+# Never reintroduce FieldChangeCallback on a synced array declaration while
+# scalar callback examples remain allowed.
+if grep -RInE '\[UdonSynced[^]]*FieldChangeCallback[^]]*\][[:space:]]*[^\n;]*\[\]' "$UDON_DIR" \
+    --include='*.md' --include='*.cs'; then
+    echo 'ERROR: FieldChangeCallback is attached to a synced array declaration' >&2
+    exit 1
+fi
+
+# Regression-check the existing contributor census and all five README copies;
+# this Issue is already represented there and should not cause doc churn.
+bash "$ROOT_DIR/tests/docs/community-contributors.test.sh"
+
+echo 'PASS: synced array callback and VRCUrl[] reference contract'

--- a/tests/docs/synced-array-callback-reference.test.sh
+++ b/tests/docs/synced-array-callback-reference.test.sh
@@ -86,13 +86,202 @@ require_text "$PATTERNS" 'one `RequestSerialization()` after all elements are up
 require_text "$PATTERNS" 'OnDeserialization runs after the serialized snapshot is applied'
 forbid_text "$PATTERNS" 'produces multiple `OnDeserialization` callbacks'
 
-# Never reintroduce FieldChangeCallback on a synced array declaration while
-# scalar callback examples remain allowed.
-if grep -RInE '\[UdonSynced[^]]*FieldChangeCallback[^]]*\][[:space:]]*[^\n;]*\[\]' "$UDON_DIR" \
-    --include='*.md' --include='*.cs'; then
-    echo 'ERROR: FieldChangeCallback is attached to a synced array declaration' >&2
-    exit 1
-fi
+# Check the executable shape of the canonical example and the two existing
+# array examples. Presence checks alone cannot detect a callback deleted from
+# a receiver, an owner apply deleted before serialization, or a request moved
+# into the element-update loop.
+python3 - "$RULES" "$NETWORKING" "$SYNC_EXAMPLES" "$PATTERNS" "$TROUBLESHOOTING" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: structural contract: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def csharp_blocks(path: Path) -> list[str]:
+    return re.findall(r"```csharp\s*\n(.*?)```", path.read_text(), re.S)
+
+
+def class_block(path: Path, class_name: str) -> str:
+    for block in csharp_blocks(path):
+        if f"class {class_name}" in block:
+            return block
+    fail(f"class {class_name} not found in {path}")
+
+
+def method_block(source: str, signature: str) -> str:
+    start = source.find(signature)
+    if start < 0:
+        fail(f"method {signature} not found")
+    brace = source.find("{", start)
+    if brace < 0:
+        fail(f"method {signature} has no body")
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    fail(f"method {signature} has an unterminated body")
+
+
+def balanced_block(source: str, opening: int) -> str:
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening : index + 1]
+    fail("unterminated nested block")
+
+
+def assert_order(label: str, source: str, *needles: str) -> None:
+    positions = []
+    for needle in needles:
+        position = source.find(needle)
+        if position < 0:
+            fail(f"{label} is missing {needle!r}")
+        positions.append(position)
+    if positions != sorted(positions):
+        fail(f"{label} is not ordered as {needles!r}")
+
+
+rules = Path(sys.argv[1])
+networking = Path(sys.argv[2])
+sync_examples = Path(sys.argv[3])
+patterns = Path(sys.argv[4])
+troubleshooting = Path(sys.argv[5])
+
+canonical = class_block(rules, "SyncedArrayExample")
+canonical_owner = method_block(canonical, "public override void Interact()")
+loop_start = re.search(r"\bfor\s*\([^{}\n]*?\)[ \t]*", canonical_owner)
+if not loop_start:
+    fail("canonical owner has no element update loop")
+loop_body_start = loop_start.end()
+while loop_body_start < len(canonical_owner) and canonical_owner[loop_body_start].isspace():
+    loop_body_start += 1
+if canonical_owner.startswith("{", loop_body_start):
+    loop = balanced_block(canonical_owner, loop_body_start)
+    loop_end = loop_body_start + len(loop)
+else:
+    newline = canonical_owner.find("\n", loop_body_start)
+    if newline < 0:
+        fail("canonical owner loop has no body line")
+    loop = canonical_owner[loop_body_start:newline]
+    loop_end = newline
+if "_syncedValues[i] =" not in loop:
+    fail("canonical owner loop does not update every element")
+if "RequestSerialization();" in loop:
+    fail("canonical owner requests serialization inside the element loop")
+assert_order(
+    "canonical owner",
+    canonical_owner[loop_end:],
+    "ApplyValues();",
+    "RequestSerialization();",
+)
+if canonical_owner.count("RequestSerialization();") != 1:
+    fail("canonical owner must request serialization exactly once")
+canonical_receiver = method_block(canonical, "public override void OnDeserialization()")
+if "ApplyValues();" not in canonical_receiver:
+    fail("canonical receiver does not apply from OnDeserialization")
+
+networking_class = class_block(networking, "SyncedArrayReceiver")
+networking_setter = method_block(networking_class, "public void _SetValues(int[] values)")
+assert_order(
+    "networking _SetValues null guard",
+    networking_setter,
+    "if (values == null) return;",
+    "if (!Networking.IsOwner(gameObject))",
+    "_syncedValues = values;",
+)
+troubleshooting_source = "\n".join(csharp_blocks(troubleshooting))
+troubleshooting_setter = method_block(
+    troubleshooting_source,
+    "public void _SetValues(int[] values)",
+)
+assert_order(
+    "troubleshooting _SetValues null guard",
+    troubleshooting_setter,
+    "if (values == null) return;",
+    "if (!Networking.IsOwner(gameObject))",
+    "_syncedValues = values;",
+)
+
+vote = class_block(sync_examples, "VoteSystemCore")
+vote_owner = method_block(vote, "public void _VoteToYes()")
+assert_order(
+    "vote owner",
+    vote_owner,
+    "SyncedVoterPlayerIds[SyncedVoterCount] = caller.playerId;",
+    "SyncedVoterCount++;",
+    "++SyncedYesCount;",
+    "RequestSerialization();",
+    "RefreshCount();",
+)
+vote_receiver = method_block(vote, "public override void OnDeserialization()")
+if "RefreshCount();" not in vote_receiver:
+    fail("vote receiver no longer refreshes from OnDeserialization")
+
+playlist = class_block(patterns, "SyncedPlaylist")
+playlist_owner = method_block(playlist, "public void SetTitles(string[] titles)")
+assert_order(
+    "playlist owner",
+    playlist_owner,
+    "_syncedTitles = JoinForSync(_titles);",
+    "OnPlaylistUpdated();",
+    "RequestSerialization();",
+)
+if playlist_owner.count("RequestSerialization();") != 1:
+    fail("playlist owner must request serialization exactly once")
+playlist_receiver = method_block(playlist, "public override void OnDeserialization()")
+assert_order(
+    "playlist receiver",
+    playlist_receiver,
+    "_titles = SplitFromSync(_syncedTitles);",
+    "OnPlaylistUpdated();",
+)
+
+# This scanner deliberately spans newlines across consecutive attributes and
+# the array declaration. A one-line grep misses the mutation it is intended
+# to reject. Keep one malformed multiline fixture as a self-test of the
+# scanner itself, then scan every active Markdown C# block in the skill.
+array_declaration = re.compile(
+    r"(?P<attributes>(?:\s*\[[^\]]+\]\s*)+)"
+    r"(?P<declaration>(?:public|private|protected|internal)?\s*"
+    r"[A-Za-z_][A-Za-z0-9_<>.,?]*\s*\[\s*\]\s+"
+    r"[A-Za-z_][A-Za-z0-9_]*\s*(?:=[^;]*)?;)",
+    re.S,
+)
+
+
+def forbidden_array_declarations(source: str) -> list[str]:
+    return [
+        match.group(0)
+        for match in array_declaration.finditer(source)
+        if "UdonSynced" in match.group("attributes")
+        and "FieldChangeCallback" in match.group("attributes")
+    ]
+
+
+bad_fixture = """[UdonSynced,\n    FieldChangeCallback(nameof(Values))]\nprivate int[] _values;"""
+if not forbidden_array_declarations(bad_fixture):
+    fail("multiline array callback scanner self-test did not detect its fixture")
+
+skill_root = rules.parents[1]
+for path in skill_root.rglob("*.md"):
+    for block in csharp_blocks(path):
+        if forbidden_array_declarations(block):
+            fail(f"FieldChangeCallback is attached to a synced array declaration in {path}")
+
+print("PASS: canonical, vote, playlist, null-guard, and multiline-array structural contracts")
+PY
 
 # Regression-check the existing contributor census and all five README copies;
 # this Issue is already represented there and should not cause doc churn.


### PR DESCRIPTION
## Summary

- Document that synced array updates must be applied from `OnDeserialization()`, including same-length element changes, array reassignment, and length changes.
- Keep the owner-side apply path idempotent and serialize a complete Manual-sync update once; document revision guards only for non-idempotent effects.
- Correct `VRCUrl[]` sync guidance and clarify fixed-slot capacity as a design choice rather than a sync workaround.
- Harden the documentation contract with structural checks for the canonical, voting, and playlist owner/receiver paths, plus a multiline synced-array callback scanner over Markdown C# fences and raw distributed `.cs` sources.
- Guard both array setter examples against null input before ownership transfer or assignment.

## Validation

- Documentation contract and contributor census checks pass; five temporary mutation copies were rejected with exit 1.
- The distributed C# scanner regression was verified with a multiline `MasterManagedPlayerPool.cs` mutation: the old scanner accepted it and the new scanner rejected it.
- Markdown C# public-method audit passes for the updated skill.
- Bash and BusyBox validator suites pass; PowerShell is covered by the required CI job (the local environment has no `pwsh`).
- npm pack dry run and `git diff --check` pass.
- Required CI is green. CodeRabbit could not complete a review because its review limit was exhausted; the independent review was used as the review gate, with no unresolved threads.

Closes #344
