### PR TITLE
chore(version): bump to v4.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "3.0.2"
+    "version": "4.0.0"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.2"
+    version: "4.0.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.2"
+    version: "4.0.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -17,7 +17,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "3.0.2"
+    version: "4.0.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
## Summary

Synchronize the five release metadata fields to `4.0.0` for the public v4.0.0 release.

SDK 3.7.1–3.10.3 active support has ended; SDK 3.10.4 is the only verified target.

## Scope

Only these five version fields changed, each from `3.0.2` to `4.0.0`:

- `package.json`
- `.claude-plugin/marketplace.json`
- `skills/unity-vrc-udon-sharp/SKILL.md`
- `skills/unity-vrc-world-sdk-3/SKILL.md`
- `.claude/skills/unity-vrc-skills-renovator/SKILL.md`

No README, CHANGELOG, Skill body, lockfile, release/tag/main/npm state, or unrelated file was changed.

## Validation

- Temporary target assertion: RED on base, GREEN after the bump
- Exact diff audit: 5 files / 5 version-field lines only
- Version Sync equivalent: PASS
- `git diff --check`: PASS
- Symlink integrity: PASS
- `npm pack --dry-run`: PASS; required `skills/`, `templates/`, `LICENSE`, and `README.md` present
- System skill-creator `quick_validate.py`: UdonSharp, World SDK, and internal renovator Skills each exit 0 with `Skill is valid!`

## Checklist

- [x] `dev` is the base branch
- [x] Assignee and labels set
- [x] Repository validation run locally
- [x] Required CI 7/7 green
- [x] Review threads resolved (0 unresolved)
- [x] Ready for review

Closes #353
Refs #349
