### PR TITLE
docs(readme): replace contributor lists with profile avatars

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -251,14 +251,18 @@ v4.0.0以降は最新の安定版SDKのみをサポートし、新しい安定�
 
 具体的なIssueを立て、検証や修正方針まで一緒に詰めてくださった皆さんに感謝します。
 
-- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject検索の代替、パフォーマンスの使い分け、疑似複数部屋のパターン、イベントの記載、ネットワークイベントの認可 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
-- [@Guribo](https://github.com/Guribo) — オーナーシップ移譲のタイミングとネットワークのアンチパターン検証 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
-- [@haru0416-dev](https://github.com/haru0416-dev) — インストーラーの更新整合性とjqなし環境での検証 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
-- [@Yodokoro](https://github.com/Yodokoro) — レイヤーの挙動、NetworkCallableの案内、空間音声の設定 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
-- [@tetradice](https://github.com/tetradice) — Agent Skillのメタデータ互換性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
-- [@owlboy](https://github.com/owlboy) — Steam Audioのドキュメント修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
-- [@nomlasvrc](https://github.com/nomlasvrc) — 非推奨のVRCInstantiateの整理 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharpのフィールド・シリアライズ挙動、SDK 3.10.4の知識、配列コールバックの注意点 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
+<!-- community-contributors:start -->
+<p>
+<a href="https://github.com/KatanoShingo" title="@KatanoShingo"><img src="https://github.com/KatanoShingo.png?size=64" width="64" height="64" alt="@KatanoShingo"></a>
+<a href="https://github.com/Guribo" title="@Guribo"><img src="https://github.com/Guribo.png?size=64" width="64" height="64" alt="@Guribo"></a>
+<a href="https://github.com/haru0416-dev" title="@haru0416-dev"><img src="https://github.com/haru0416-dev.png?size=64" width="64" height="64" alt="@haru0416-dev"></a>
+<a href="https://github.com/Yodokoro" title="@Yodokoro"><img src="https://github.com/Yodokoro.png?size=64" width="64" height="64" alt="@Yodokoro"></a>
+<a href="https://github.com/tetradice" title="@tetradice"><img src="https://github.com/tetradice.png?size=64" width="64" height="64" alt="@tetradice"></a>
+<a href="https://github.com/owlboy" title="@owlboy"><img src="https://github.com/owlboy.png?size=64" width="64" height="64" alt="@owlboy"></a>
+<a href="https://github.com/nomlasvrc" title="@nomlasvrc"><img src="https://github.com/nomlasvrc.png?size=64" width="64" height="64" alt="@nomlasvrc"></a>
+<a href="https://github.com/ureishi" title="@ureishi"><img src="https://github.com/ureishi.png?size=64" width="64" height="64" alt="@ureishi"></a>
+</p>
+<!-- community-contributors:end -->
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -251,14 +251,18 @@ v4.0.0부터는 최신 안정 SDK만 지원하며, 새 안정 버전으로의 �
 
 구체적인 Issue를 제보하고 검증과 수정 방향을 함께 다듬어 주신 분들께 감사드립니다.
 
-- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject 조회 대안, 성능 선택지, 재사용 가능한 방 패턴, 이벤트 문서 보완과 네트워크 이벤트 권한 부여 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
-- [@Guribo](https://github.com/Guribo) — 소유권 이전 시점과 네트워크 안티패턴 검증 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
-- [@haru0416-dev](https://github.com/haru0416-dev) — 설치 프로그램 업그레이드 일관성과 jq가 없는 환경의 안전한 검증 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
-- [@Yodokoro](https://github.com/Yodokoro) — 레이어 동작, NetworkCallable 안내, 공간 음향 설정 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
-- [@tetradice](https://github.com/tetradice) — Agent Skill 메타데이터 호환성 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
-- [@owlboy](https://github.com/owlboy) — Steam Audio 문서 수정 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
-- [@nomlasvrc](https://github.com/nomlasvrc) — 더 이상 권장되지 않는 VRCInstantiate 정리 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp 필드와 직렬화 동작, SDK 3.10.4 지식, 배열 콜백의 주의점 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
+<!-- community-contributors:start -->
+<p>
+<a href="https://github.com/KatanoShingo" title="@KatanoShingo"><img src="https://github.com/KatanoShingo.png?size=64" width="64" height="64" alt="@KatanoShingo"></a>
+<a href="https://github.com/Guribo" title="@Guribo"><img src="https://github.com/Guribo.png?size=64" width="64" height="64" alt="@Guribo"></a>
+<a href="https://github.com/haru0416-dev" title="@haru0416-dev"><img src="https://github.com/haru0416-dev.png?size=64" width="64" height="64" alt="@haru0416-dev"></a>
+<a href="https://github.com/Yodokoro" title="@Yodokoro"><img src="https://github.com/Yodokoro.png?size=64" width="64" height="64" alt="@Yodokoro"></a>
+<a href="https://github.com/tetradice" title="@tetradice"><img src="https://github.com/tetradice.png?size=64" width="64" height="64" alt="@tetradice"></a>
+<a href="https://github.com/owlboy" title="@owlboy"><img src="https://github.com/owlboy.png?size=64" width="64" height="64" alt="@owlboy"></a>
+<a href="https://github.com/nomlasvrc" title="@nomlasvrc"><img src="https://github.com/nomlasvrc.png?size=64" width="64" height="64" alt="@nomlasvrc"></a>
+<a href="https://github.com/ureishi" title="@ureishi"><img src="https://github.com/ureishi.png?size=64" width="64" height="64" alt="@ureishi"></a>
+</p>
+<!-- community-contributors:end -->
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -251,14 +251,18 @@ The table below keeps historical feature-introduction notes for migration refere
 
 This project has benefited from people who took the time to file concrete Issues and help verify the fixes. Thank you to:
 
-- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject lookup alternatives, performance trade-offs, reusable-room patterns, event coverage, and network-event authorization ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
-- [@Guribo](https://github.com/Guribo) — ownership-transfer timing and networking anti-pattern verification ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
-- [@haru0416-dev](https://github.com/haru0416-dev) — installer upgrade consistency and jq-safe validation ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
-- [@Yodokoro](https://github.com/Yodokoro) — layer behavior, NetworkCallable guidance, and spatial-audio setup ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
-- [@tetradice](https://github.com/tetradice) — Agent Skill metadata compatibility ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
-- [@owlboy](https://github.com/owlboy) — Steam Audio documentation correction ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
-- [@nomlasvrc](https://github.com/nomlasvrc) — deprecated VRCInstantiate cleanup ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp field and serialization behavior, SDK 3.10.4 knowledge, and array callback caveats ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
+<!-- community-contributors:start -->
+<p>
+<a href="https://github.com/KatanoShingo" title="@KatanoShingo"><img src="https://github.com/KatanoShingo.png?size=64" width="64" height="64" alt="@KatanoShingo"></a>
+<a href="https://github.com/Guribo" title="@Guribo"><img src="https://github.com/Guribo.png?size=64" width="64" height="64" alt="@Guribo"></a>
+<a href="https://github.com/haru0416-dev" title="@haru0416-dev"><img src="https://github.com/haru0416-dev.png?size=64" width="64" height="64" alt="@haru0416-dev"></a>
+<a href="https://github.com/Yodokoro" title="@Yodokoro"><img src="https://github.com/Yodokoro.png?size=64" width="64" height="64" alt="@Yodokoro"></a>
+<a href="https://github.com/tetradice" title="@tetradice"><img src="https://github.com/tetradice.png?size=64" width="64" height="64" alt="@tetradice"></a>
+<a href="https://github.com/owlboy" title="@owlboy"><img src="https://github.com/owlboy.png?size=64" width="64" height="64" alt="@owlboy"></a>
+<a href="https://github.com/nomlasvrc" title="@nomlasvrc"><img src="https://github.com/nomlasvrc.png?size=64" width="64" height="64" alt="@nomlasvrc"></a>
+<a href="https://github.com/ureishi" title="@ureishi"><img src="https://github.com/ureishi.png?size=64" width="64" height="64" alt="@ureishi"></a>
+</p>
+<!-- community-contributors:end -->
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,14 +250,18 @@ Bash 验证器需要 `jq`。如果无法使用 `jq`，钩子会原样传递输�
 
 感谢这些提交具体 Issue、参与验证并帮助完善修正方案的贡献者。
 
-- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject 查找替代方案、性能取舍、可复用房间模式、事件文档覆盖和网络事件授权 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
-- [@Guribo](https://github.com/Guribo) — 所有权转移时机和网络反模式验证 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
-- [@haru0416-dev](https://github.com/haru0416-dev) — 安装器升级一致性和无 jq 环境下的安全验证 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
-- [@Yodokoro](https://github.com/Yodokoro) — 图层行为、NetworkCallable 指引和空间音频设置 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
-- [@tetradice](https://github.com/tetradice) — Agent Skill 元数据兼容性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
-- [@owlboy](https://github.com/owlboy) — Steam Audio 文档修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
-- [@nomlasvrc](https://github.com/nomlasvrc) — 移除已弃用的 VRCInstantiate 用法 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp 字段与序列化行为、SDK 3.10.4 知识，以及数组回调的注意事项 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
+<!-- community-contributors:start -->
+<p>
+<a href="https://github.com/KatanoShingo" title="@KatanoShingo"><img src="https://github.com/KatanoShingo.png?size=64" width="64" height="64" alt="@KatanoShingo"></a>
+<a href="https://github.com/Guribo" title="@Guribo"><img src="https://github.com/Guribo.png?size=64" width="64" height="64" alt="@Guribo"></a>
+<a href="https://github.com/haru0416-dev" title="@haru0416-dev"><img src="https://github.com/haru0416-dev.png?size=64" width="64" height="64" alt="@haru0416-dev"></a>
+<a href="https://github.com/Yodokoro" title="@Yodokoro"><img src="https://github.com/Yodokoro.png?size=64" width="64" height="64" alt="@Yodokoro"></a>
+<a href="https://github.com/tetradice" title="@tetradice"><img src="https://github.com/tetradice.png?size=64" width="64" height="64" alt="@tetradice"></a>
+<a href="https://github.com/owlboy" title="@owlboy"><img src="https://github.com/owlboy.png?size=64" width="64" height="64" alt="@owlboy"></a>
+<a href="https://github.com/nomlasvrc" title="@nomlasvrc"><img src="https://github.com/nomlasvrc.png?size=64" width="64" height="64" alt="@nomlasvrc"></a>
+<a href="https://github.com/ureishi" title="@ureishi"><img src="https://github.com/ureishi.png?size=64" width="64" height="64" alt="@ureishi"></a>
+</p>
+<!-- community-contributors:end -->
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -250,14 +250,18 @@ Bash 驗證器需要 `jq`。若無法使用 `jq`，掛鉤會原樣傳遞輸入�
 
 感謝這些提出具體 Issue、參與驗證並協助完善修正方案的貢獻者。
 
-- [@KatanoShingo](https://github.com/KatanoShingo) — GameObject 搜尋替代方案、效能取捨、可重複使用的房間模式、事件文件涵蓋與網路事件授權 ([#181](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/181), [#182](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/182), [#189](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/189), [#199](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/199), [#213](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/213), [#302](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/302))
-- [@Guribo](https://github.com/Guribo) — 所有權轉移時機與網路反模式驗證 ([#171](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/171))
-- [@haru0416-dev](https://github.com/haru0416-dev) — 安裝器升級一致性與無 jq 環境的安全驗證 ([#164](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/164), [#165](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/165))
-- [@Yodokoro](https://github.com/Yodokoro) — 圖層行為、NetworkCallable 指引與空間音訊設定 ([#267](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/267), [#286](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/286), [#297](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/297))
-- [@tetradice](https://github.com/tetradice) — Agent Skill 中繼資料相容性 ([#281](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/281))
-- [@owlboy](https://github.com/owlboy) — Steam Audio 文件修正 ([#324](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/324))
-- [@nomlasvrc](https://github.com/nomlasvrc) — 移除已棄用的 VRCInstantiate 用法 ([#333](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/333))
-- [@ureishi](https://github.com/ureishi) — UdonSharp 欄位與序列化行為、SDK 3.10.4 知識，以及陣列回呼的注意事項 ([#337](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/337), [#338](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/338), [#341](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/341), [#342](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/342), [#344](https://github.com/niaka3dayo/agent-skills-vrc-udon/issues/344))
+<!-- community-contributors:start -->
+<p>
+<a href="https://github.com/KatanoShingo" title="@KatanoShingo"><img src="https://github.com/KatanoShingo.png?size=64" width="64" height="64" alt="@KatanoShingo"></a>
+<a href="https://github.com/Guribo" title="@Guribo"><img src="https://github.com/Guribo.png?size=64" width="64" height="64" alt="@Guribo"></a>
+<a href="https://github.com/haru0416-dev" title="@haru0416-dev"><img src="https://github.com/haru0416-dev.png?size=64" width="64" height="64" alt="@haru0416-dev"></a>
+<a href="https://github.com/Yodokoro" title="@Yodokoro"><img src="https://github.com/Yodokoro.png?size=64" width="64" height="64" alt="@Yodokoro"></a>
+<a href="https://github.com/tetradice" title="@tetradice"><img src="https://github.com/tetradice.png?size=64" width="64" height="64" alt="@tetradice"></a>
+<a href="https://github.com/owlboy" title="@owlboy"><img src="https://github.com/owlboy.png?size=64" width="64" height="64" alt="@owlboy"></a>
+<a href="https://github.com/nomlasvrc" title="@nomlasvrc"><img src="https://github.com/nomlasvrc.png?size=64" width="64" height="64" alt="@nomlasvrc"></a>
+<a href="https://github.com/ureishi" title="@ureishi"><img src="https://github.com/ureishi.png?size=64" width="64" height="64" alt="@ureishi"></a>
+</p>
+<!-- community-contributors:end -->
 
 ---
 

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -110,9 +110,18 @@ for path in readme_paths:
         f"{path} has an invalid heading/marker order"
     )
 
+    tail_start = end + len(end_marker)
+    next_heading = re.search(r"^<h2[ >]", text[tail_start:], re.MULTILINE)
+    assert next_heading, f"{path} has no heading after community-contributors section"
+    section_end = tail_start + next_heading.start()
+    tail = text[tail_start:section_end]
+    assert tail.strip() == "---", (
+        f"{path} must contain only the separator after the contributor marker"
+    )
+
     intro = text[heading.end() : start]
     assert intro.strip(), f"{path} is missing its localized thank-you text"
-    section = text[heading.start() : end + len(end_marker)]
+    section = text[heading.start() : section_end]
     assert not issue_url_re.search(section), (
         f"{path} contains an Issue URL in the contributor section"
     )

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -5,9 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 README_FILES=(
     "$ROOT_DIR/README.md"
     "$ROOT_DIR/README.ja.md"
+    "$ROOT_DIR/README.ko.md"
     "$ROOT_DIR/README.zh-CN.md"
     "$ROOT_DIR/README.zh-TW.md"
-    "$ROOT_DIR/README.ko.md"
 )
 
 fail() {
@@ -18,9 +18,9 @@ fail() {
 CENSUS="$ROOT_DIR/tests/docs/fixtures/community-contributor-census.json"
 [ -f "$CENSUS" ] || fail "missing contributor census evidence: $CENSUS"
 
-# The census is the sole source of truth. Each README is compared against the
-# fixture's contributor handles and per-contributor Issue set, rather than
-# keeping a second hard-coded list in this test.
+# The census is the sole source of truth. The README contract intentionally
+# contains only stable profile links and avatar attributes; Issue evidence stays
+# in the fixture for auditability rather than being duplicated in each README.
 python3 - "$CENSUS" "${README_FILES[@]}" <<'PY'
 import json
 import re
@@ -39,82 +39,130 @@ excluded_handles = {
     "dependabot",
     "renovate",
 }
-expected_by_handle = {
-    contributor["handle"]: sorted({int(issue) for issue in contributor["issues"]})
+expected_handles = [contributor["handle"] for contributor in contributors]
+assert expected_handles
+assert len(expected_handles) == len(set(expected_handles)), (
+    "the census contains duplicate contributor handles"
+)
+assert not excluded_handles.intersection(expected_handles)
+assert all(re.fullmatch(r"[A-Za-z0-9_-]+", handle) for handle in expected_handles)
+
+# Keep the census integrity checks here so the contract cannot silently become
+# detached from the evidence that selected the eight reporters.
+expected_issues = sorted(
+    {
+        int(issue)
+        for contributor in contributors
+        for issue in contributor["issues"]
+    }
+)
+all_fixture_issues = [
+    issue
     for contributor in contributors
-}
-assert len(expected_by_handle) == len(contributors)
-assert not excluded_handles.intersection(expected_by_handle)
-expected_issues = sorted({issue for issues in expected_by_handle.values() for issue in issues})
-all_fixture_issues = [issue for contributor in contributors for issue in contributor["issues"]]
+    for issue in contributor["issues"]
+]
 assert classification["issues_scanned"] >= 1
-assert classification["selected_reporters"] == len(expected_by_handle) > 0
+assert classification["selected_reporters"] == len(expected_handles)
 assert classification["selected_issues"] == len(expected_issues) > 0
 assert len(all_fixture_issues) == len(set(all_fixture_issues)) == len(expected_issues)
 assert classification["duplicate_invalid_wontfix_spam_issues_selected"] == 0
 
-profile_re = re.compile(r"https://github\.com/([A-Za-z0-9_-]+)\)")
-contributor_line_re = re.compile(
-    r"^- \[@([A-Za-z0-9_-]+)\]\(https://github\.com/([A-Za-z0-9_-]+)\)",
-    re.MULTILINE,
+start_marker = "<!-- community-contributors:start -->"
+end_marker = "<!-- community-contributors:end -->"
+heading_re = re.compile(
+    r'^<h2 id="community-contributors">[^\n]*</h2>$', re.MULTILINE
 )
-issue_re = re.compile(
-    r"https://github\.com/niaka3dayo/agent-skills-vrc-udon/issues/(\d+)"
+entry_re = re.compile(
+    r'^<a href="https://github\.com/(?P<href>[A-Za-z0-9_-]+)" '
+    r'title="@(?P<title>[A-Za-z0-9_-]+)"><img '
+    r'src="https://github\.com/(?P<src>[A-Za-z0-9_-]+)\.png\?size=64" '
+    r'width="(?P<width>64)" height="(?P<height>64)" '
+    r'alt="@(?P<alt>[A-Za-z0-9_-]+)"></a>$'
+)
+issue_url_re = re.compile(
+    r"https://github\.com/[^\s)\"]+/issues(?:[/#]|$)"
+)
+profile_href_re = re.compile(
+    r'href="https://github\.com/([A-Za-z0-9_-]+)"'
+)
+legacy_profile_list_re = re.compile(
+    r"(?m)^-\s+\["
 )
 
+canonical_block = None
 for path in readme_paths:
     text = path.read_text(encoding="utf-8")
-    heading = '<h2 id="community-contributors">'
-    start = text.find(heading)
-    assert start >= 0, f"{path} is missing the community-contributors section"
-    body_start = start + len(heading)
-    next_heading = re.search(r"^<h2[ >]", text[body_start:], re.MULTILINE)
-    assert next_heading, f"{path} has an unterminated community-contributors section"
-    body = text[body_start : body_start + next_heading.start()]
-    assert body.strip(), f"{path} has an empty community-contributors section"
+    assert text.count(start_marker) == 1, (
+        f"{path} must contain exactly one community-contributors start marker"
+    )
+    assert text.count(end_marker) == 1, (
+        f"{path} must contain exactly one community-contributors end marker"
+    )
 
-    profile_matches = profile_re.findall(body)
-    profile_handles = set(profile_matches)
-    expected_handles = set(expected_by_handle)
-    assert len(profile_matches) == len(profile_handles) == len(expected_handles), (
-        f"{path} has {len(profile_handles)} unique contributor profiles; "
+    heading_matches = list(heading_re.finditer(text))
+    assert len(heading_matches) == 1, (
+        f"{path} must contain exactly one community-contributors heading"
+    )
+    heading = heading_matches[0]
+    start = text.index(start_marker)
+    end = text.index(end_marker)
+    assert heading.end() < start < end, (
+        f"{path} has an invalid heading/marker order"
+    )
+
+    intro = text[heading.end() : start]
+    assert intro.strip(), f"{path} is missing its localized thank-you text"
+    section = text[heading.start() : end + len(end_marker)]
+    assert not issue_url_re.search(section), (
+        f"{path} contains an Issue URL in the contributor section"
+    )
+    assert not legacy_profile_list_re.search(section), (
+        f"{path} contains a legacy Markdown contributor list"
+    )
+    assert profile_href_re.findall(section) == expected_handles, (
+        f"{path} has an extra, missing, or out-of-order profile href in the "
+        "contributor section"
+    )
+
+    block = text[start + len(start_marker) : end]
+    block_match = re.fullmatch(r"\n<p>\n(?P<entries>.+)\n</p>\n", block, re.DOTALL)
+    assert block_match, (
+        f"{path} must contain one newline-delimited <p> avatar block between markers"
+    )
+    entry_lines = block_match.group("entries").split("\n")
+    assert len(entry_lines) == len(expected_handles), (
+        f"{path} has {len(entry_lines)} avatar lines; "
         f"expected {len(expected_handles)}"
     )
-    assert profile_handles == expected_handles, (
-        f"{path} contributor profiles differ from the census: "
-        f"actual={sorted(profile_handles)} expected={sorted(expected_handles)}"
-    )
-    assert not excluded_handles.intersection(profile_handles), (
-        f"{path} credits a maintainer or bot in the contributor section"
-    )
 
-    actual_by_handle = {}
-    for match in contributor_line_re.finditer(body):
-        display_handle, linked_handle = match.groups()
-        assert display_handle == linked_handle, (
-            f"{path} has a contributor profile/link mismatch for @{display_handle}"
+    actual_handles = []
+    for line_number, line in enumerate(entry_lines, start=1):
+        match = entry_re.fullmatch(line)
+        assert match, (
+            f"{path} avatar line {line_number} does not use the exact "
+            "profile/avatar contract"
         )
-        assert display_handle not in actual_by_handle, (
-            f"{path} lists @{display_handle} more than once"
-        )
-        line_end = body.find("\n", match.start())
-        line = body[match.start() : line_end if line_end >= 0 else len(body)]
-        actual_by_handle[display_handle] = sorted(
-            {int(issue) for issue in issue_re.findall(line)}
-        )
-    assert actual_by_handle == expected_by_handle, (
-        f"{path} per-contributor Issue links differ from the census: "
-        f"actual={actual_by_handle} expected={expected_by_handle}"
-    )
+        attributes = match.groupdict()
+        handle = attributes["href"]
+        assert attributes["title"] == handle
+        assert attributes["src"] == handle
+        assert attributes["alt"] == handle
+        actual_handles.append(handle)
 
-    actual_issues = sorted({int(issue) for issue in issue_re.findall(body)})
-    assert actual_issues == expected_issues, (
-        f"{path} aggregate Issue links differ from the census: "
-        f"actual={actual_issues} expected={expected_issues}"
+    assert actual_handles == expected_handles, (
+        f"{path} contributor handle order differs from the census: "
+        f"actual={actual_handles} expected={expected_handles}"
     )
+    assert len(actual_handles) == len(set(actual_handles)), (
+        f"{path} contains duplicate contributor profiles"
+    )
+    assert canonical_block is None or block == canonical_block, (
+        f"{path} contributor avatar block differs from the other READMEs"
+    )
+    canonical_block = block
 
 print(
-    "PASS: community contributor profiles, per-contributor Issues, and "
-    "aggregate Issue census are exact across all five READMEs"
+    "PASS: exact fixture-ordered profile-linked avatar blocks, markers, "
+    "attributes, and contributor-section exclusions across all five READMEs"
 )
 PY


### PR DESCRIPTION
Closes #351

## Summary
Replace the five localized Community Contributors Markdown lists with one shared, fixture-ordered block of profile-linked GitHub avatar icons.

## Changes
- Preserve each localized heading and thank-you sentence.
- Add the same eight avatar links between `community-contributors:start` and `community-contributors:end` markers.
- Remove per-contributor descriptions and Issue URLs from the README sections.
- Rewrite the community contributor contract test to enforce exact fixture order, profile/avatar attributes, marker counts, duplicate/extra detection, and section exclusions.

## Validation
- Contract test: RED against the pre-change README form; GREEN after the replacement.
- Contributor section tail coverage: temp-copy Issue URL, legacy list, and plain description mutations after the end marker now fail; the next-heading boundary and separator-only tail are enforced.
- All `tests/docs/*.test.sh` scripts: pass.
- Hook smoke tests, symlink audit, `git diff --check`, local EditorConfig audit, version sync, and `npm pack --dry-run`: pass.
- Profile/avatar URL batch audit: 8 unique handles / 16 endpoints, all HTTP 206; avatar URLs followed one redirect to `avatars.githubusercontent.com`, profile URLs had no redirect.
- `editorconfig-checker` and `lychee` are not installed locally; changed README local-link audit passed and required GitHub checks remain the authoritative full-repository gates.

## Scope
Only the five READMEs and `tests/docs/community-contributors.test.sh` changed. The census fixture and skills are unchanged. This PR targets `dev`; the release parent is #349 and the existing main-to-dev sync PR #350 is untouched.

## Merge gate
Keep this PR open until required CI and review threads are green and resolved. Do not merge as part of this task.

