### PR TITLE
docs(governance): align contributor avatar census

### DIFF
--- a/.claude/rules/doc-sync.md
+++ b/.claude/rules/doc-sync.md
@@ -21,7 +21,7 @@ Any change to these paths requires a documentation sync check:
 2. **Rule paths**: Do `templates/*.md` reference valid rule file paths under `skills/*/rules/`?
 3. **Hook references**: If hooks were added/removed/renamed, are they listed in README.md Hooks section?
 4. **SDK support policy**: If the active target changes, synchronize the stable-only verification gate, historical boundary, and SDK Versions section across all five READMEs.
-5. **Community contributors**: Keep the contributor handles, Issue links, and descriptions synchronized across all five READMEs; include only external GitHub Issue reporters whose contributions were accepted, confirmed, or implemented. Exclude maintainer and bot accounts, invalid/duplicate/wontfix/spam Issues, and PR-only contributors. When the census changes, refresh `tests/docs/fixtures/community-contributor-census.json` and the contract-test expectations from a new all-Issue query.
+5. **Community contributors**: Keep one ordered profile-linked avatar block synchronized across all five READMEs. Keep Issue numbers, selection evidence, and status details only in `tests/docs/fixtures/community-contributor-census.json`; do not duplicate them in the README sections. Include only external GitHub Issue reporters whose contributions were accepted, confirmed, or implemented. Exclude maintainer and bot accounts, invalid/duplicate/wontfix/spam Issues, and PR-only contributors. When the census changes, refresh the fixture and contract-test expectations from a new all-Issue query.
 6. **Structure tree**: If directories were added/removed, update the Structure section in README.md and CLAUDE.md
 
 ## What NOT to Update

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -47,6 +47,9 @@ community_rule = community_rule_match.group(1)
 assert "ordered profile-linked avatar block" in community_rule, (
     "the maintainer rule must preserve the avatar-only README contract"
 )
+assert "across all five READMEs" in community_rule, (
+    "the maintainer rule must keep all five README translations in scope"
+)
 assert "tests/docs/fixtures/community-contributor-census.json" in community_rule, (
     "the maintainer rule must name the Issue-evidence source of truth"
 )

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -16,22 +16,36 @@ fail() {
 }
 
 CENSUS="$ROOT_DIR/tests/docs/fixtures/community-contributor-census.json"
+DOC_SYNC="$ROOT_DIR/.claude/rules/doc-sync.md"
 [ -f "$CENSUS" ] || fail "missing contributor census evidence: $CENSUS"
+[ -f "$DOC_SYNC" ] || fail "missing documentation sync rule: $DOC_SYNC"
 
 # The census is the sole source of truth. The README contract intentionally
 # contains only stable profile links and avatar attributes; Issue evidence stays
 # in the fixture for auditability rather than being duplicated in each README.
-python3 - "$CENSUS" "${README_FILES[@]}" <<'PY'
+python3 - "$CENSUS" "$DOC_SYNC" "${README_FILES[@]}" <<'PY'
 import json
 import re
 import sys
 from pathlib import Path
 
 census_path = Path(sys.argv[1])
-readme_paths = [Path(path) for path in sys.argv[2:]]
+doc_sync_path = Path(sys.argv[2])
+readme_paths = [Path(path) for path in sys.argv[3:]]
 data = json.loads(census_path.read_text(encoding="utf-8"))
 classification = data["classification"]
 contributors = data["contributors"]
