### PR TITLE
chore(version): bump to v4.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI Agent Skills for VRChat UdonSharp world development",
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "plugins": [
     {

--- a/.claude/skills/unity-vrc-skills-renovator/SKILL.md
+++ b/.claude/skills/unity-vrc-skills-renovator/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "4.0.0"
+    version: "4.1.0"
     tags: skill-maintenance, sdk-update, knowledge-management
     internal: true
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-vrc-udon",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "AI Agent Skills for VRChat UdonSharp - Rules, validation hooks, and knowledge base for correct UdonSharp code generation",
   "license": "MIT",
   "author": "niaka3dayo",

--- a/skills/unity-vrc-udon-sharp/SKILL.md
+++ b/skills/unity-vrc-udon-sharp/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "4.0.0"
+    version: "4.1.0"
     tags: vrchat, udonsharp, udon, networking, sync, persistence, dynamics, asmdef, vpm, assembly-definition
 ---
 

--- a/skills/unity-vrc-world-sdk-3/SKILL.md
+++ b/skills/unity-vrc-world-sdk-3/SKILL.md
@@ -18,7 +18,7 @@ description: >
 license: MIT
 metadata:
     author: niaka3dayo
-    version: "4.0.0"
+    version: "4.1.0"
     tags: vrchat, world-sdk, scene-setup, optimization, components, upload, sdk-validation, build-panel
 ---
 


### PR DESCRIPTION
Prepare v4.1.0 for the verified VRChat SDK 3.10.5 support delivered by #362.

Only the five package-version fields change: package.json, marketplace metadata, both distributed Skills and the internal renovator Skill. The SDK target and Skill behavior remain unchanged.

Validation: five-field parity and JSON/frontmatter parsing, npm pack content and executable-hook check. The implementation's Unity, real-host routing, hook suites and independent review results are recorded in #360. All seven required CI checks must pass before merge.

Related: #360.