+
+doc_sync = doc_sync_path.read_text(encoding="utf-8")
+assert "ordered profile-linked avatar block" in doc_sync, (
+    "the maintainer rule must preserve the avatar-only README contract"
+)
+assert "tests/docs/fixtures/community-contributor-census.json" in doc_sync, (
+    "the maintainer rule must name the Issue-evidence source of truth"
+)
+assert "Issue links, and descriptions synchronized across all five READMEs" not in doc_sync, (
+    "the maintainer rule still requires the removed contributor list format"
+)
 
 excluded_handles = {
     "niaka3dayo",
@@ -46,6 +60,15 @@ assert len(expected_handles) == len(set(expected_handles)), (
 )
 assert not excluded_handles.intersection(expected_handles)
 assert all(re.fullmatch(r"[A-Za-z0-9_-]+", handle) for handle in expected_handles)
+
+ureishi = next(
+    contributor for contributor in contributors if contributor["handle"] == "ureishi"
+)
+assert ureishi["issues"] == [337, 338, 341, 342, 344]
+assert ureishi["evidence"]["merged_prs"] == [339, 340, 345, 347, 348]
+assert "open_accepted_issues" not in ureishi["evidence"], (
+    "the census still records closed @ureishi reports as open work"
+)
 
 # Keep the census integrity checks here so the contract cannot silently become
 # detached from the evidence that selected the eight reporters.

--- a/tests/docs/community-contributors.test.sh
+++ b/tests/docs/community-contributors.test.sh
@@ -37,13 +37,27 @@ classification = data["classification"]
 contributors = data["contributors"]
 
 doc_sync = doc_sync_path.read_text(encoding="utf-8")
-assert "ordered profile-linked avatar block" in doc_sync, (
+community_rule_match = re.search(
+    r"^5\. \*\*Community contributors\*\*:(.*?)(?=^6\.)",
+    doc_sync,
+    re.MULTILINE | re.DOTALL,
+)
+assert community_rule_match, "the maintainer rule has no Community contributors item"
+community_rule = community_rule_match.group(1)
+assert "ordered profile-linked avatar block" in community_rule, (
     "the maintainer rule must preserve the avatar-only README contract"
 )
-assert "tests/docs/fixtures/community-contributor-census.json" in doc_sync, (
+assert "tests/docs/fixtures/community-contributor-census.json" in community_rule, (
     "the maintainer rule must name the Issue-evidence source of truth"
 )
-assert "Issue links, and descriptions synchronized across all five READMEs" not in doc_sync, (
+assert "do not duplicate them in the README sections" in community_rule, (
+    "the maintainer rule must keep Issue evidence out of the README sections"
+)
+assert not re.search(
+    r"(?:Issue\s+links?.*descriptions?|descriptions?.*Issue\s+links?)",
+    community_rule,
+    re.IGNORECASE | re.DOTALL,
+), (
     "the maintainer rule still requires the removed contributor list format"
 )
 
@@ -66,6 +80,7 @@ ureishi = next(
 )
 assert ureishi["issues"] == [337, 338, 341, 342, 344]
 assert ureishi["evidence"]["merged_prs"] == [339, 340, 345, 347, 348]
+assert ureishi["evidence"]["classification"] == "implemented and confirmed"
 assert "open_accepted_issues" not in ureishi["evidence"], (
     "the census still records closed @ureishi reports as open work"
 )

--- a/tests/docs/fixtures/community-contributor-census.json
+++ b/tests/docs/fixtures/community-contributor-census.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-08-18",
+  "generated_at": "2026-08-19",
   "repository": "niaka3dayo/agent-skills-vrc-udon",
   "query": "gh issue list --state all --limit 1000 --json number,title,state,author,labels,comments,url,closedAt",
   "timeline_query": "gh api repos/niaka3dayo/agent-skills-vrc-udon/issues/{number}/timeline --paginate -H 'Accept: application/vnd.github+json'",
   "scope": "External authors of GitHub Issues that contributed accepted, confirmed, or implemented corrections or knowledge additions. PR-only contributors are out of scope.",
   "classification": {
-    "issues_scanned": 152,
+    "issues_scanned": 157,
     "maintainer_and_bot_authors_excluded": [
       "niaka3dayo",
       "github-actions[bot]",
@@ -78,12 +78,8 @@
       "handle": "ureishi",
       "issues": [337, 338, 341, 342, 344],
       "evidence": {
-        "classification": "implemented, confirmed, and accepted current work",
-        "merged_prs": [339, 340],
-        "open_accepted_issues": [341, 342, 344],
-        "acceptance_notes": {
-          "344": "Accepted into the v4.0.0 support work; technical implementation is tracked separately from this policy PR."
-        }
+        "classification": "implemented and confirmed",
+        "merged_prs": [339, 340, 345, 347, 348]
       }
     }
   ],


### PR DESCRIPTION
## Summary

Align the Community Contributors maintenance contract with the avatar-only README layout before v4.0.0:

- keep ordered profile-linked avatar blocks in the five READMEs;
- keep Issue numbers, selection evidence, and status details only in the contributor census fixture;
- refresh @ureishi's census evidence now that #341, #342, and #344 are closed through PRs #345, #347, and #348;
- add a contract test that rejects the removed list-style governance and stale open-work evidence.

The public contributor roster and all five README avatar blocks are unchanged.

## TDD evidence

- RED: `tests/docs/community-contributors.test.sh` failed on `127e63c` because the maintainer rule still required Issue links/descriptions in each README.
- GREEN: the contributor contract and all 14 documentation tests pass after the rule and fixture update.
- Review RED/GREEN: paraphrased README-duplication guidance, stale evidence classification, and loss of the five-README scope passed the prior contracts; each mutation is now rejected independently.
- Evidence logs: `/home/natsuki/workspaces/evidence/agent-skills-vrc-udon/issue-357/`

## Validation

- All `tests/docs/*.test.sh`: PASS (14/14)
- `tests/docs/community-contributors.test.sh`: PASS
- `tests/docs/repository-governance-contract.test.sh`: PASS
- `npm pack --dry-run`: PASS (v4.0.0, 73 files)
- `git diff --check`: PASS
- Symlink integrity: PASS

## Review

- Final HEAD: `0ed71603a7e11893d697f79c2359e21e85dcb25d`
- Both CodeRabbit findings addressed with mutation evidence; review threads resolved
- Final independent re-review: APPROVE, no CRITICAL/HIGH/MUST findings

Closes #357
Refs #349

